### PR TITLE
Simplify royalty logic

### DIFF
--- a/contracts/interfaces/modules/royalty/policies/IAncestorsVaultLAP.sol
+++ b/contracts/interfaces/modules/royalty/policies/IAncestorsVaultLAP.sol
@@ -10,9 +10,8 @@ interface IAncestorsVaultLAP {
     /// @notice Event emitted when a claim is made
     /// @param ipId The ipId address
     /// @param claimerIpId The claimer ipId address
-    /// @param withdrawETH Indicates if the claimer wants to withdraw ETH
     /// @param tokens The ERC20 tokens to withdraw
-    event Claimed(address ipId, address claimerIpId, bool withdrawETH, ERC20[] tokens);
+    event Claimed(address ipId, address claimerIpId, ERC20[] tokens);
 
     /// @notice Returns the canonical RoyaltyPolicyLAP
     function ROYALTY_POLICY_LAP() external view returns (IRoyaltyPolicyLAP);
@@ -22,14 +21,12 @@ interface IAncestorsVaultLAP {
     /// @param claimerIpId The claimer ipId is the ancestor address that wants to claim
     /// @param ancestors The ancestors for the selected ipId
     /// @param ancestorsRoyalties The royalties of the ancestors for the selected ipId
-    /// @param withdrawETH Indicates if the claimer wants to withdraw ETH
     /// @param tokens The ERC20 tokens to withdraw
     function claim(
         address ipId,
         address claimerIpId,
         address[] calldata ancestors,
         uint32[] calldata ancestorsRoyalties,
-        bool withdrawETH,
         ERC20[] calldata tokens
     ) external;
 }

--- a/contracts/interfaces/modules/royalty/policies/IRoyaltyPolicyLAP.sol
+++ b/contracts/interfaces/modules/royalty/policies/IRoyaltyPolicyLAP.sol
@@ -103,30 +103,26 @@ interface IRoyaltyPolicyLAP is IRoyaltyPolicy {
     /// @dev If there are no funds available in split main contract but there are funds in the split clone contract
     /// then a distributeIpPoolFunds() call should precede this call
     /// @param account The account to claim for
-    /// @param withdrawETH The amount of ETH to withdraw
     /// @param tokens The tokens to withdraw
-    function claimFromIpPool(address account, uint256 withdrawETH, ERC20[] calldata tokens) external;
+    function claimFromIpPool(address account, ERC20[] calldata tokens) external;
 
     /// @notice Claims the available royalties for a given address that holds all the royalty nfts of an ipId
     /// @dev This call will revert if the caller does not hold all the royalty nfts of the ipId
     /// @param ipId The ipId whose received funds will be distributed
-    /// @param withdrawETH The amount of ETH to withdraw
     /// @param token The token to withdraw
-    function claimFromIpPoolAsTotalRnftOwner(address ipId, uint256 withdrawETH, address token) external;
+    function claimFromIpPoolAsTotalRnftOwner(address ipId, address token) external;
 
     /// @notice Claims available royalty nfts and accrued royalties for an ancestor of a given ipId
     /// @param ipId The ipId of the ancestors vault to claim from
     /// @param claimerIpId The claimer ipId is the ancestor address that wants to claim
     /// @param ancestors The ancestors for the selected ipId
     /// @param ancestorsRoyalties The royalties of the ancestors for the selected ipId
-    /// @param withdrawETH Indicates if the claimer wants to withdraw ETH
     /// @param tokens The ERC20 tokens to withdraw
     function claimFromAncestorsVault(
         address ipId,
         address claimerIpId,
         address[] calldata ancestors,
         uint32[] calldata ancestorsRoyalties,
-        bool withdrawETH,
         ERC20[] calldata tokens
     ) external;
 }

--- a/contracts/lib/Errors.sol
+++ b/contracts/lib/Errors.sol
@@ -242,7 +242,6 @@ library Errors {
     error AncestorsVaultLAP__InvalidAncestorsHash();
     error AncestorsVaultLAP__InvalidClaimer();
     error AncestorsVaultLAP__ClaimerNotAnAncestor();
-    error AncestorsVaultLAP__ETHBalanceNotZero();
     error AncestorsVaultLAP__ERC20BalanceNotZero();
     error AncestorsVaultLAP__TransferFailed();
 

--- a/contracts/modules/royalty/policies/RoyaltyPolicyLAP.sol
+++ b/contracts/modules/royalty/policies/RoyaltyPolicyLAP.sol
@@ -250,18 +250,16 @@ contract RoyaltyPolicyLAP is IRoyaltyPolicyLAP, Governable, ERC1155Holder, Reent
     /// @dev If there are no funds available in split main contract but there are funds in the split clone contract
     /// then a distributeIpPoolFunds() call should precede this call
     /// @param account The account to claim for
-    /// @param withdrawETH The amount of ETH to withdraw
     /// @param tokens The tokens to withdraw
-    function claimFromIpPool(address account, uint256 withdrawETH, ERC20[] calldata tokens) external {
-        ILiquidSplitMain(LIQUID_SPLIT_MAIN).withdraw(account, withdrawETH, tokens);
+    function claimFromIpPool(address account, ERC20[] calldata tokens) external {
+        ILiquidSplitMain(LIQUID_SPLIT_MAIN).withdraw(account, 0, tokens);
     }
 
     /// @notice Claims the available royalties for a given address that holds all the royalty nfts of an ipId
     /// @dev This call will revert if the caller does not hold all the royalty nfts of the ipId
     /// @param ipId The ipId whose received funds will be distributed
-    /// @param withdrawETH The amount of ETH to withdraw
     /// @param token The token to withdraw
-    function claimFromIpPoolAsTotalRnftOwner(address ipId, uint256 withdrawETH, address token) external nonReentrant {
+    function claimFromIpPoolAsTotalRnftOwner(address ipId, address token) external nonReentrant {
         ILiquidSplitClone splitClone = ILiquidSplitClone(royaltyData[ipId].splitClone);
         ILiquidSplitMain splitMain = ILiquidSplitMain(LIQUID_SPLIT_MAIN);
 
@@ -273,25 +271,17 @@ contract RoyaltyPolicyLAP is IRoyaltyPolicyLAP, Governable, ERC1155Holder, Reent
         accounts[0] = msg.sender;
         accounts[1] = address(this);
 
-        ERC20[] memory tokens = withdrawETH != 0 ? new ERC20[](0) : new ERC20[](1);
+        ERC20[] memory tokens = new ERC20[](1);
 
-        if (withdrawETH != 0) {
-            splitClone.distributeFunds(address(0), accounts, address(0));
-        } else {
-            splitClone.distributeFunds(token, accounts, address(0));
-            tokens[0] = ERC20(token);
-        }
+        splitClone.distributeFunds(token, accounts, address(0));
+        tokens[0] = ERC20(token);
 
-        splitMain.withdraw(msg.sender, withdrawETH, tokens);
-        splitMain.withdraw(address(this), withdrawETH, tokens);
+        splitMain.withdraw(msg.sender, 0, tokens);
+        splitMain.withdraw(address(this), 0, tokens);
 
         splitClone.safeTransferFrom(address(this), msg.sender, 0, 1, "0x0");
 
-        if (withdrawETH != 0) {
-            _safeTransferETH(msg.sender, address(this).balance);
-        } else {
-            IERC20(token).safeTransfer(msg.sender, IERC20(token).balanceOf(address(this)));
-        }
+        IERC20(token).safeTransfer(msg.sender, IERC20(token).balanceOf(address(this)));
     }
 
     /// @notice Claims all available royalty nfts and accrued royalties for an ancestor of a given ipId
@@ -299,14 +289,12 @@ contract RoyaltyPolicyLAP is IRoyaltyPolicyLAP, Governable, ERC1155Holder, Reent
     /// @param claimerIpId The claimer ipId is the ancestor address that wants to claim
     /// @param ancestors The ancestors for the selected ipId
     /// @param ancestorsRoyalties The royalties of the ancestors for the selected ipId
-    /// @param withdrawETH Indicates if the claimer wants to withdraw ETH
     /// @param tokens The ERC20 tokens to withdraw
     function claimFromAncestorsVault(
         address ipId,
         address claimerIpId,
         address[] calldata ancestors,
         uint32[] calldata ancestorsRoyalties,
-        bool withdrawETH,
         ERC20[] calldata tokens
     ) external {
         IAncestorsVaultLAP(royaltyData[ipId].ancestorsVault).claim(
@@ -314,7 +302,6 @@ contract RoyaltyPolicyLAP is IRoyaltyPolicyLAP, Governable, ERC1155Holder, Reent
             claimerIpId,
             ancestors,
             ancestorsRoyalties,
-            withdrawETH,
             tokens
         );
     }
@@ -452,19 +439,5 @@ contract RoyaltyPolicyLAP is IRoyaltyPolicyLAP, Governable, ERC1155Holder, Reent
         );
 
         return splitClone;
-    }
-
-    /// @dev Allows to transfers ETH
-    /// @param to The address to transfer to
-    /// @param amount The amount to transfer
-    function _safeTransferETH(address to, uint256 amount) internal {
-        bool callStatus;
-
-        assembly {
-            // Transfer the ETH and store if it succeeded or not.
-            callStatus := call(gas(), to, amount, 0, 0, 0, 0)
-        }
-
-        if (!callStatus) revert Errors.RoyaltyPolicyLAP__TransferFailed();
     }
 }

--- a/contracts/modules/royalty/policies/RoyaltyPolicyLAP.sol
+++ b/contracts/modules/royalty/policies/RoyaltyPolicyLAP.sol
@@ -197,6 +197,9 @@ contract RoyaltyPolicyLAP is IRoyaltyPolicyLAP, Governable, ERC1155Holder, Reent
         // deploy split clone
         address splitClone = _deploySplitClone(ipId, ancestorsVault, royaltyStack);
 
+        // ancestorsVault is adjusted as address(this) was just used for the split clone deployment
+        ancestorsVault = ancestorsVault == address(this) ? address(0) : ancestorsVault;
+
         royaltyData[ipId] = LAPRoyaltyData({
             // whether calling via minting license or linking to parents the ipId becomes unlinkable
             isUnlinkableToParents: true,

--- a/script/foundry/deployment/Main.s.sol
+++ b/script/foundry/deployment/Main.s.sol
@@ -721,8 +721,8 @@ contract Main is Script, BroadcastManager, JsonDeploymentHandler {
             // 0xSplitMain that acts as a ledger for revenue distribution.
             // vm.expectEmit(LIQUID_SPLIT_MAIN);
             // TODO: check Withdrawal(699999999999999998) (Royalty stack is 300, or 30% [absolute] sent to ancestors)
-            royaltyPolicyLAP.claimFromIpPool({ account: ipAcct[5], withdrawETH: 0, tokens: tokens });
-            royaltyPolicyLAP.claimFromIpPool({ account: ancestorVault_ipAcct5, withdrawETH: 0, tokens: tokens });
+            royaltyPolicyLAP.claimFromIpPool({ account: ipAcct[5], tokens: tokens });
+            royaltyPolicyLAP.claimFromIpPool({ account: ancestorVault_ipAcct5, tokens: tokens });
 
             // Bob (owner of IPAccount1) calls the claim her portion of rNFTs and tokens. He can only call
             // `claimFromAncestorsVault` once. Afterwards, she will automatically receive money on revenue distribution.
@@ -740,7 +740,6 @@ contract Main is Script, BroadcastManager, JsonDeploymentHandler {
                 claimerIpId: ipAcct[1],
                 ancestors: ancestors,
                 ancestorsRoyalties: ancestorsRoyalties,
-                withdrawETH: false,
                 tokens: tokens
             });
         }

--- a/test/foundry/integration/flows/royalty/Royalty.t.sol
+++ b/test/foundry/integration/flows/royalty/Royalty.t.sol
@@ -244,8 +244,8 @@ contract Flows_Integration_Disputes is BaseIntegration {
             // 0xSplitMain that acts as a ledger for revenue distribution.
             // vm.expectEmit(LIQUID_SPLIT_MAIN);
             // TODO: check Withdrawal(699999999999999998) (Royalty stack is 300, or 30% [absolute] sent to ancestors)
-            royaltyPolicyLAP.claimFromIpPool({ account: ipAcct[3], withdrawETH: 0, tokens: tokens });
-            royaltyPolicyLAP.claimFromIpPool({ account: ancestorVault_ipAcct3, withdrawETH: 0, tokens: tokens });
+            royaltyPolicyLAP.claimFromIpPool({ account: ipAcct[3], tokens: tokens });
+            royaltyPolicyLAP.claimFromIpPool({ account: ancestorVault_ipAcct3, tokens: tokens });
 
             // Bob (owner of IPAccount2) calls the claim her portion of rNFTs and tokens. He can only call
             // `claimFromAncestorsVault` once. Afterwards, she will automatically receive money on revenue distribution.
@@ -263,7 +263,6 @@ contract Flows_Integration_Disputes is BaseIntegration {
                 claimerIpId: ipAcct[2],
                 ancestors: ancestors,
                 ancestorsRoyalties: ancestorsRoyalties,
-                withdrawETH: false,
                 tokens: tokens
             });
         }
@@ -276,7 +275,7 @@ contract Flows_Integration_Disputes is BaseIntegration {
             (, address splitClone_ipAcct1, , , ) = royaltyPolicyLAP.royaltyData(ipAcct[1]);
             (, , address ancestorVault_ipAcct3, , ) = royaltyPolicyLAP.royaltyData(ipAcct[3]);
 
-            uint256 balanceBefore_SplitClone_ipAcct1 = mockToken.balanceOf(splitClone_ipAcct1);
+            uint256 balanceBefore_SplitClone_ipAcct1 = mockToken.balanceOf(ipAcct[1]);
             uint256 balanceBefore_AncestorVault_ipAcct3 = mockToken.balanceOf(ancestorVault_ipAcct3);
 
             address[] memory ancestors = new address[](2);
@@ -292,11 +291,10 @@ contract Flows_Integration_Disputes is BaseIntegration {
                 claimerIpId: ipAcct[1],
                 ancestors: ancestors,
                 ancestorsRoyalties: ancestorsRoyalties,
-                withdrawETH: false,
                 tokens: tokens
             });
 
-            uint256 balanceAfter_SplitClone_ipAcct1 = mockToken.balanceOf(splitClone_ipAcct1);
+            uint256 balanceAfter_SplitClone_ipAcct1 = mockToken.balanceOf(ipAcct[1]);
             uint256 balanceAfter_AncestorVault_ipAcct3 = mockToken.balanceOf(ancestorVault_ipAcct3);
 
             // IPAccount1's split clone should receive 30% of the total payment to IPAccount3

--- a/test/foundry/modules/royalty/RoyaltyPolicyLAP.t.sol
+++ b/test/foundry/modules/royalty/RoyaltyPolicyLAP.t.sol
@@ -610,7 +610,7 @@ contract TestRoyaltyPolicyLAP is BaseTest {
         uint256 splitMainUSDCBalBefore = USDC.balanceOf(royaltyPolicyLAP.LIQUID_SPLIT_MAIN());
         uint256 address2USDCBalBefore = USDC.balanceOf(address(2));
 
-        royaltyPolicyLAP.claimFromIpPool(address(2), 0, tokens);
+        royaltyPolicyLAP.claimFromIpPool(address(2), tokens);
 
         uint256 splitMainUSDCBalAfter = USDC.balanceOf(royaltyPolicyLAP.LIQUID_SPLIT_MAIN());
         uint256 address2USDCBalAfter = USDC.balanceOf(address(2));
@@ -624,12 +624,20 @@ contract TestRoyaltyPolicyLAP is BaseTest {
 
         uint256 royaltyAmountUSDC = 100 * 10 ** 6;
         USDC.mint(address(splitClone7), royaltyAmountUSDC);
-        uint256 royaltyAmountETH = 1 ether;
-        vm.deal(address(splitClone7), royaltyAmountETH);
 
         vm.startPrank(address(7));
         ERC1155(address(splitClone7)).setApprovalForAll(address(royaltyPolicyLAP), true);
 
-        royaltyPolicyLAP.claimFromIpPoolAsTotalRnftOwner(address(7), 1, address(USDC));
+        uint256 usdcClaimerBalBefore = USDC.balanceOf(address(7));
+        uint256 rnftClaimerBalBefore = ERC1155(address(splitClone7)).balanceOf(address(7), 0);
+
+        royaltyPolicyLAP.claimFromIpPoolAsTotalRnftOwner(address(7), address(USDC));
+
+        uint256 usdcClaimerBalAfter = USDC.balanceOf(address(7));
+        uint256 rnftClaimerBalAfter = ERC1155(address(splitClone7)).balanceOf(address(7), 0);
+
+        assertApproxEqRel(usdcClaimerBalAfter - usdcClaimerBalBefore, royaltyAmountUSDC, 0.0001e18);
+        assertEq(rnftClaimerBalAfter, 1000);
+        assertEq(rnftClaimerBalBefore, 1000);
     }
 }

--- a/test/foundry/modules/royalty/RoyaltyPolicyLAP.t.sol
+++ b/test/foundry/modules/royalty/RoyaltyPolicyLAP.t.sol
@@ -502,7 +502,7 @@ contract TestRoyaltyPolicyLAP is BaseTest {
         assertEq(royaltyStack, 0);
         assertEq(ancestorsHash, keccak256(abi.encodePacked(targetAncestors, targetRoyaltyAmount)));
         assertFalse(splitClone == address(0));
-        assertEq(ancestorsVault, address(royaltyPolicyLAP));
+        assertEq(ancestorsVault, address(0));
     }
 
     function test_RoyaltyPolicyLAP_onLinkToParents_revert_NotRoyaltyModule() public {


### PR DESCRIPTION
This pr makes 3 adjustments to the LAP royalty policy:

- Does a minor fix the event PolicyInitialized
- Changes the receiver of the RNFTs present the ancestors vault to being the IPAccount (vs the IP Pool) to significantly simplify the royalty claiming process
- Removes ETH claiming from the codebase to simplify the code given it is not supported for payment and therefore was not being used