### PR TITLE
Remove ancestors hash and royalty context requirement from royalty LAP policy

### DIFF
--- a/contracts/interfaces/modules/royalty/policies/IAncestorsVaultLAP.sol
+++ b/contracts/interfaces/modules/royalty/policies/IAncestorsVaultLAP.sol
@@ -19,14 +19,6 @@ interface IAncestorsVaultLAP {
     /// @notice Claims all available royalty nfts and accrued royalties for an ancestor of a given ipId
     /// @param ipId The ipId of the ancestors vault to claim from
     /// @param claimerIpId The claimer ipId is the ancestor address that wants to claim
-    /// @param ancestors The ancestors for the selected ipId
-    /// @param ancestorsRoyalties The royalties of the ancestors for the selected ipId
     /// @param tokens The ERC20 tokens to withdraw
-    function claim(
-        address ipId,
-        address claimerIpId,
-        address[] calldata ancestors,
-        uint32[] calldata ancestorsRoyalties,
-        ERC20[] calldata tokens
-    ) external;
+    function claim(address ipId, address claimerIpId, ERC20[] calldata tokens) external;
 }

--- a/contracts/interfaces/modules/royalty/policies/IRoyaltyPolicyLAP.sol
+++ b/contracts/interfaces/modules/royalty/policies/IRoyaltyPolicyLAP.sol
@@ -7,22 +7,6 @@ import { IRoyaltyPolicy } from "../../../../interfaces/modules/royalty/policies/
 
 /// @title RoyaltyPolicy interface
 interface IRoyaltyPolicyLAP is IRoyaltyPolicy {
-    /// @notice Initializes a royalty policy LAP for a given IP asset
-    /// @param targetAncestors The expected ancestors addresses of an ipId
-    /// @param targetRoyaltyAmount The expected royalties of each of the ancestors for a given ipId
-    /// @param parentAncestors1 The addresses of the ancestors of the first parent
-    /// @param parentAncestors2 The addresses of the ancestors of the second parent
-    /// @param parentAncestorsRoyalties1 The royalties of each of the ancestors of the first parent
-    /// @param parentAncestorsRoyalties2 The royalties of each of the ancestors of the second parent
-    struct InitParams {
-        address[] targetAncestors;
-        uint32[] targetRoyaltyAmount;
-        address[] parentAncestors1;
-        address[] parentAncestors2;
-        uint32[] parentAncestorsRoyalties1;
-        uint32[] parentAncestorsRoyalties2;
-    }
-
     /// @notice Event emitted when a policy is initialized
     /// @param ipId The ID of the IP asset that the policy is being initialized for
     /// @param splitClone The split clone address
@@ -38,26 +22,6 @@ interface IRoyaltyPolicyLAP is IRoyaltyPolicy {
         address[] targetAncestors,
         uint32[] targetRoyaltyAmount
     );
-
-    /// @notice Returns the royalty data for a given IP asset
-    /// @param ipId The ID of the IP asset
-    /// @return isUnlinkable Indicates if the ipId is unlinkable to new parents
-    /// @return splitClone The address of the liquid split clone contract for a given ipId
-    /// @return ancestorsVault The address of the ancestors vault contract for a given ipId
-    /// @return royaltyStack The royalty stack of a given ipId is the sum of the royalties to be paid to each ancestors
-    /// @return ancestorsHash The hash of the unique ancestors addresses and royalties arrays
-    function royaltyData(
-        address ipId
-    )
-        external
-        view
-        returns (
-            bool isUnlinkable,
-            address splitClone,
-            address ancestorsVault,
-            uint32 royaltyStack,
-            bytes32 ancestorsHash
-        );
 
     /// @notice Returns the percentage scale - 1000 rnfts represents 100%
     function TOTAL_RNFT_SUPPLY() external view returns (uint32);
@@ -115,14 +79,20 @@ interface IRoyaltyPolicyLAP is IRoyaltyPolicy {
     /// @notice Claims available royalty nfts and accrued royalties for an ancestor of a given ipId
     /// @param ipId The ipId of the ancestors vault to claim from
     /// @param claimerIpId The claimer ipId is the ancestor address that wants to claim
-    /// @param ancestors The ancestors for the selected ipId
-    /// @param ancestorsRoyalties The royalties of the ancestors for the selected ipId
     /// @param tokens The ERC20 tokens to withdraw
     function claimFromAncestorsVault(
         address ipId,
         address claimerIpId,
-        address[] calldata ancestors,
-        uint32[] calldata ancestorsRoyalties,
         ERC20[] calldata tokens
     ) external;
+
+    /// @notice Returns the royalty data for a given IP asset
+    /// @param ipId The ID of the IP asset
+    /// @return isUnlinkable Indicates if the ipId is unlinkable to new parents
+    /// @return splitClone The address of the liquid split clone contract for a given ipId
+    /// @return ancestorsVault The address of the ancestors vault contract for a given ipId
+    /// @return royaltyStack The royalty stack of a given ipId is the sum of the royalties to be paid to each ancestors
+    /// @return targetAncestors The ip ancestors array
+    /// @return targetRoyaltyAmount The ip royalty amount array
+    function getRoyaltyData(address ipId) external view returns (bool, address, address, uint32, address[] memory, uint32[] memory);
 }

--- a/contracts/interfaces/modules/royalty/policies/IRoyaltyPolicyLAP.sol
+++ b/contracts/interfaces/modules/royalty/policies/IRoyaltyPolicyLAP.sol
@@ -80,11 +80,7 @@ interface IRoyaltyPolicyLAP is IRoyaltyPolicy {
     /// @param ipId The ipId of the ancestors vault to claim from
     /// @param claimerIpId The claimer ipId is the ancestor address that wants to claim
     /// @param tokens The ERC20 tokens to withdraw
-    function claimFromAncestorsVault(
-        address ipId,
-        address claimerIpId,
-        ERC20[] calldata tokens
-    ) external;
+    function claimFromAncestorsVault(address ipId, address claimerIpId, ERC20[] calldata tokens) external;
 
     /// @notice Returns the royalty data for a given IP asset
     /// @param ipId The ID of the IP asset
@@ -94,5 +90,7 @@ interface IRoyaltyPolicyLAP is IRoyaltyPolicy {
     /// @return royaltyStack The royalty stack of a given ipId is the sum of the royalties to be paid to each ancestors
     /// @return targetAncestors The ip ancestors array
     /// @return targetRoyaltyAmount The ip royalty amount array
-    function getRoyaltyData(address ipId) external view returns (bool, address, address, uint32, address[] memory, uint32[] memory);
+    function getRoyaltyData(
+        address ipId
+    ) external view returns (bool, address, address, uint32, address[] memory, uint32[] memory);
 }

--- a/contracts/lib/Errors.sol
+++ b/contracts/lib/Errors.sol
@@ -194,7 +194,6 @@ library Errors {
     error DisputeModule__NotInDisputeState();
     error DisputeModule__NotAbleToResolve();
     error DisputeModule__NotRegisteredIpId();
-    error DisputeModule__UnauthorizedAccess();
 
     error ArbitrationPolicySP__ZeroDisputeModule();
     error ArbitrationPolicySP__ZeroPaymentToken();
@@ -214,7 +213,6 @@ library Errors {
     error RoyaltyModule__ZeroLicensingModule();
     error RoyaltyModule__CanOnlyMintSelectedPolicy();
     error RoyaltyModule__NoParentsOnLinking();
-    error RoyaltyModule__NotRegisteredIpId();
 
     error RoyaltyPolicyLAP__ZeroRoyaltyModule();
     error RoyaltyPolicyLAP__ZeroLiquidSplitFactory();
@@ -224,26 +222,18 @@ library Errors {
     error RoyaltyPolicyLAP__AboveParentLimit();
     error RoyaltyPolicyLAP__AboveAncestorsLimit();
     error RoyaltyPolicyLAP__AboveRoyaltyStackLimit();
-    error RoyaltyPolicyLAP__InvalidAncestorsLength();
-    error RoyaltyPolicyLAP__InvalidAncestors();
-    error RoyaltyPolicyLAP__InvalidRoyaltyAmountLength();
-    error RoyaltyPolicyLAP__InvalidAncestorsHash();
     error RoyaltyPolicyLAP__InvalidParentRoyaltiesLength();
-    error RoyaltyPolicyLAP__InvalidAncestorsRoyalty();
     error RoyaltyPolicyLAP__ImplementationAlreadySet();
     error RoyaltyPolicyLAP__ZeroAncestorsVaultImpl();
     error RoyaltyPolicyLAP__NotFullOwnership();
     error RoyaltyPolicyLAP__UnlinkableToParents();
-    error RoyaltyPolicyLAP__TransferFailed();
     error RoyaltyPolicyLAP__LastPositionNotAbleToMintLicense();
 
     error AncestorsVaultLAP__ZeroRoyaltyPolicyLAP();
     error AncestorsVaultLAP__AlreadyClaimed();
-    error AncestorsVaultLAP__InvalidAncestorsHash();
-    error AncestorsVaultLAP__InvalidClaimer();
+    error AncestorsVaultLAP__InvalidVault();
     error AncestorsVaultLAP__ClaimerNotAnAncestor();
     error AncestorsVaultLAP__ERC20BalanceNotZero();
-    error AncestorsVaultLAP__TransferFailed();
 
     ////////////////////////////////////////////////////////////////////////////
     //                             ModuleRegistry                             //

--- a/contracts/modules/royalty/policies/RoyaltyPolicyLAP.sol
+++ b/contracts/modules/royalty/policies/RoyaltyPolicyLAP.sol
@@ -131,7 +131,7 @@ contract RoyaltyPolicyLAP is IRoyaltyPolicyLAP, Governable, ERC1155Holder, Reent
         } else {
             // If the policy is already initialized and an ipId has the maximum number of ancestors
             // it can not have any derivative and therefore is not allowed to mint any license
-            if (royaltyData[ipId].ancestorsAddresses.length >= MAX_ANCESTORS)
+            if (data.ancestorsAddresses.length >= MAX_ANCESTORS)
                 revert Errors.RoyaltyPolicyLAP__LastPositionNotAbleToMintLicense();
         }
     }

--- a/contracts/modules/royalty/policies/RoyaltyPolicyLAP.sol
+++ b/contracts/modules/royalty/policies/RoyaltyPolicyLAP.sol
@@ -172,7 +172,11 @@ contract RoyaltyPolicyLAP is IRoyaltyPolicyLAP, Governable, ERC1155Holder, Reent
         if (parentIpIds.length > MAX_PARENTS) revert Errors.RoyaltyPolicyLAP__AboveParentLimit();
 
         // calculate new royalty stack
-        (uint32 royaltyStack, address[] memory newAncestors, uint32[] memory newAncestorsRoyalties) = _getNewAncestorsData(parentIpIds, parentRoyalties);
+        (
+            uint32 royaltyStack,
+            address[] memory newAncestors,
+            uint32[] memory newAncestorsRoyalties
+        ) = _getNewAncestorsData(parentIpIds, parentRoyalties);
 
         // set the parents as unlinkable / loop limited to 2 parents
         for (uint256 i = 0; i < parentIpIds.length; i++) {
@@ -199,14 +203,7 @@ contract RoyaltyPolicyLAP is IRoyaltyPolicyLAP, Governable, ERC1155Holder, Reent
             ancestorsRoyalties: newAncestorsRoyalties
         });
 
-        emit PolicyInitialized(
-            ipId,
-            splitClone,
-            ancestorsVault,
-            royaltyStack,
-            newAncestors,
-            newAncestorsRoyalties
-        );
+        emit PolicyInitialized(ipId, splitClone, ancestorsVault, royaltyStack, newAncestors, newAncestorsRoyalties);
     }
 
     /// @notice Allows the caller to pay royalties to the given IP asset
@@ -278,16 +275,8 @@ contract RoyaltyPolicyLAP is IRoyaltyPolicyLAP, Governable, ERC1155Holder, Reent
     /// @param ipId The ipId of the ancestors vault to claim from
     /// @param claimerIpId The claimer ipId is the ancestor address that wants to claim
     /// @param tokens The ERC20 tokens to withdraw
-    function claimFromAncestorsVault(
-        address ipId,
-        address claimerIpId,
-        ERC20[] calldata tokens
-    ) external {
-        IAncestorsVaultLAP(royaltyData[ipId].ancestorsVault).claim(
-            ipId,
-            claimerIpId,
-            tokens
-        );
+    function claimFromAncestorsVault(address ipId, address claimerIpId, ERC20[] calldata tokens) external {
+        IAncestorsVaultLAP(royaltyData[ipId].ancestorsVault).claim(ipId, claimerIpId, tokens);
     }
 
     /// @dev Gets the new ancestors data
@@ -360,7 +349,7 @@ contract RoyaltyPolicyLAP is IRoyaltyPolicyLAP, Governable, ERC1155Holder, Reent
             }
 
             address[] memory parentAncestors = royaltyData[parentIpIds[i]].ancestorsAddresses;
-            uint32[] memory parentAncestorsRoyalties = royaltyData[parentIpIds[i]].ancestorsRoyalties; 
+            uint32[] memory parentAncestorsRoyalties = royaltyData[parentIpIds[i]].ancestorsRoyalties;
 
             for (uint256 j = 0; j < parentAncestors.length; j++) {
                 if (i == 0) {
@@ -389,7 +378,7 @@ contract RoyaltyPolicyLAP is IRoyaltyPolicyLAP, Governable, ERC1155Holder, Reent
         for (uint256 k = 0; k < ancestorsCount; k++) {
             newAncestors[k] = newAncestors_[k];
             newAncestorsRoyalty[k] = newAncestorsRoyalty_[k];
-        }    
+        }
     }
 
     /// @dev Deploys a liquid split clone contract
@@ -424,7 +413,9 @@ contract RoyaltyPolicyLAP is IRoyaltyPolicyLAP, Governable, ERC1155Holder, Reent
     /// @return royaltyStack The royalty stack of a given ipId is the sum of the royalties to be paid to each ancestors
     /// @return ancestorsAddresses The ancestors addresses array
     /// @return ancestorsRoyalties The ancestors royalties array
-    function getRoyaltyData(address ipId) external view returns (bool, address, address, uint32, address[] memory, uint32[] memory) {
+    function getRoyaltyData(
+        address ipId
+    ) external view returns (bool, address, address, uint32, address[] memory, uint32[] memory) {
         LAPRoyaltyData memory data = royaltyData[ipId];
         return (
             data.isUnlinkableToParents,

--- a/contracts/modules/royalty/policies/RoyaltyPolicyLAP.sol
+++ b/contracts/modules/royalty/policies/RoyaltyPolicyLAP.sol
@@ -28,13 +28,15 @@ contract RoyaltyPolicyLAP is IRoyaltyPolicyLAP, Governable, ERC1155Holder, Reent
     /// @param splitClone The address of the liquid split clone contract for a given ipId
     /// @param ancestorsVault The address of the ancestors vault contract for a given ipId
     /// @param royaltyStack The royalty stack of a given ipId is the sum of the royalties to be paid to each ancestors
-    /// @param ancestorsHash The hash of the unique ancestors addresses and royalties arrays
+    /// @param ancestorsAddresses The ancestors addresses array
+    /// @param ancestorsRoyalties The ancestors royalties array
     struct LAPRoyaltyData {
         bool isUnlinkableToParents;
         address splitClone;
         address ancestorsVault;
         uint32 royaltyStack;
-        bytes32 ancestorsHash;
+        address[] ancestorsAddresses;
+        uint32[] ancestorsRoyalties;
     }
 
     /// @notice Returns the percentage scale - 1000 rnfts represents 100%
@@ -125,21 +127,12 @@ contract RoyaltyPolicyLAP is IRoyaltyPolicyLAP, Governable, ERC1155Holder, Reent
             // called _initPolicy() when linking to their parents with onLinkToParents() call.
             address[] memory rootParents = new address[](0);
             bytes[] memory rootParentRoyalties = new bytes[](0);
-            _initPolicy(ipId, rootParents, rootParentRoyalties, externalData);
+            _initPolicy(ipId, rootParents, rootParentRoyalties);
         } else {
-            InitParams memory params = abi.decode(externalData, (InitParams));
             // If the policy is already initialized and an ipId has the maximum number of ancestors
             // it can not have any derivative and therefore is not allowed to mint any license
-            if (params.targetAncestors.length >= MAX_ANCESTORS)
+            if (royaltyData[ipId].ancestorsAddresses.length >= MAX_ANCESTORS)
                 revert Errors.RoyaltyPolicyLAP__LastPositionNotAbleToMintLicense();
-
-            // the check below ensures that the ancestors hash is the same as the one stored in the royalty data
-            // and that the targetAncestors passed in by the user matches the record stored in state on policy
-            // initialization
-            if (
-                keccak256(abi.encodePacked(params.targetAncestors, params.targetRoyaltyAmount)) !=
-                royaltyData[ipId].ancestorsHash
-            ) revert Errors.RoyaltyPolicyLAP__InvalidAncestorsHash();
         }
     }
 
@@ -157,7 +150,7 @@ contract RoyaltyPolicyLAP is IRoyaltyPolicyLAP, Governable, ERC1155Holder, Reent
     ) external onlyRoyaltyModule {
         if (royaltyData[ipId].isUnlinkableToParents) revert Errors.RoyaltyPolicyLAP__UnlinkableToParents();
 
-        _initPolicy(ipId, parentIpIds, licenseData, externalData);
+        _initPolicy(ipId, parentIpIds, licenseData);
     }
 
     /// @dev Initializes the royalty policy for a given IP asset.
@@ -165,25 +158,21 @@ contract RoyaltyPolicyLAP is IRoyaltyPolicyLAP, Governable, ERC1155Holder, Reent
     /// @param ipId The to initialize the policy for
     /// @param parentIpIds The parent ipIds that the children ipId is being linked to (if any)
     /// @param licenseData The license data custom to each the royalty policy
-    /// @param externalData The external data custom to each the royalty policy
     function _initPolicy(
         address ipId,
         address[] memory parentIpIds,
-        bytes[] memory licenseData,
-        bytes calldata externalData
+        bytes[] memory licenseData
     ) internal onlyRoyaltyModule {
-        // decode license and external data
-        InitParams memory params = abi.decode(externalData, (InitParams));
+        // decode license data
         uint32[] memory parentRoyalties = new uint32[](parentIpIds.length);
         for (uint256 i = 0; i < parentIpIds.length; i++) {
             parentRoyalties[i] = abi.decode(licenseData[i], (uint32));
         }
 
-        if (params.targetAncestors.length > MAX_ANCESTORS) revert Errors.RoyaltyPolicyLAP__AboveAncestorsLimit();
         if (parentIpIds.length > MAX_PARENTS) revert Errors.RoyaltyPolicyLAP__AboveParentLimit();
 
         // calculate new royalty stack
-        uint32 royaltyStack = _checkAncestorsDataIsValid(parentIpIds, parentRoyalties, params);
+        (uint32 royaltyStack, address[] memory newAncestors, uint32[] memory newAncestorsRoyalties) = _getNewAncestorsData(parentIpIds, parentRoyalties);
 
         // set the parents as unlinkable / loop limited to 2 parents
         for (uint256 i = 0; i < parentIpIds.length; i++) {
@@ -206,7 +195,8 @@ contract RoyaltyPolicyLAP is IRoyaltyPolicyLAP, Governable, ERC1155Holder, Reent
             splitClone: splitClone,
             ancestorsVault: ancestorsVault,
             royaltyStack: royaltyStack,
-            ancestorsHash: keccak256(abi.encodePacked(params.targetAncestors, params.targetRoyaltyAmount))
+            ancestorsAddresses: newAncestors,
+            ancestorsRoyalties: newAncestorsRoyalties
         });
 
         emit PolicyInitialized(
@@ -214,8 +204,8 @@ contract RoyaltyPolicyLAP is IRoyaltyPolicyLAP, Governable, ERC1155Holder, Reent
             splitClone,
             ancestorsVault,
             royaltyStack,
-            params.targetAncestors,
-            params.targetRoyaltyAmount
+            newAncestors,
+            newAncestorsRoyalties
         );
     }
 
@@ -287,37 +277,29 @@ contract RoyaltyPolicyLAP is IRoyaltyPolicyLAP, Governable, ERC1155Holder, Reent
     /// @notice Claims all available royalty nfts and accrued royalties for an ancestor of a given ipId
     /// @param ipId The ipId of the ancestors vault to claim from
     /// @param claimerIpId The claimer ipId is the ancestor address that wants to claim
-    /// @param ancestors The ancestors for the selected ipId
-    /// @param ancestorsRoyalties The royalties of the ancestors for the selected ipId
     /// @param tokens The ERC20 tokens to withdraw
     function claimFromAncestorsVault(
         address ipId,
         address claimerIpId,
-        address[] calldata ancestors,
-        uint32[] calldata ancestorsRoyalties,
         ERC20[] calldata tokens
     ) external {
         IAncestorsVaultLAP(royaltyData[ipId].ancestorsVault).claim(
             ipId,
             claimerIpId,
-            ancestors,
-            ancestorsRoyalties,
             tokens
         );
     }
 
-    /// @dev Checks if the ancestors data is valid
+    /// @dev Gets the new ancestors data
     /// @param parentIpIds The parent ipIds
     /// @param parentRoyalties The parent royalties
-    /// @param params The init params
     /// @return newRoyaltyStack The new royalty stack
-    function _checkAncestorsDataIsValid(
+    /// @return newAncestors The new ancestors
+    /// @return newAncestorsRoyalty The new ancestors royalty
+    function _getNewAncestorsData(
         address[] memory parentIpIds,
-        uint32[] memory parentRoyalties,
-        InitParams memory params
-    ) internal view returns (uint32) {
-        if (params.targetRoyaltyAmount.length != params.targetAncestors.length)
-            revert Errors.RoyaltyPolicyLAP__InvalidRoyaltyAmountLength();
+        uint32[] memory parentRoyalties
+    ) internal view returns (uint32, address[] memory, uint32[] memory) {
         if (parentRoyalties.length != parentIpIds.length)
             revert Errors.RoyaltyPolicyLAP__InvalidParentRoyaltiesLength();
 
@@ -326,25 +308,17 @@ contract RoyaltyPolicyLAP is IRoyaltyPolicyLAP, Governable, ERC1155Holder, Reent
             uint32[] memory newAncestorsRoyalty,
             uint32 newAncestorsCount,
             uint32 newRoyaltyStack
-        ) = _getExpectedOutputs(parentIpIds, parentRoyalties, params);
+        ) = _getExpectedOutputs(parentIpIds, parentRoyalties);
 
-        if (params.targetAncestors.length != newAncestorsCount)
-            revert Errors.RoyaltyPolicyLAP__InvalidAncestorsLength();
+        if (newAncestorsCount > MAX_ANCESTORS) revert Errors.RoyaltyPolicyLAP__AboveAncestorsLimit();
         if (newRoyaltyStack > TOTAL_RNFT_SUPPLY) revert Errors.RoyaltyPolicyLAP__AboveRoyaltyStackLimit();
 
-        for (uint256 k = 0; k < newAncestorsCount; k++) {
-            if (params.targetAncestors[k] != newAncestors[k]) revert Errors.RoyaltyPolicyLAP__InvalidAncestors();
-            if (params.targetRoyaltyAmount[k] != newAncestorsRoyalty[k])
-                revert Errors.RoyaltyPolicyLAP__InvalidAncestorsRoyalty();
-        }
-
-        return newRoyaltyStack;
+        return (newRoyaltyStack, newAncestors, newAncestorsRoyalty);
     }
 
     /// @dev Gets the expected outputs for the ancestors and ancestors royalties
     /// @param parentIpIds The parent ipIds
     /// @param parentRoyalties The parent royalties
-    /// @param params The init params
     /// @return newAncestors The new ancestors
     /// @return newAncestorsRoyalty The new ancestors royalty
     /// @return ancestorsCount The number of ancestors
@@ -352,8 +326,7 @@ contract RoyaltyPolicyLAP is IRoyaltyPolicyLAP, Governable, ERC1155Holder, Reent
     // solhint-disable-next-line code-complexity
     function _getExpectedOutputs(
         address[] memory parentIpIds,
-        uint32[] memory parentRoyalties,
-        InitParams memory params
+        uint32[] memory parentRoyalties
     )
         internal
         view
@@ -364,57 +337,59 @@ contract RoyaltyPolicyLAP is IRoyaltyPolicyLAP, Governable, ERC1155Holder, Reent
             uint32 royaltyStack
         )
     {
-        newAncestorsRoyalty = new uint32[](params.targetRoyaltyAmount.length);
-        newAncestors = new address[](params.targetAncestors.length);
+        uint32[] memory newAncestorsRoyalty_ = new uint32[](MAX_ANCESTORS);
+        address[] memory newAncestors_ = new address[](MAX_ANCESTORS);
 
         for (uint256 i = 0; i < parentIpIds.length; i++) {
             if (i == 0) {
-                newAncestors[ancestorsCount] = parentIpIds[i];
-                newAncestorsRoyalty[ancestorsCount] += parentRoyalties[i];
+                newAncestors_[ancestorsCount] = parentIpIds[i];
+                newAncestorsRoyalty_[ancestorsCount] += parentRoyalties[i];
                 royaltyStack += parentRoyalties[i];
                 ancestorsCount++;
             } else if (i == 1) {
-                (uint256 index, bool isIn) = ArrayUtils.indexOf(newAncestors, parentIpIds[i]);
+                (uint256 index, bool isIn) = ArrayUtils.indexOf(newAncestors_, parentIpIds[i]);
                 if (!isIn) {
-                    newAncestors[ancestorsCount] = parentIpIds[i];
-                    newAncestorsRoyalty[ancestorsCount] += parentRoyalties[i];
+                    newAncestors_[ancestorsCount] = parentIpIds[i];
+                    newAncestorsRoyalty_[ancestorsCount] += parentRoyalties[i];
                     royaltyStack += parentRoyalties[i];
                     ancestorsCount++;
                 } else {
-                    newAncestorsRoyalty[index] += parentRoyalties[i];
+                    newAncestorsRoyalty_[index] += parentRoyalties[i];
                     royaltyStack += parentRoyalties[i];
                 }
             }
 
-            address[] memory parentAncestors = i == 0 ? params.parentAncestors1 : params.parentAncestors2;
-            uint32[] memory parentAncestorsRoyalties = i == 0
-                ? params.parentAncestorsRoyalties1
-                : params.parentAncestorsRoyalties2;
-            if (
-                keccak256(abi.encodePacked(parentAncestors, parentAncestorsRoyalties)) !=
-                royaltyData[parentIpIds[i]].ancestorsHash
-            ) revert Errors.RoyaltyPolicyLAP__InvalidAncestorsHash();
+            address[] memory parentAncestors = royaltyData[parentIpIds[i]].ancestorsAddresses;
+            uint32[] memory parentAncestorsRoyalties = royaltyData[parentIpIds[i]].ancestorsRoyalties; 
 
             for (uint256 j = 0; j < parentAncestors.length; j++) {
                 if (i == 0) {
-                    newAncestors[ancestorsCount] = parentAncestors[j];
-                    newAncestorsRoyalty[ancestorsCount] += parentAncestorsRoyalties[j];
+                    newAncestors_[ancestorsCount] = parentAncestors[j];
+                    newAncestorsRoyalty_[ancestorsCount] += parentAncestorsRoyalties[j];
                     royaltyStack += parentAncestorsRoyalties[j];
                     ancestorsCount++;
                 } else if (i == 1) {
-                    (uint256 index, bool isIn) = ArrayUtils.indexOf(newAncestors, parentAncestors[j]);
+                    (uint256 index, bool isIn) = ArrayUtils.indexOf(newAncestors_, parentAncestors[j]);
                     if (!isIn) {
-                        newAncestors[ancestorsCount] = parentAncestors[j];
-                        newAncestorsRoyalty[ancestorsCount] += parentAncestorsRoyalties[j];
+                        newAncestors_[ancestorsCount] = parentAncestors[j];
+                        newAncestorsRoyalty_[ancestorsCount] += parentAncestorsRoyalties[j];
                         royaltyStack += parentAncestorsRoyalties[j];
                         ancestorsCount++;
                     } else {
-                        newAncestorsRoyalty[index] += parentAncestorsRoyalties[j];
+                        newAncestorsRoyalty_[index] += parentAncestorsRoyalties[j];
                         royaltyStack += parentAncestorsRoyalties[j];
                     }
                 }
             }
         }
+
+        // remove empty elements from each array
+        newAncestors = new address[](ancestorsCount);
+        newAncestorsRoyalty = new uint32[](ancestorsCount);
+        for (uint256 k = 0; k < ancestorsCount; k++) {
+            newAncestors[k] = newAncestors_[k];
+            newAncestorsRoyalty[k] = newAncestorsRoyalty_[k];
+        }    
     }
 
     /// @dev Deploys a liquid split clone contract
@@ -439,5 +414,25 @@ contract RoyaltyPolicyLAP is IRoyaltyPolicyLAP, Governable, ERC1155Holder, Reent
         );
 
         return splitClone;
+    }
+
+    /// @notice Returns the royalty data for a given IP asset
+    /// @param ipId The ipId to get the royalty data for
+    /// @return isUnlinkableToParents Indicates if the ipId is unlinkable to new parents
+    /// @return splitClone The address of the liquid split clone contract for a given ipId
+    /// @return ancestorsVault The address of the ancestors vault contract for a given ipId
+    /// @return royaltyStack The royalty stack of a given ipId is the sum of the royalties to be paid to each ancestors
+    /// @return ancestorsAddresses The ancestors addresses array
+    /// @return ancestorsRoyalties The ancestors royalties array
+    function getRoyaltyData(address ipId) external view returns (bool, address, address, uint32, address[] memory, uint32[] memory) {
+        LAPRoyaltyData memory data = royaltyData[ipId];
+        return (
+            data.isUnlinkableToParents,
+            data.splitClone,
+            data.ancestorsVault,
+            data.royaltyStack,
+            data.ancestorsAddresses,
+            data.ancestorsRoyalties
+        );
     }
 }

--- a/script/foundry/deployment/Main.s.sol
+++ b/script/foundry/deployment/Main.s.sol
@@ -553,10 +553,15 @@ contract Main is Script, BroadcastManager, JsonDeploymentHandler {
                 block.chainid,
                 address(erc721),
                 3,
-                "IPAccount3",
-                bytes32("some of the best description"),
-                "https://example.com/best-derivative-ip",
-                ""
+                address(ipResolver),
+                true,
+                abi.encode(IP.MetadataV1({
+                    name: "IPAccount3",
+                    hash: bytes32("more content hash"),
+                    registrationDate: uint64(block.timestamp),
+                    registrant: deployer,
+                    uri: "https://example.com/test-derivative-ip"
+                }))
             );
         }
 

--- a/script/foundry/deployment/Main.s.sol
+++ b/script/foundry/deployment/Main.s.sol
@@ -386,17 +386,6 @@ contract Main is Script, BroadcastManager, JsonDeploymentHandler {
         // For license/royalty payment, on both minting license and royalty distribution
         erc20.approve(address(royaltyPolicyLAP), MAX_ROYALTY_APPROVAL);
 
-        bytes memory emptyRoyaltyPolicyLAPInitParams = abi.encode(
-            IRoyaltyPolicyLAP.InitParams({
-                targetAncestors: new address[](0),
-                targetRoyaltyAmount: new uint32[](0),
-                parentAncestors1: new address[](0),
-                parentAncestors2: new address[](0),
-                parentAncestorsRoyalties1: new uint32[](0),
-                parentAncestorsRoyalties2: new uint32[](0)
-            })
-        );
-
         licensingModule.registerPolicyFrameworkManager(address(pilPfm));
         frameworkAddrs["pil"] = address(pilPfm);
 
@@ -552,38 +541,22 @@ contract Main is Script, BroadcastManager, JsonDeploymentHandler {
                 ipAcct[1],
                 2,
                 deployer,
-                emptyRoyaltyPolicyLAPInitParams
+                ""
             );
 
             ipAcct[3] = getIpId(erc721, 3);
             vm.label(ipAcct[3], "IPAccount3");
 
-            IRoyaltyPolicyLAP.InitParams memory royaltyContext = IRoyaltyPolicyLAP.InitParams({
-                targetAncestors: new address[](1),
-                targetRoyaltyAmount: new uint32[](1),
-                parentAncestors1: new address[](0),
-                parentAncestors2: new address[](0),
-                parentAncestorsRoyalties1: new uint32[](0),
-                parentAncestorsRoyalties2: new uint32[](0)
-            });
-            royaltyContext.targetAncestors[0] = ipAcct[1];
-            royaltyContext.targetRoyaltyAmount[0] = 100;
-
             ipAssetRegistry.register(
                 licenseIds,
-                abi.encode(royaltyContext),
+                "",
                 block.chainid,
                 address(erc721),
                 3,
-                address(ipResolver),
-                true,
-                abi.encode(IP.MetadataV1({
-                    name: "IPAccount3",
-                    hash: bytes32("more content hash"),
-                    registrationDate: uint64(block.timestamp),
-                    registrant: deployer,
-                    uri: "https://example.com/test-derivative-ip"
-                }))
+                "IPAccount3",
+                bytes32("some of the best description"),
+                "https://example.com/best-derivative-ip",
+                ""
             );
         }
 
@@ -596,22 +569,11 @@ contract Main is Script, BroadcastManager, JsonDeploymentHandler {
                 ipAcct[2],
                 1,
                 deployer,
-                emptyRoyaltyPolicyLAPInitParams
+                ""
             );
 
             ipAcct[4] = getIpId(erc721, 4);
             vm.label(ipAcct[4], "IPAccount4");
-
-            IRoyaltyPolicyLAP.InitParams memory params = IRoyaltyPolicyLAP.InitParams({
-                targetAncestors: new address[](1),
-                targetRoyaltyAmount: new uint32[](1),
-                parentAncestors1: new address[](0),
-                parentAncestors2: new address[](0),
-                parentAncestorsRoyalties1: new uint32[](0),
-                parentAncestorsRoyalties2: new uint32[](0)
-            });
-            params.targetAncestors[0] = ipAcct[2];
-            params.targetRoyaltyAmount[0] = 100;
 
             ipAcct[4] = ipAssetRegistry.register(
                 block.chainid,
@@ -628,7 +590,7 @@ contract Main is Script, BroadcastManager, JsonDeploymentHandler {
                 }))
             );
 
-            licensingModule.linkIpToParents(licenseIds, ipAcct[4], abi.encode(params));
+            licensingModule.linkIpToParents(licenseIds, ipAcct[4], "");
         }
 
         // Multi-parent
@@ -642,46 +604,20 @@ contract Main is Script, BroadcastManager, JsonDeploymentHandler {
                 ipAcct[1],
                 1,
                 deployer,
-                emptyRoyaltyPolicyLAPInitParams
+                ""
             );
-
-            IRoyaltyPolicyLAP.InitParams memory paramsMintLicense = IRoyaltyPolicyLAP.InitParams({
-                targetAncestors: new address[](1),
-                targetRoyaltyAmount: new uint32[](1),
-                parentAncestors1: new address[](0),
-                parentAncestors2: new address[](0),
-                parentAncestorsRoyalties1: new uint32[](0),
-                parentAncestorsRoyalties2: new uint32[](0)
-            });
-            paramsMintLicense.targetAncestors[0] = ipAcct[1];
-            paramsMintLicense.targetRoyaltyAmount[0] = 100;
 
             licenseIds[1] = licensingModule.mintLicense(
                 policyIds["pil_com_deriv_expensive"],
                 ipAcct[3], // is child of ipAcct[1]
                 1,
                 deployer,
-                abi.encode(paramsMintLicense)
+                ""
             );
-
-            IRoyaltyPolicyLAP.InitParams memory paramsLinkParent = IRoyaltyPolicyLAP.InitParams({
-                targetAncestors: new address[](2),
-                targetRoyaltyAmount: new uint32[](2),
-                parentAncestors1: new address[](0),
-                parentAncestors2: new address[](1),
-                parentAncestorsRoyalties1: new uint32[](0),
-                parentAncestorsRoyalties2: new uint32[](1)
-            });
-            paramsLinkParent.targetAncestors[0] = ipAcct[1]; // grandparent
-            paramsLinkParent.targetAncestors[1] = ipAcct[3]; // parent
-            paramsLinkParent.targetRoyaltyAmount[0] = 200; // 100 + 100
-            paramsLinkParent.targetRoyaltyAmount[1] = 100;
-            paramsLinkParent.parentAncestors2[0] = ipAcct[1];
-            paramsLinkParent.parentAncestorsRoyalties2[0] = 100;
 
             ipAssetRegistry.register(
                 licenseIds,
-                abi.encode(paramsLinkParent),
+                "",
                 block.chainid,
                 address(erc721),
                 5,
@@ -715,7 +651,7 @@ contract Main is Script, BroadcastManager, JsonDeploymentHandler {
         // 0xSplits Main, which will get distributed to IPAccount3 AND its claimer based on revenue
         // sharing terms specified in the royalty policy.
         {
-            (, , address ipAcct5_ancestorVault, , ) = royaltyPolicyLAP.royaltyData(ipAcct[5]);
+            (, , address ipAcct5_ancestorVault, , ,) = royaltyPolicyLAP.getRoyaltyData(ipAcct[5]);
 
             address[] memory accounts = new address[](2);
             // If you face InvalidSplit__AccountsOutOfOrder, shuffle the order of accounts (swap index 0 and 1)
@@ -730,7 +666,7 @@ contract Main is Script, BroadcastManager, JsonDeploymentHandler {
             ERC20[] memory tokens = new ERC20[](1);
             tokens[0] = erc20;
 
-            (, , address ancestorVault_ipAcct5, , ) = royaltyPolicyLAP.royaltyData(ipAcct[5]);
+            (, , address ancestorVault_ipAcct5, , ,) = royaltyPolicyLAP.getRoyaltyData(ipAcct[5]);
 
             // First, release the money from the IPAccount5's 0xSplitWallet (that just received money) to the main
             // 0xSplitMain that acts as a ledger for revenue distribution.
@@ -753,8 +689,6 @@ contract Main is Script, BroadcastManager, JsonDeploymentHandler {
             royaltyPolicyLAP.claimFromAncestorsVault({
                 ipId: ipAcct[5],
                 claimerIpId: ipAcct[1],
-                ancestors: ancestors,
-                ancestorsRoyalties: ancestorsRoyalties,
                 tokens: tokens
             });
         }

--- a/test/foundry/integration/big-bang/SingleNftCollection.t.sol
+++ b/test/foundry/integration/big-bang/SingleNftCollection.t.sol
@@ -9,7 +9,6 @@ import { IIPAccount } from "../../../../contracts/interfaces/IIPAccount.sol";
 import { IP } from "../../../../contracts/lib/IP.sol";
 import { Errors } from "../../../../contracts/lib/Errors.sol";
 import { PILPolicy } from "../../../../contracts/modules/licensing/PILPolicyFrameworkManager.sol";
-import { IRoyaltyPolicyLAP } from "../../../../contracts/interfaces/modules/royalty/policies/IRoyaltyPolicyLAP.sol";
 
 // test
 import { BaseIntegration } from "../BaseIntegration.t.sol";
@@ -26,8 +25,6 @@ contract BigBang_Integration_SingleNftCollection is BaseIntegration {
     mapping(uint256 tokenId => address ipAccount) internal ipAcct;
 
     mapping(string name => uint256 licenseId) internal licenseIds;
-
-    bytes internal emptyRoyaltyPolicyLAPInitParams;
 
     uint32 internal constant derivCheapFlexibleRevShare = 10;
 
@@ -84,17 +81,6 @@ contract BigBang_Integration_SingleNftCollection is BaseIntegration {
                 territories: new string[](0),
                 distributionChannels: new string[](0),
                 contentRestrictions: new string[](0)
-            })
-        );
-
-        emptyRoyaltyPolicyLAPInitParams = abi.encode(
-            IRoyaltyPolicyLAP.InitParams({
-                targetAncestors: new address[](0),
-                targetRoyaltyAmount: new uint32[](0),
-                parentAncestors1: new address[](0),
-                parentAncestors2: new address[](0),
-                parentAncestorsRoyalties1: new uint32[](0),
-                parentAncestorsRoyalties2: new uint32[](0)
             })
         );
     }
@@ -171,23 +157,12 @@ contract BigBang_Integration_SingleNftCollection is BaseIntegration {
                 ipAcct[1],
                 1,
                 u.carl,
-                emptyRoyaltyPolicyLAPInitParams
+                ""
             );
 
             ipAcct[6] = registerIpAccount(mockNFT, 6, u.carl);
 
-            IRoyaltyPolicyLAP.InitParams memory params = IRoyaltyPolicyLAP.InitParams({
-                targetAncestors: new address[](1),
-                targetRoyaltyAmount: new uint32[](1),
-                parentAncestors1: new address[](0),
-                parentAncestors2: new address[](0),
-                parentAncestorsRoyalties1: new uint32[](0),
-                parentAncestorsRoyalties2: new uint32[](0)
-            });
-            params.targetAncestors[0] = ipAcct[1];
-            params.targetRoyaltyAmount[0] = derivCheapFlexibleRevShare;
-
-            linkIpToParents(carl_license_from_root_alice, ipAcct[6], u.carl, abi.encode(params));
+            linkIpToParents(carl_license_from_root_alice, ipAcct[6], u.carl, "");
         }
 
         // Carl mints 2 license for policy "pil_noncom_deriv_reciprocal_derivative" on Bob's NFT 3 IPAccount
@@ -206,24 +181,13 @@ contract BigBang_Integration_SingleNftCollection is BaseIntegration {
                 ipAcct[3],
                 1,
                 u.carl,
-                emptyRoyaltyPolicyLAPInitParams
+                ""
             );
-
-            IRoyaltyPolicyLAP.InitParams memory royaltyContextRegister = IRoyaltyPolicyLAP.InitParams({
-                targetAncestors: new address[](1),
-                targetRoyaltyAmount: new uint32[](1),
-                parentAncestors1: new address[](0),
-                parentAncestors2: new address[](0),
-                parentAncestorsRoyalties1: new uint32[](0),
-                parentAncestorsRoyalties2: new uint32[](0)
-            });
-            royaltyContextRegister.targetAncestors[0] = ipAcct[3];
-            royaltyContextRegister.targetRoyaltyAmount[0] = 0;
 
             // TODO: events check
             ipAssetRegistry.register(
                 carl_license_from_root_bob,
-                abi.encode(royaltyContextRegister),
+                "",
                 block.chainid,
                 address(mockNFT),
                 7,
@@ -262,22 +226,11 @@ contract BigBang_Integration_SingleNftCollection is BaseIntegration {
                 ipAcct[3],
                 mintAmount,
                 u.alice,
-                emptyRoyaltyPolicyLAPInitParams
+                ""
             );
 
-            IRoyaltyPolicyLAP.InitParams memory params = IRoyaltyPolicyLAP.InitParams({
-                targetAncestors: new address[](1),
-                targetRoyaltyAmount: new uint32[](1),
-                parentAncestors1: new address[](0),
-                parentAncestors2: new address[](0),
-                parentAncestorsRoyalties1: new uint32[](0),
-                parentAncestorsRoyalties2: new uint32[](0)
-            });
-            params.targetAncestors[0] = ipAcct[3];
-            params.targetRoyaltyAmount[0] = derivCheapFlexibleRevShare;
-
             ipAcct[2] = registerIpAccount(mockNFT, 2, u.alice);
-            linkIpToParents(alice_license_from_root_bob, ipAcct[2], u.alice, abi.encode(params));
+            linkIpToParents(alice_license_from_root_bob, ipAcct[2], u.alice, "");
 
             uint256 tokenId = 99999999;
             mockNFT.mintId(u.alice, tokenId);
@@ -294,7 +247,7 @@ contract BigBang_Integration_SingleNftCollection is BaseIntegration {
                     uri: "external URL"
                 }),
                 u.alice, // caller
-                abi.encode(params)
+                ""
             );
         }
 
@@ -326,7 +279,7 @@ contract BigBang_Integration_SingleNftCollection is BaseIntegration {
                 ipAcct[1],
                 license0_mintAmount,
                 u.carl,
-                emptyRoyaltyPolicyLAPInitParams
+                ""
             );
 
             // Non-commercial license
@@ -335,14 +288,14 @@ contract BigBang_Integration_SingleNftCollection is BaseIntegration {
                 ipAcct[3],
                 1,
                 u.carl,
-                emptyRoyaltyPolicyLAPInitParams
+                ""
             );
 
             // This should revert since license[0] is commercial but license[1] is non-commercial
             vm.expectRevert(Errors.LicensingModule__IncompatibleLicensorCommercialPolicy.selector);
             ipAssetRegistry.register(
                 carl_licenses,
-                emptyRoyaltyPolicyLAPInitParams,
+                "",
                 block.chainid,
                 address(mockNFT),
                 tokenId,
@@ -361,23 +314,11 @@ contract BigBang_Integration_SingleNftCollection is BaseIntegration {
                 ipAcct[300],
                 license1_mintAmount,
                 u.carl,
-                emptyRoyaltyPolicyLAPInitParams
+                ""
             );
 
             // Linking 2 licenses, ID 1 and ID 4.
             // These licenses are from 2 different parents, ipAcct[1] and ipAcct[300], respectively.
-            IRoyaltyPolicyLAP.InitParams memory params = IRoyaltyPolicyLAP.InitParams({
-                targetAncestors: new address[](2),
-                targetRoyaltyAmount: new uint32[](2),
-                parentAncestors1: new address[](0),
-                parentAncestors2: new address[](0),
-                parentAncestorsRoyalties1: new uint32[](0),
-                parentAncestorsRoyalties2: new uint32[](0)
-            });
-            params.targetAncestors[0] = ipAcct[1];
-            params.targetAncestors[1] = ipAcct[300];
-            params.targetRoyaltyAmount[0] = derivCheapFlexibleRevShare;
-            params.targetRoyaltyAmount[1] = derivCheapFlexibleRevShare;
 
             // This should succeed since both license[0] and license[1] are commercial
             registerDerivativeIps(
@@ -386,7 +327,7 @@ contract BigBang_Integration_SingleNftCollection is BaseIntegration {
                 tokenId,
                 metadata,
                 u.carl, // caller
-                abi.encode(params)
+                ""
             );
         }
     }

--- a/test/foundry/integration/flows/disputes/Disputes.t.sol
+++ b/test/foundry/integration/flows/disputes/Disputes.t.sol
@@ -7,7 +7,6 @@ import { Strings } from "@openzeppelin/contracts/utils/Strings.sol";
 import { IERC20 } from "@openzeppelin/contracts/token/ERC20/IERC20.sol";
 
 // contract
-import { IRoyaltyPolicyLAP } from "contracts/interfaces/modules/royalty/policies/IRoyaltyPolicyLAP.sol";
 import { Errors } from "contracts/lib/Errors.sol";
 
 // test
@@ -74,21 +73,10 @@ contract Flows_Integration_Disputes is BaseIntegration {
         uint256[] memory licenseIds = new uint256[](1);
         licenseIds[0] = licenseId;
 
-        IRoyaltyPolicyLAP.InitParams memory royaltyContext = IRoyaltyPolicyLAP.InitParams({
-            targetAncestors: new address[](0),
-            targetRoyaltyAmount: new uint32[](0),
-            parentAncestors1: new address[](0),
-            parentAncestors2: new address[](0),
-            parentAncestorsRoyalties1: new uint32[](0),
-            parentAncestorsRoyalties2: new uint32[](0)
-        });
-
         vm.prank(u.carl);
         vm.expectRevert(Errors.LicensingModule__LinkingRevokedLicense.selector);
-        licensingModule.linkIpToParents(licenseIds, ipAcct[3], abi.encode(royaltyContext));
+        licensingModule.linkIpToParents(licenseIds, ipAcct[3], "");
     }
-
-    // TODO: check if IPAccount is transferable even if disputed
 
     function test_Integration_Disputes_transferLicenseAfterIpDispute() public {
         assertEq(licenseRegistry.balanceOf(u.carl, policyId), 0);

--- a/test/foundry/modules/royalty/RoyaltyModule.t.sol
+++ b/test/foundry/modules/royalty/RoyaltyModule.t.sol
@@ -463,7 +463,7 @@ contract TestRoyaltyModule is BaseTest {
         address receiverIpId = address(7);
         address payerIpId = address(3);
 
-        (, address splitClone, , , ) = royaltyPolicyLAP.royaltyData(receiverIpId);
+        (, address splitClone, , , , ) = royaltyPolicyLAP.getRoyaltyData(receiverIpId);
 
         vm.startPrank(payerIpId);
         USDC.mint(payerIpId, royaltyAmount);
@@ -491,7 +491,7 @@ contract TestRoyaltyModule is BaseTest {
         address licenseRoyaltyPolicy = address(royaltyPolicyLAP);
         address token = address(USDC);
 
-        (, address splitClone, , , ) = royaltyPolicyLAP.royaltyData(receiverIpId);
+        (, address splitClone, , , , ) = royaltyPolicyLAP.getRoyaltyData(receiverIpId);
 
         vm.startPrank(payerAddress);
         USDC.mint(payerAddress, royaltyAmount);

--- a/test/foundry/modules/royalty/RoyaltyPolicyLAP.t.sol
+++ b/test/foundry/modules/royalty/RoyaltyPolicyLAP.t.sol
@@ -20,19 +20,8 @@ contract TestRoyaltyPolicyLAP is BaseTest {
         uint32[] targetRoyaltyAmount
     );
 
-    struct InitParams {
-        address[] targetAncestors;
-        uint32[] targetRoyaltyAmount;
-        address[] parentAncestors1;
-        address[] parentAncestors2;
-        uint32[] parentAncestorsRoyalties1;
-        uint32[] parentAncestorsRoyalties2;
-    }
-
     RoyaltyPolicyLAP internal testRoyaltyPolicyLAP;
 
-    InitParams internal initParamsMax;
-    bytes internal MAX_ANCESTORS;
     address[] internal MAX_ANCESTORS_ = new address[](14);
     uint32[] internal MAX_ANCESTORS_ROYALTY_ = new uint32[](14);
     address[] internal parentsIpIds100;
@@ -53,40 +42,21 @@ contract TestRoyaltyPolicyLAP is BaseTest {
 
         vm.startPrank(address(royaltyModule));
         _setupMaxUniqueTree();
-        //_setupDuplicatesTree();
     }
 
     function _setupMaxUniqueTree() internal {
         // init royalty policy for roots
-        address[] memory nullTargetAncestors = new address[](0);
-        uint32[] memory nullTargetRoyaltyAmount = new uint32[](0);
-        uint32[] memory parentRoyalties = new uint32[](0);
-        address[] memory nullParentAncestors1 = new address[](0);
-        address[] memory nullParentAncestors2 = new address[](0);
-        uint32[] memory nullParentAncestorsRoyalties1 = new uint32[](0);
-        uint32[] memory nullParentAncestorsRoyalties2 = new uint32[](0);
-        InitParams memory nullInitParams = InitParams({
-            targetAncestors: nullTargetAncestors,
-            targetRoyaltyAmount: nullTargetRoyaltyAmount,
-            parentAncestors1: nullParentAncestors1,
-            parentAncestors2: nullParentAncestors2,
-            parentAncestorsRoyalties1: nullParentAncestorsRoyalties1,
-            parentAncestorsRoyalties2: nullParentAncestorsRoyalties2
-        });
-        bytes memory nullBytes = abi.encode(nullInitParams);
-        royaltyPolicyLAP.onLicenseMinting(address(7), abi.encode(uint32(7)), nullBytes);
-        royaltyPolicyLAP.onLicenseMinting(address(8), abi.encode(uint32(8)), nullBytes);
-        royaltyPolicyLAP.onLicenseMinting(address(9), abi.encode(uint32(9)), nullBytes);
-        royaltyPolicyLAP.onLicenseMinting(address(10), abi.encode(uint32(10)), nullBytes);
-        royaltyPolicyLAP.onLicenseMinting(address(11), abi.encode(uint32(11)), nullBytes);
-        royaltyPolicyLAP.onLicenseMinting(address(12), abi.encode(uint32(12)), nullBytes);
-        royaltyPolicyLAP.onLicenseMinting(address(13), abi.encode(uint32(13)), nullBytes);
-        royaltyPolicyLAP.onLicenseMinting(address(14), abi.encode(uint32(14)), nullBytes);
+        royaltyPolicyLAP.onLicenseMinting(address(7), abi.encode(uint32(7)), "");
+        royaltyPolicyLAP.onLicenseMinting(address(8), abi.encode(uint32(8)), "");
+        royaltyPolicyLAP.onLicenseMinting(address(9), abi.encode(uint32(9)), "");
+        royaltyPolicyLAP.onLicenseMinting(address(10), abi.encode(uint32(10)), "");
+        royaltyPolicyLAP.onLicenseMinting(address(11), abi.encode(uint32(11)), "");
+        royaltyPolicyLAP.onLicenseMinting(address(12), abi.encode(uint32(12)), "");
+        royaltyPolicyLAP.onLicenseMinting(address(13), abi.encode(uint32(13)), "");
+        royaltyPolicyLAP.onLicenseMinting(address(14), abi.encode(uint32(14)), "");
 
         // init 2nd level with children
         address[] memory parents = new address[](2);
-        address[] memory targetAncestors1 = new address[](2);
-        uint32[] memory targetRoyaltyAmount1 = new uint32[](2);
         uint32[] memory parentRoyalties1 = new uint32[](2);
         bytes[] memory encodedLicenseData = new bytes[](2);
 
@@ -95,184 +65,67 @@ contract TestRoyaltyPolicyLAP is BaseTest {
         parents[1] = address(8);
         parentRoyalties1[0] = 7;
         parentRoyalties1[1] = 8;
-        targetAncestors1[0] = address(7);
-        targetAncestors1[1] = address(8);
-        targetRoyaltyAmount1[0] = 7;
-        targetRoyaltyAmount1[1] = 8;
-        InitParams memory initParams = InitParams({
-            targetAncestors: targetAncestors1,
-            targetRoyaltyAmount: targetRoyaltyAmount1,
-            parentAncestors1: nullParentAncestors1,
-            parentAncestors2: nullParentAncestors2,
-            parentAncestorsRoyalties1: nullParentAncestorsRoyalties1,
-            parentAncestorsRoyalties2: nullParentAncestorsRoyalties2
-        });
+
         for (uint32 i = 0; i < parentRoyalties1.length; i++) {
             encodedLicenseData[i] = abi.encode(parentRoyalties1[i]);
         }
-        bytes memory encodedBytes = abi.encode(initParams);
-        royaltyPolicyLAP.onLinkToParents(address(3), parents, encodedLicenseData, encodedBytes);
+        royaltyPolicyLAP.onLinkToParents(address(3), parents, encodedLicenseData, "");
 
         // 4 is child of 9 and 10
         parents[0] = address(9);
         parents[1] = address(10);
         parentRoyalties1[0] = 9;
         parentRoyalties1[1] = 10;
-        targetAncestors1[0] = address(9);
-        targetAncestors1[1] = address(10);
-        targetRoyaltyAmount1[0] = 9;
-        targetRoyaltyAmount1[1] = 10;
-        initParams = InitParams({
-            targetAncestors: targetAncestors1,
-            targetRoyaltyAmount: targetRoyaltyAmount1,
-            parentAncestors1: nullParentAncestors1,
-            parentAncestors2: nullParentAncestors2,
-            parentAncestorsRoyalties1: nullParentAncestorsRoyalties1,
-            parentAncestorsRoyalties2: nullParentAncestorsRoyalties2
-        });
+
         for (uint32 i = 0; i < parentRoyalties1.length; i++) {
             encodedLicenseData[i] = abi.encode(parentRoyalties1[i]);
         }
-        encodedBytes = abi.encode(initParams);
-        royaltyPolicyLAP.onLinkToParents(address(4), parents, encodedLicenseData, encodedBytes);
+        royaltyPolicyLAP.onLinkToParents(address(4), parents, encodedLicenseData, "");
 
         // 5 is child of 11 and 12
         parents[0] = address(11);
         parents[1] = address(12);
         parentRoyalties1[0] = 11;
         parentRoyalties1[1] = 12;
-        targetAncestors1[0] = address(11);
-        targetAncestors1[1] = address(12);
-        targetRoyaltyAmount1[0] = 11;
-        targetRoyaltyAmount1[1] = 12;
-        initParams = InitParams({
-            targetAncestors: targetAncestors1,
-            targetRoyaltyAmount: targetRoyaltyAmount1,
-            parentAncestors1: nullParentAncestors1,
-            parentAncestors2: nullParentAncestors2,
-            parentAncestorsRoyalties1: nullParentAncestorsRoyalties1,
-            parentAncestorsRoyalties2: nullParentAncestorsRoyalties2
-        });
+
         for (uint32 i = 0; i < parentRoyalties1.length; i++) {
             encodedLicenseData[i] = abi.encode(parentRoyalties1[i]);
         }
-        encodedBytes = abi.encode(initParams);
-        royaltyPolicyLAP.onLinkToParents(address(5), parents, encodedLicenseData, encodedBytes);
+        royaltyPolicyLAP.onLinkToParents(address(5), parents, encodedLicenseData, "");
 
         // 6 is child of 13 and 14
         parents[0] = address(13);
         parents[1] = address(14);
         parentRoyalties1[0] = 13;
         parentRoyalties1[1] = 14;
-        targetAncestors1[0] = address(13);
-        targetAncestors1[1] = address(14);
-        targetRoyaltyAmount1[0] = 13;
-        targetRoyaltyAmount1[1] = 14;
-        initParams = InitParams({
-            targetAncestors: targetAncestors1,
-            targetRoyaltyAmount: targetRoyaltyAmount1,
-            parentAncestors1: nullParentAncestors1,
-            parentAncestors2: nullParentAncestors2,
-            parentAncestorsRoyalties1: nullParentAncestorsRoyalties1,
-            parentAncestorsRoyalties2: nullParentAncestorsRoyalties2
-        });
+
         for (uint32 i = 0; i < parentRoyalties1.length; i++) {
             encodedLicenseData[i] = abi.encode(parentRoyalties1[i]);
         }
-        encodedBytes = abi.encode(initParams);
-        royaltyPolicyLAP.onLinkToParents(address(6), parents, encodedLicenseData, encodedBytes);
+        royaltyPolicyLAP.onLinkToParents(address(6), parents, encodedLicenseData, "");
 
         // init 3rd level with children
-        address[] memory targetAncestors2 = new address[](6);
-        uint32[] memory targetRoyaltyAmount2 = new uint32[](6);
-        address[] memory parentAncestors1 = new address[](2);
-        address[] memory parentAncestors2 = new address[](2);
-        uint32[] memory parentAncestorsRoyalties1 = new uint32[](2);
-        uint32[] memory parentAncestorsRoyalties2 = new uint32[](2);
-
         // 1 is child of 3 and 4
         parents[0] = address(3);
         parents[1] = address(4);
         parentRoyalties1[0] = 3;
         parentRoyalties1[1] = 4;
-        parentAncestors1[0] = address(7);
-        parentAncestors1[1] = address(8);
-        parentAncestors2[0] = address(9);
-        parentAncestors2[1] = address(10);
-        parentAncestorsRoyalties1[0] = 7;
-        parentAncestorsRoyalties1[1] = 8;
-        parentAncestorsRoyalties2[0] = 9;
-        parentAncestorsRoyalties2[1] = 10;
-        targetAncestors2[0] = address(3);
-        targetAncestors2[1] = address(7);
-        targetAncestors2[2] = address(8);
-        targetAncestors2[3] = address(4);
-        targetAncestors2[4] = address(9);
-        targetAncestors2[5] = address(10);
-        targetRoyaltyAmount2[0] = 3;
-        targetRoyaltyAmount2[1] = 7;
-        targetRoyaltyAmount2[2] = 8;
-        targetRoyaltyAmount2[3] = 4;
-        targetRoyaltyAmount2[4] = 9;
-        targetRoyaltyAmount2[5] = 10;
-        initParams = InitParams({
-            targetAncestors: targetAncestors2,
-            targetRoyaltyAmount: targetRoyaltyAmount2,
-            parentAncestors1: parentAncestors1,
-            parentAncestors2: parentAncestors2,
-            parentAncestorsRoyalties1: parentAncestorsRoyalties1,
-            parentAncestorsRoyalties2: parentAncestorsRoyalties2
-        });
+
         for (uint32 i = 0; i < parentRoyalties1.length; i++) {
             encodedLicenseData[i] = abi.encode(parentRoyalties1[i]);
         }
-        encodedBytes = abi.encode(initParams);
-        royaltyPolicyLAP.onLinkToParents(address(1), parents, encodedLicenseData, encodedBytes);
+        royaltyPolicyLAP.onLinkToParents(address(1), parents, encodedLicenseData, "");
 
         // 2 is child of 5 and 6
         parents[0] = address(5);
         parents[1] = address(6);
         parentRoyalties1[0] = 5;
         parentRoyalties1[1] = 6;
-        parentAncestors1[0] = address(11);
-        parentAncestors1[1] = address(12);
-        parentAncestors2[0] = address(13);
-        parentAncestors2[1] = address(14);
-        parentAncestorsRoyalties1[0] = 11;
-        parentAncestorsRoyalties1[1] = 12;
-        parentAncestorsRoyalties2[0] = 13;
-        parentAncestorsRoyalties2[1] = 14;
-        targetAncestors2[0] = address(5);
-        targetAncestors2[1] = address(11);
-        targetAncestors2[2] = address(12);
-        targetAncestors2[3] = address(6);
-        targetAncestors2[4] = address(13);
-        targetAncestors2[5] = address(14);
-        targetRoyaltyAmount2[0] = 5;
-        targetRoyaltyAmount2[1] = 11;
-        targetRoyaltyAmount2[2] = 12;
-        targetRoyaltyAmount2[3] = 6;
-        targetRoyaltyAmount2[4] = 13;
-        targetRoyaltyAmount2[5] = 14;
-        initParams = InitParams({
-            targetAncestors: targetAncestors2,
-            targetRoyaltyAmount: targetRoyaltyAmount2,
-            parentAncestors1: parentAncestors1,
-            parentAncestors2: parentAncestors2,
-            parentAncestorsRoyalties1: parentAncestorsRoyalties1,
-            parentAncestorsRoyalties2: parentAncestorsRoyalties2
-        });
+
         for (uint32 i = 0; i < parentRoyalties1.length; i++) {
             encodedLicenseData[i] = abi.encode(parentRoyalties1[i]);
         }
-        encodedBytes = abi.encode(initParams);
-        royaltyPolicyLAP.onLinkToParents(address(2), parents, encodedLicenseData, encodedBytes);
-
-        address[] memory parentAncestors3 = new address[](6);
-        address[] memory parentAncestors4 = new address[](6);
-        uint32[] memory parentAncestorsRoyalties3 = new uint32[](6);
-        uint32[] memory parentAncestorsRoyalties4 = new uint32[](6);
-        uint32[] memory parentRoyalties3 = new uint32[](2);
+        royaltyPolicyLAP.onLinkToParents(address(2), parents, encodedLicenseData, "");
 
         // ancestors of parent 1
         MAX_ANCESTORS_[0] = address(1);
@@ -306,46 +159,6 @@ contract TestRoyaltyPolicyLAP is BaseTest {
         MAX_ANCESTORS_ROYALTY_[12] = 13;
         MAX_ANCESTORS_ROYALTY_[13] = 14;
 
-        parentAncestors3[0] = address(3);
-        parentAncestors3[1] = address(7);
-        parentAncestors3[2] = address(8);
-        parentAncestors3[3] = address(4);
-        parentAncestors3[4] = address(9);
-        parentAncestors3[5] = address(10);
-        parentAncestorsRoyalties3[0] = 3;
-        parentAncestorsRoyalties3[1] = 7;
-        parentAncestorsRoyalties3[2] = 8;
-        parentAncestorsRoyalties3[3] = 4;
-        parentAncestorsRoyalties3[4] = 9;
-        parentAncestorsRoyalties3[5] = 10;
-
-        parentAncestors4[0] = address(5);
-        parentAncestors4[1] = address(11);
-        parentAncestors4[2] = address(12);
-        parentAncestors4[3] = address(6);
-        parentAncestors4[4] = address(13);
-        parentAncestors4[5] = address(14);
-        parentAncestorsRoyalties4[0] = 5;
-        parentAncestorsRoyalties4[1] = 11;
-        parentAncestorsRoyalties4[2] = 12;
-        parentAncestorsRoyalties4[3] = 6;
-        parentAncestorsRoyalties4[4] = 13;
-        parentAncestorsRoyalties4[5] = 14;
-
-        parentRoyalties3[0] = 1;
-        parentRoyalties3[1] = 2;
-
-        initParamsMax = InitParams({
-            targetAncestors: MAX_ANCESTORS_,
-            targetRoyaltyAmount: MAX_ANCESTORS_ROYALTY_,
-            parentAncestors1: parentAncestors3,
-            parentAncestors2: parentAncestors4,
-            parentAncestorsRoyalties1: parentAncestorsRoyalties3,
-            parentAncestorsRoyalties2: parentAncestorsRoyalties4
-        });
-
-        MAX_ANCESTORS = abi.encode(initParamsMax);
-
         parentsIpIds100 = new address[](2);
         parentsIpIds100[0] = address(1);
         parentsIpIds100[1] = address(2);
@@ -378,27 +191,6 @@ contract TestRoyaltyPolicyLAP is BaseTest {
         assertEq(royaltyPolicyLAP2.ANCESTORS_VAULT_IMPL(), address(2));
     }
 
-    function test_RoyaltyPolicyLAP_initPolicy_AboveAncestorsLimit() public {
-        address[] memory targetAncestors = new address[](15);
-        uint32[] memory targetRoyaltyAmount = new uint32[](0);
-        address[] memory parentAncestors1 = new address[](0);
-        address[] memory parentAncestors2 = new address[](0);
-        uint32[] memory parentAncestorsRoyalties1 = new uint32[](0);
-        uint32[] memory parentAncestorsRoyalties2 = new uint32[](0);
-        InitParams memory initParams = InitParams({
-            targetAncestors: targetAncestors,
-            targetRoyaltyAmount: targetRoyaltyAmount,
-            parentAncestors1: parentAncestors1,
-            parentAncestors2: parentAncestors2,
-            parentAncestorsRoyalties1: parentAncestorsRoyalties1,
-            parentAncestorsRoyalties2: parentAncestorsRoyalties2
-        });
-        bytes memory inputBytes = abi.encode(initParams);
-
-        vm.expectRevert(Errors.RoyaltyPolicyLAP__AboveAncestorsLimit.selector);
-        royaltyPolicyLAP.onLicenseMinting(address(30), abi.encode(uint32(0)), inputBytes);
-    }
-
     function test_RoyaltyPolicyLAP_onLicenseMinting_revert_NotRoyaltyModule() public {
         vm.stopPrank();
         vm.expectRevert(Errors.RoyaltyPolicyLAP__NotRoyaltyModule.selector);
@@ -406,58 +198,8 @@ contract TestRoyaltyPolicyLAP is BaseTest {
     }
 
     function test_RoyaltyPolicyLAP_onLicenseMinting_revert_AboveRoyaltyStackLimit() public {
-        address[] memory targetAncestors = new address[](0);
-        uint32[] memory targetRoyaltyAmount = new uint32[](0);
-        address[] memory parentAncestors1 = new address[](0);
-        address[] memory parentAncestors2 = new address[](0);
-        uint32[] memory parentAncestorsRoyalties1 = new uint32[](0);
-        uint32[] memory parentAncestorsRoyalties2 = new uint32[](0);
-        InitParams memory initParams = InitParams({
-            targetAncestors: targetAncestors,
-            targetRoyaltyAmount: targetRoyaltyAmount,
-            parentAncestors1: parentAncestors1,
-            parentAncestors2: parentAncestors2,
-            parentAncestorsRoyalties1: parentAncestorsRoyalties1,
-            parentAncestorsRoyalties2: parentAncestorsRoyalties2
-        });
-        bytes memory inputBytes = abi.encode(initParams);
-
         vm.expectRevert(Errors.RoyaltyPolicyLAP__AboveRoyaltyStackLimit.selector);
-        royaltyPolicyLAP.onLicenseMinting(address(100), abi.encode(uint32(1001)), inputBytes);
-    }
-
-    function test_RoyaltyPolicyLAP_onLicenseMinting_revert_InvalidAncestors() public {
-        address[] memory targetAncestors = new address[](0);
-        uint32[] memory targetRoyaltyAmount = new uint32[](0);
-        address[] memory parentAncestors1 = new address[](0);
-        address[] memory parentAncestors2 = new address[](0);
-        uint32[] memory parentAncestorsRoyalties1 = new uint32[](0);
-        uint32[] memory parentAncestorsRoyalties2 = new uint32[](0);
-        InitParams memory initParams = InitParams({
-            targetAncestors: targetAncestors,
-            targetRoyaltyAmount: targetRoyaltyAmount,
-            parentAncestors1: parentAncestors1,
-            parentAncestors2: parentAncestors2,
-            parentAncestorsRoyalties1: parentAncestorsRoyalties1,
-            parentAncestorsRoyalties2: parentAncestorsRoyalties2
-        });
-        bytes memory inputBytes = abi.encode(initParams);
-
-        royaltyPolicyLAP.onLicenseMinting(address(100), abi.encode(uint32(0)), inputBytes);
-
-        address[] memory targetAncestors2 = new address[](2);
-        initParams = InitParams({
-            targetAncestors: targetAncestors2,
-            targetRoyaltyAmount: targetRoyaltyAmount,
-            parentAncestors1: parentAncestors1,
-            parentAncestors2: parentAncestors2,
-            parentAncestorsRoyalties1: parentAncestorsRoyalties1,
-            parentAncestorsRoyalties2: parentAncestorsRoyalties2
-        });
-        inputBytes = abi.encode(initParams);
-
-        vm.expectRevert(Errors.RoyaltyPolicyLAP__InvalidAncestorsHash.selector);
-        royaltyPolicyLAP.onLicenseMinting(address(100), abi.encode(uint32(0)), inputBytes);
+        royaltyPolicyLAP.onLicenseMinting(address(100), abi.encode(uint32(1001)), "");
     }
 
     function test_RoyaltyPolicyLAP_onLicenseMinting_revert_LastPositionNotAbleToMintLicense() public {
@@ -466,36 +208,27 @@ contract TestRoyaltyPolicyLAP is BaseTest {
             encodedLicenseData[i] = abi.encode(parentsIpIds100[i]);
         }
 
-        royaltyPolicyLAP.onLinkToParents(address(100), parentsIpIds100, encodedLicenseData, MAX_ANCESTORS);
+        royaltyPolicyLAP.onLinkToParents(address(100), parentsIpIds100, encodedLicenseData, "");
 
         vm.expectRevert(Errors.RoyaltyPolicyLAP__LastPositionNotAbleToMintLicense.selector);
-        royaltyPolicyLAP.onLicenseMinting(address(100), abi.encode(uint32(0)), MAX_ANCESTORS);
+        royaltyPolicyLAP.onLicenseMinting(address(100), abi.encode(uint32(0)), "");
     }
 
     function test_RoyaltyPolicyLAP_onLicenseMinting() public {
-        address[] memory targetAncestors = new address[](0);
-        uint32[] memory targetRoyaltyAmount = new uint32[](0);
-        address[] memory parentAncestors1 = new address[](0);
-        address[] memory parentAncestors2 = new address[](0);
-        uint32[] memory parentAncestorsRoyalties1 = new uint32[](0);
-        uint32[] memory parentAncestorsRoyalties2 = new uint32[](0);
-        InitParams memory initParams = InitParams({
-            targetAncestors: targetAncestors,
-            targetRoyaltyAmount: targetRoyaltyAmount,
-            parentAncestors1: parentAncestors1,
-            parentAncestors2: parentAncestors2,
-            parentAncestorsRoyalties1: parentAncestorsRoyalties1,
-            parentAncestorsRoyalties2: parentAncestorsRoyalties2
-        });
-        bytes memory inputBytes = abi.encode(initParams);
+        royaltyPolicyLAP.onLicenseMinting(address(100), abi.encode(uint32(0)), "");
 
-        royaltyPolicyLAP.onLicenseMinting(address(100), abi.encode(uint32(0)), inputBytes);
-
-        (, address splitClone, address ancestorsVault, uint32 royaltyStack, bytes32 ancestorsHash) = royaltyPolicyLAP
-            .royaltyData(address(100));
+        (
+            ,
+            address splitClone,
+            address ancestorsVault,
+            uint32 royaltyStack,
+            address[] memory ancestors,
+            uint32[] memory ancestorsRoyalties
+        ) = royaltyPolicyLAP.getRoyaltyData(address(100));
 
         assertEq(royaltyStack, 0);
-        assertEq(ancestorsHash, keccak256(abi.encodePacked(targetAncestors, targetRoyaltyAmount)));
+        assertEq(ancestors.length, 0);
+        assertEq(ancestorsRoyalties.length, 0);
         assertFalse(splitClone == address(0));
         assertEq(ancestorsVault, address(0));
     }
@@ -508,7 +241,22 @@ contract TestRoyaltyPolicyLAP is BaseTest {
 
         vm.stopPrank();
         vm.expectRevert(Errors.RoyaltyPolicyLAP__NotRoyaltyModule.selector);
-        royaltyPolicyLAP.onLinkToParents(address(100), parentsIpIds100, encodedLicenseData, MAX_ANCESTORS);
+        royaltyPolicyLAP.onLinkToParents(address(100), parentsIpIds100, encodedLicenseData, "");
+    }
+
+    function test_RoyaltyPolicyLAP_onLinkToParents_revert_AboveParentLimit() public {
+        bytes[] memory encodedLicenseData = new bytes[](3);
+        for (uint32 i = 0; i < 3; i++) {
+            encodedLicenseData[i] = abi.encode(1);
+        }
+
+        address[] memory excessParents = new address[](3);
+        excessParents[0] = address(1);
+        excessParents[1] = address(2);
+        excessParents[2] = address(3);
+
+        vm.expectRevert(Errors.RoyaltyPolicyLAP__AboveParentLimit.selector);
+        royaltyPolicyLAP.onLinkToParents(address(100), excessParents, encodedLicenseData, "");
     }
 
     function test_RoyaltyPolicyLAP_onLinkToParents() public {
@@ -517,13 +265,22 @@ contract TestRoyaltyPolicyLAP is BaseTest {
             encodedLicenseData[i] = abi.encode(parentsIpIds100[i]);
         }
 
-        royaltyPolicyLAP.onLinkToParents(address(100), parentsIpIds100, encodedLicenseData, MAX_ANCESTORS);
+        royaltyPolicyLAP.onLinkToParents(address(100), parentsIpIds100, encodedLicenseData, "");
 
-        (, address splitClone, address ancestorsVault, uint32 royaltyStack, bytes32 ancestorsHash) = royaltyPolicyLAP
-            .royaltyData(address(100));
+        (
+            ,
+            address splitClone,
+            address ancestorsVault,
+            uint32 royaltyStack,
+            address[] memory ancestors,
+            uint32[] memory ancestorsRoyalties
+        ) = royaltyPolicyLAP.getRoyaltyData(address(100));
 
         assertEq(royaltyStack, 105);
-        assertEq(ancestorsHash, keccak256(abi.encodePacked(MAX_ANCESTORS_, MAX_ANCESTORS_ROYALTY_)));
+        for (uint32 i = 0; i < ancestorsRoyalties.length; i++) {
+            assertEq(ancestorsRoyalties[i], MAX_ANCESTORS_ROYALTY_[i]);
+        }
+        assertEq(ancestors, MAX_ANCESTORS_);
         assertFalse(splitClone == address(0));
         assertFalse(ancestorsVault == address(0));
     }
@@ -535,7 +292,7 @@ contract TestRoyaltyPolicyLAP is BaseTest {
     }
 
     function test_RoyaltyPolicyLAP_onRoyaltyPayment() public {
-        (, address splitClone2, , , ) = royaltyPolicyLAP.royaltyData(address(2));
+        (, address splitClone2, , , , ) = royaltyPolicyLAP.getRoyaltyData(address(2));
         uint256 royaltyAmount = 1000 * 10 ** 6;
         USDC.mint(address(1), royaltyAmount);
         vm.stopPrank();
@@ -559,7 +316,7 @@ contract TestRoyaltyPolicyLAP is BaseTest {
     }
 
     function test_RoyaltyPolicyLAP_distributeIpPoolFunds() public {
-        (, address splitClone2, address ancestorsVault2, , ) = royaltyPolicyLAP.royaltyData(address(2));
+        (, address splitClone2, address ancestorsVault2, , , ) = royaltyPolicyLAP.getRoyaltyData(address(2));
 
         // send USDC to 0xSplitClone
         uint256 royaltyAmount = 1000 * 10 ** 6;
@@ -582,7 +339,7 @@ contract TestRoyaltyPolicyLAP is BaseTest {
     }
 
     function test_RoyaltyPolicyLAP_claimFromIpPool() public {
-        (, address splitClone2, address ancestorsVault2, , ) = royaltyPolicyLAP.royaltyData(address(2));
+        (, address splitClone2, address ancestorsVault2, , , ) = royaltyPolicyLAP.getRoyaltyData(address(2));
 
         // send USDC to 0xSplitClone
         uint256 royaltyAmount = 1000 * 10 ** 6;
@@ -615,7 +372,7 @@ contract TestRoyaltyPolicyLAP is BaseTest {
     }
 
     function test_RoyaltyPolicyLAP_claimAsFullRnftOwner() public {
-        (, address splitClone7, , , ) = royaltyPolicyLAP.royaltyData(address(7));
+        (, address splitClone7, , , , ) = royaltyPolicyLAP.getRoyaltyData(address(7));
 
         uint256 royaltyAmountUSDC = 100 * 10 ** 6;
         USDC.mint(address(splitClone7), royaltyAmountUSDC);


### PR DESCRIPTION
This pr:
- Removes ancestors hash from LAP royalty policy
- Removes the requirement royalty context from LAP royalty policy

The goal of the changes is to greatly improve integrability as external projects no longer need to request the SDK to obtain the royaltyContext input when setting up a royalty policy. Gas increased by around 50% as previously discussed for initPolicy. Developer experience and ease of setup are greatly improved as there is no need to retrieve and understand the previously existing royalty context data struct.