### PR TITLE
Implement Permissionless IP Registration

### DIFF
--- a/contracts/interfaces/registries/IIPAssetRegistry.sol
+++ b/contracts/interfaces/registries/IIPAssetRegistry.sol
@@ -36,6 +36,25 @@ interface IIPAssetRegistry is IIPAccountRegistry {
         bytes metadata
     );
 
+    // TODO: replace the IPRegistered event with IPRegisteredPermissionless
+    /// @notice Emits when an IP is officially registered into the protocol.
+    /// @param ipId The canonical identifier for the IP.
+    /// @param chainId The chain identifier of where the IP resides.
+    /// @param tokenContract The token contract address of the IP NFT.
+    /// @param tokenId The token identifier of the IP.
+    /// @param name The name of the IP.
+    /// @param uri The URI of the IP.
+    /// @param registrationDate The date and time the IP was registered.
+    event IPRegisteredPermissionless(
+        address ipId,
+        uint256 indexed chainId,
+        address indexed tokenContract,
+        uint256 indexed tokenId,
+        string name,
+        string uri,
+        uint256 registrationDate
+    );
+
     /// @notice Emits when an IP resolver is bound to an IP.
     /// @param ipId The canonical identifier of the specified IP.
     /// @param resolver The address of the new resolver bound to the IP.
@@ -69,6 +88,12 @@ interface IIPAssetRegistry is IIPAccountRegistry {
     /// @param operator The address of the operator the sender authorizes.
     /// @param approved Whether or not to approve that operator for registration.
     function setApprovalForAll(address operator, bool approved) external;
+
+    /// @notice Registers an NFT as an IP asset.
+    /// @param tokenContract The address of the NFT.
+    /// @param tokenId The token identifier of the NFT.
+    /// @return id The address of the newly registered IP.
+    function register(address tokenContract, uint256 tokenId) external returns (address id);
 
     /// @notice Registers an NFT as IP, creating a corresponding IP record.
     /// @param chainId The chain identifier of where the NFT resides.

--- a/contracts/lib/Errors.sol
+++ b/contracts/lib/Errors.sol
@@ -63,6 +63,15 @@ library Errors {
     /// @notice The metadata provider is not valid.
     error IPAssetRegistry__InvalidMetadataProvider();
 
+    /// @notice The NFT token contract is not valid ERC721 contract.
+    error IPAssetRegistry__UnsupportedIERC721(address contractAddress);
+
+    /// @notice The NFT token contract does not support ERC721Metadata.
+    error IPAssetRegistry__UnsupportedIERC721Metadata(address contractAddress);
+
+    /// @notice The NFT token id does not exist or invalid.
+    error IPAssetRegistry__InvalidToken(address contractAddress, uint256 tokenId);
+
     ////////////////////////////////////////////////////////////////////////////
     //                                 IPResolver                            ///
     ////////////////////////////////////////////////////////////////////////////

--- a/contracts/registries/IPAssetRegistry.sol
+++ b/contracts/registries/IPAssetRegistry.sol
@@ -2,7 +2,9 @@
 pragma solidity 0.8.23;
 
 import { IERC721 } from "@openzeppelin/contracts/token/ERC721/IERC721.sol";
+import { IERC721Metadata } from "@openzeppelin/contracts/token/ERC721/extensions/IERC721Metadata.sol";
 import { ERC165Checker } from "@openzeppelin/contracts/utils/introspection/ERC165Checker.sol";
+import { Strings } from "@openzeppelin/contracts/utils/Strings.sol";
 
 import { IIPAccount } from "../interfaces/IIPAccount.sol";
 import { IIPAssetRegistry } from "../interfaces/registries/IIPAssetRegistry.sol";
@@ -16,6 +18,7 @@ import { IModuleRegistry } from "../interfaces/registries/IModuleRegistry.sol";
 import { ILicensingModule } from "../interfaces/modules/licensing/ILicensingModule.sol";
 import { IIPAssetRegistry } from "../interfaces/registries/IIPAssetRegistry.sol";
 import { Governable } from "../governance/Governable.sol";
+import { IPAccountStorageOps } from "../lib/IPAccountStorageOps.sol";
 
 /// @title IP Asset Registry
 /// @notice This contract acts as the source of truth for all IP registered in
@@ -27,6 +30,10 @@ import { Governable } from "../governance/Governable.sol";
 ///         IMPORTANT: The IP account address, besides being used for protocol
 ///                    auth, is also the canonical IP identifier for the IP NFT.
 contract IPAssetRegistry is IIPAssetRegistry, IPAccountRegistry, Governable {
+    using ERC165Checker for address;
+    using Strings for *;
+    using IPAccountStorageOps for IIPAccount;
+
     /// @notice The canonical module registry used by the protocol.
     IModuleRegistry public immutable MODULE_REGISTRY;
 
@@ -69,6 +76,44 @@ contract IPAssetRegistry is IIPAssetRegistry, IPAccountRegistry, Governable {
         _metadataProvider.setUpgradeProvider(newMetadataProvider);
         _metadataProvider = IMetadataProviderMigratable(newMetadataProvider);
     }
+
+    /// @notice Registers an NFT as an IP asset.
+    /// @dev The IP required metadata name and URI are derived from the NFT's metadata.
+    /// @param tokenContract The address of the NFT.
+    /// @param tokenId The token identifier of the NFT.
+    /// @return id The address of the newly registered IP.
+    function register(address tokenContract, uint256 tokenId) external returns (address id) {
+        if (!tokenContract.supportsInterface(type(IERC721).interfaceId)) {
+            revert Errors.IPAssetRegistry__UnsupportedIERC721(tokenContract);
+        }
+
+        if (IERC721(tokenContract).ownerOf(tokenId) == address(0)) {
+            revert Errors.IPAssetRegistry__InvalidToken(tokenContract, tokenId);
+        }
+
+        if (!tokenContract.supportsInterface(type(IERC721Metadata).interfaceId)) {
+            revert Errors.IPAssetRegistry__UnsupportedIERC721Metadata(tokenContract);
+        }
+
+        id = registerIpAccount(block.chainid, tokenContract, tokenId);
+        IIPAccount ipAccount = IIPAccount(payable(id));
+
+        if (bytes(ipAccount.getString("NAME")).length != 0) {
+            revert Errors.IPAssetRegistry__AlreadyRegistered();
+        }
+
+        string memory name = string.concat(IERC721Metadata(tokenContract).name(), " #", tokenId.toString());
+        string memory uri = IERC721Metadata(tokenContract).tokenURI(tokenId);
+        uint256 registrationDate = block.timestamp;
+        ipAccount.setString("NAME", name);
+        ipAccount.setString("URI", uri);
+        ipAccount.setUint256("REGISTRATION_DATE", registrationDate);
+
+        totalSupply++;
+
+        emit IPRegisteredPermissionless(id, block.chainid, tokenContract, tokenId, name, uri, registrationDate);
+    }
+
 
     /// @notice Registers an NFT as IP, creating a corresponding IP record.
     /// @param chainId The chain identifier of where the NFT resides.
@@ -146,7 +191,7 @@ contract IPAssetRegistry is IIPAssetRegistry, IPAccountRegistry, Governable {
     /// @param id The canonical identifier for the IP.
     /// @return isRegistered Whether the IP was registered into the protocol.
     function isRegistered(address id) external view returns (bool) {
-        return _records[id].resolver != address(0);
+        return _records[id].resolver != address(0) || id.code.length != 0;
     }
 
     /// @notice Gets the resolver bound to an IP based on its ID.

--- a/contracts/registries/IPAssetRegistry.sol
+++ b/contracts/registries/IPAssetRegistry.sol
@@ -114,7 +114,6 @@ contract IPAssetRegistry is IIPAssetRegistry, IPAccountRegistry, Governable {
         emit IPRegisteredPermissionless(id, block.chainid, tokenContract, tokenId, name, uri, registrationDate);
     }
 
-
     /// @notice Registers an NFT as IP, creating a corresponding IP record.
     /// @param chainId The chain identifier of where the NFT resides.
     /// @param tokenContract The address of the NFT.

--- a/contracts/registries/IPAssetRegistry.sol
+++ b/contracts/registries/IPAssetRegistry.sol
@@ -102,7 +102,13 @@ contract IPAssetRegistry is IIPAssetRegistry, IPAccountRegistry, Governable {
             revert Errors.IPAssetRegistry__AlreadyRegistered();
         }
 
-        string memory name = string.concat(IERC721Metadata(tokenContract).name(), " #", tokenId.toString());
+        string memory name = string.concat(
+            block.chainid.toString(),
+            ": ",
+            IERC721Metadata(tokenContract).name(),
+            " #",
+            tokenId.toString()
+        );
         string memory uri = IERC721Metadata(tokenContract).tokenURI(tokenId);
         uint256 registrationDate = block.timestamp;
         ipAccount.setString("NAME", name);

--- a/contracts/registries/IPAssetRegistry.sol
+++ b/contracts/registries/IPAssetRegistry.sol
@@ -190,6 +190,7 @@ contract IPAssetRegistry is IIPAssetRegistry, IPAccountRegistry, Governable {
     /// @param id The canonical identifier for the IP.
     /// @return isRegistered Whether the IP was registered into the protocol.
     function isRegistered(address id) external view returns (bool) {
+        // TODO: also check the ipAccount has "Name" metadata after clean up permissioned functions.
         return _records[id].resolver != address(0) || id.code.length != 0;
     }
 

--- a/contracts/utils/ShortStringOps.sol
+++ b/contracts/utils/ShortStringOps.sol
@@ -2,10 +2,12 @@
 pragma solidity 0.8.23;
 
 import { ShortString, ShortStrings } from "@openzeppelin/contracts/utils/ShortStrings.sol";
+import { Strings } from "@openzeppelin/contracts/utils/Strings.sol";
 
 /// @notice Library for working with Openzeppelin's ShortString data types.
 library ShortStringOps {
     using ShortStrings for *;
+    using Strings for *;
 
     /// @dev Compares whether two ShortStrings are equal.
     function equal(ShortString a, ShortString b) internal pure returns (bool) {
@@ -43,5 +45,9 @@ library ShortStringOps {
 
     function bytes32ToString(bytes32 b) internal pure returns (string memory) {
         return ShortString.wrap(b).toString();
+    }
+
+    function toShortString(uint256 value) internal pure returns (ShortString) {
+        return value.toString().toShortString();
     }
 }

--- a/test/foundry/mocks/token/MockERC721WithoutMetadata.sol
+++ b/test/foundry/mocks/token/MockERC721WithoutMetadata.sol
@@ -4,7 +4,7 @@ pragma solidity 0.8.23;
 import { IERC721, IERC165 } from "@openzeppelin/contracts/token/ERC721/IERC721.sol";
 
 contract MockERC721WithoutMetadata is IERC721 {
-    mapping (uint256 => address) private _owners;
+    mapping(uint256 => address) private _owners;
 
     function mint(address to, uint256 tokenId) external {
         _owners[tokenId] = to;

--- a/test/foundry/mocks/token/MockERC721WithoutMetadata.sol
+++ b/test/foundry/mocks/token/MockERC721WithoutMetadata.sol
@@ -1,0 +1,43 @@
+// SPDX-License-Identifier: BUSDL-1.1
+pragma solidity 0.8.23;
+
+import { IERC721, IERC165 } from "@openzeppelin/contracts/token/ERC721/IERC721.sol";
+
+contract MockERC721WithoutMetadata is IERC721 {
+    mapping (uint256 => address) private _owners;
+
+    function mint(address to, uint256 tokenId) external {
+        _owners[tokenId] = to;
+    }
+
+    function balanceOf(address owner) external view returns (uint256 balance) {
+        revert("MockERC721WithoutMetadata: not implemented");
+    }
+    function ownerOf(uint256 tokenId) external view returns (address owner) {
+        return _owners[tokenId];
+    }
+    function safeTransferFrom(address from, address to, uint256 tokenId, bytes calldata data) external {
+        revert("MockERC721WithoutMetadata: not implemented");
+    }
+    function safeTransferFrom(address from, address to, uint256 tokenId) external {
+        revert("MockERC721WithoutMetadata: not implemented");
+    }
+    function transferFrom(address from, address to, uint256 tokenId) external {
+        revert("MockERC721WithoutMetadata: not implemented");
+    }
+    function approve(address to, uint256 tokenId) external {
+        revert("MockERC721WithoutMetadata: not implemented");
+    }
+    function setApprovalForAll(address operator, bool approved) external {
+        revert("MockERC721WithoutMetadata: not implemented");
+    }
+    function getApproved(uint256 tokenId) external view returns (address operator) {
+        revert("MockERC721WithoutMetadata: not implemented");
+    }
+    function isApprovedForAll(address owner, address operator) external view returns (bool) {
+        revert("MockERC721WithoutMetadata: not implemented");
+    }
+    function supportsInterface(bytes4 interfaceId) public view virtual returns (bool) {
+        return interfaceId == type(IERC165).interfaceId || interfaceId == type(IERC721).interfaceId;
+    }
+}

--- a/test/foundry/registries/IPAssetRegistry.t.sol
+++ b/test/foundry/registries/IPAssetRegistry.t.sol
@@ -10,6 +10,7 @@ import { Errors } from "contracts/lib/Errors.sol";
 import { IIPAccount } from "contracts/interfaces/IIPAccount.sol";
 import { IPAccountStorageOps } from "contracts/lib/IPAccountStorageOps.sol";
 import { ShortStrings } from "@openzeppelin/contracts/utils/ShortStrings.sol";
+import { Strings } from "@openzeppelin/contracts/utils/Strings.sol";
 import { MockERC721WithoutMetadata } from "test/foundry/mocks/token/MockERC721WithoutMetadata.sol";
 
 import { BaseTest } from "../utils/BaseTest.t.sol";
@@ -19,6 +20,7 @@ import { BaseTest } from "../utils/BaseTest.t.sol";
 contract IPAssetRegistryTest is BaseTest {
     using IPAccountStorageOps for IIPAccount;
     using ShortStrings for *;
+    using Strings for *;
     // Default IP record attributes.
     string public constant IP_NAME = "IPAsset";
     string public constant IP_DESCRIPTION = "IPs all the way down.";
@@ -76,14 +78,14 @@ contract IPAssetRegistryTest is BaseTest {
 
         assertTrue(!registry.isRegistered(ipId));
         assertTrue(!IPAccountChecker.isRegistered(ipAccountRegistry, block.chainid, tokenAddress, tokenId));
-
+        string memory name = string.concat(block.chainid.toString(), ": Ape #99");
         vm.expectEmit(true, true, true, true);
         emit IIPAssetRegistry.IPRegisteredPermissionless(
             ipId,
             block.chainid,
             tokenAddress,
             tokenId,
-            "Ape #99",
+            name,
             "https://storyprotocol.xyz/erc721/99",
             block.timestamp
         );
@@ -92,7 +94,7 @@ contract IPAssetRegistryTest is BaseTest {
 
         assertEq(totalSupply + 1, registry.totalSupply());
         assertTrue(IPAccountChecker.isRegistered(ipAccountRegistry, block.chainid, tokenAddress, tokenId));
-        assertEq(IIPAccount(payable(ipId)).getString(address(registry), "NAME"), "Ape #99");
+        assertEq(IIPAccount(payable(ipId)).getString(address(registry), "NAME"), name);
         assertEq(IIPAccount(payable(ipId)).getString(address(registry), "URI"), "https://storyprotocol.xyz/erc721/99");
         assertEq(IIPAccount(payable(ipId)).getUint256(address(registry), "REGISTRATION_DATE"), block.timestamp);
     }
@@ -102,14 +104,14 @@ contract IPAssetRegistryTest is BaseTest {
         uint256 totalSupply = registry.totalSupply();
 
         IIPAccountRegistry(registry).registerIpAccount(block.chainid, tokenAddress, tokenId);
-
+        string memory name = string.concat(block.chainid.toString(), ": Ape #99");
         vm.expectEmit(true, true, true, true);
         emit IIPAssetRegistry.IPRegisteredPermissionless(
             ipId,
             block.chainid,
             tokenAddress,
             tokenId,
-            "Ape #99",
+            name,
             "https://storyprotocol.xyz/erc721/99",
             block.timestamp
         );
@@ -118,7 +120,7 @@ contract IPAssetRegistryTest is BaseTest {
 
         assertEq(totalSupply + 1, registry.totalSupply());
         assertTrue(IPAccountChecker.isRegistered(ipAccountRegistry, block.chainid, tokenAddress, tokenId));
-        assertEq(IIPAccount(payable(ipId)).getString(address(registry), "NAME"), "Ape #99");
+        assertEq(IIPAccount(payable(ipId)).getString(address(registry), "NAME"), name);
         assertEq(IIPAccount(payable(ipId)).getString(address(registry), "URI"), "https://storyprotocol.xyz/erc721/99");
         assertEq(IIPAccount(payable(ipId)).getUint256(address(registry), "REGISTRATION_DATE"), block.timestamp);
     }

--- a/test/foundry/registries/IPAssetRegistry.t.sol
+++ b/test/foundry/registries/IPAssetRegistry.t.sol
@@ -5,13 +5,20 @@ import { IIPAssetRegistry } from "contracts/interfaces/registries/IIPAssetRegist
 import { IPAccountChecker } from "contracts/lib/registries/IPAccountChecker.sol";
 import { IP } from "contracts/lib/IP.sol";
 import { IPAssetRegistry } from "contracts/registries/IPAssetRegistry.sol";
+import { IIPAccountRegistry } from "contracts/interfaces/registries/IIPAccountRegistry.sol";
 import { Errors } from "contracts/lib/Errors.sol";
+import { IIPAccount } from "contracts/interfaces/IIPAccount.sol";
+import { IPAccountStorageOps } from "contracts/lib/IPAccountStorageOps.sol";
+import { ShortStrings } from "@openzeppelin/contracts/utils/ShortStrings.sol";
+import { MockERC721WithoutMetadata } from "test/foundry/mocks/token/MockERC721WithoutMetadata.sol";
 
 import { BaseTest } from "../utils/BaseTest.t.sol";
 
 /// @title IP Asset Registry Testing Contract
 /// @notice Contract for testing core IP registration.
 contract IPAssetRegistryTest is BaseTest {
+    using IPAccountStorageOps for IIPAccount;
+    using ShortStrings for *;
     // Default IP record attributes.
     string public constant IP_NAME = "IPAsset";
     string public constant IP_DESCRIPTION = "IPs all the way down.";
@@ -61,6 +68,98 @@ contract IPAssetRegistryTest is BaseTest {
         bytes memory metadata = _generateMetadata();
         vm.prank(bob);
         registry.register(block.chainid, tokenAddress, tokenId, resolver, true, metadata);
+    }
+
+    /// @notice Tests registration of IP permissionlessly.
+    function test_IPAssetRegistry_RegisterPermissionless() public {
+        uint256 totalSupply = registry.totalSupply();
+
+        assertTrue(!registry.isRegistered(ipId));
+        assertTrue(!IPAccountChecker.isRegistered(ipAccountRegistry, block.chainid, tokenAddress, tokenId));
+
+        vm.expectEmit(true, true, true, true);
+        emit IIPAssetRegistry.IPRegisteredPermissionless(
+            ipId,
+            block.chainid,
+            tokenAddress,
+            tokenId,
+            "Ape #99",
+            "https://storyprotocol.xyz/erc721/99",
+            block.timestamp
+        );
+        vm.prank(alice);
+        registry.register(tokenAddress, tokenId);
+
+        assertEq(totalSupply + 1, registry.totalSupply());
+        assertTrue(IPAccountChecker.isRegistered(ipAccountRegistry, block.chainid, tokenAddress, tokenId));
+        assertEq(IIPAccount(payable(ipId)).getString(address(registry), "NAME"), "Ape #99");
+        assertEq(IIPAccount(payable(ipId)).getString(address(registry), "URI"), "https://storyprotocol.xyz/erc721/99");
+        assertEq(IIPAccount(payable(ipId)).getUint256(address(registry), "REGISTRATION_DATE"), block.timestamp);
+    }
+
+    /// @notice Tests registration of IP permissionlessly for IPAccount already created.
+    function test_IPAssetRegistry_RegisterPermissionless_IPAccountAlreadyExist() public {
+        uint256 totalSupply = registry.totalSupply();
+
+        IIPAccountRegistry(registry).registerIpAccount(block.chainid, tokenAddress, tokenId);
+
+        vm.expectEmit(true, true, true, true);
+        emit IIPAssetRegistry.IPRegisteredPermissionless(
+            ipId,
+            block.chainid,
+            tokenAddress,
+            tokenId,
+            "Ape #99",
+            "https://storyprotocol.xyz/erc721/99",
+            block.timestamp
+        );
+        vm.prank(alice);
+        registry.register(tokenAddress, tokenId);
+
+        assertEq(totalSupply + 1, registry.totalSupply());
+        assertTrue(IPAccountChecker.isRegistered(ipAccountRegistry, block.chainid, tokenAddress, tokenId));
+        assertEq(IIPAccount(payable(ipId)).getString(address(registry), "NAME"), "Ape #99");
+        assertEq(IIPAccount(payable(ipId)).getString(address(registry), "URI"), "https://storyprotocol.xyz/erc721/99");
+        assertEq(IIPAccount(payable(ipId)).getUint256(address(registry), "REGISTRATION_DATE"), block.timestamp);
+    }
+
+    /// @notice Tests registration of the same IP twice.
+    function test_IPAssetRegistry_revert_RegisterPermissionlessTwice() public {
+        assertTrue(!registry.isRegistered(ipId));
+        assertTrue(!IPAccountChecker.isRegistered(ipAccountRegistry, block.chainid, tokenAddress, tokenId));
+
+        vm.prank(alice);
+        registry.register(tokenAddress, tokenId);
+
+        vm.expectRevert(Errors.IPAssetRegistry__AlreadyRegistered.selector);
+        vm.prank(alice);
+        registry.register(tokenAddress, tokenId);
+    }
+
+    /// @notice Tests registration of IP with non ERC721 token.
+    function test_IPAssetRegistry_revert_InvalidTokenContract() public {
+        // not an ERC721 contract
+        vm.expectRevert(abi.encodeWithSelector(Errors.IPAssetRegistry__UnsupportedIERC721.selector, address(0x12345)));
+        registry.register(address(0x12345), 1);
+
+        // not implemented ERC721Metadata contract
+        MockERC721WithoutMetadata erc721WithoutMetadata = new MockERC721WithoutMetadata();
+        erc721WithoutMetadata.mint(alice, 1);
+        vm.expectRevert(
+            abi.encodeWithSelector(Errors.IPAssetRegistry__UnsupportedIERC721Metadata.selector, erc721WithoutMetadata)
+        );
+        registry.register(address(erc721WithoutMetadata), 1);
+    }
+
+    /// @notice Tests registration of IP with non-exist NFT.
+    function test_IPAssetRegistry_revert_InvalidNFTToken() public {
+        MockERC721WithoutMetadata erc721WithoutMetadata = new MockERC721WithoutMetadata();
+        erc721WithoutMetadata.mint(alice, 1);
+        // non exist token id
+        vm.expectRevert(
+            abi.encodeWithSelector(Errors.IPAssetRegistry__InvalidToken.selector, erc721WithoutMetadata, 999)
+        );
+        registry.register(address(erc721WithoutMetadata), 999);
     }
 
     /// @notice Tests registration of IP assets without licenses.
@@ -223,5 +322,9 @@ contract IPAssetRegistryTest is BaseTest {
                     uri: IP_EXTERNAL_URL
                 })
             );
+    }
+
+    function _toBytes32(address a) internal pure returns (bytes32) {
+        return bytes32(uint256(uint160(a)));
     }
 }


### PR DESCRIPTION
This PR introduces an enhancement to the IP registration process within the Story Protocol by implementing permissionless IP registration. With this update, the IPAssetRegistry now automatically retrieves the required metadata ("name" and "tokenURI") from the IP NFT, eliminating the need for registrants or callers to provide this metadata manually. 
It allows anyone can register IP for any NFT permissionlessly.

Additionally, IPAccounts are deployed automatically during the IP registration process, with metadata being stored directly into the IPAccount. This simplification not only streamlines the registration process but also reduces the gas costs on-board IPs into the Story Protocol. 

It's important to note that while this PR enables permissionless IP registration, it does not remove the existing permissioned IP registration-related functions. The cleanup of these functions will be handled in the next PR.

### Key Changes
1. **Automatic Metadata Retrieval:** The IPAssetRegistry now automatically fetches "name" and "tokenURI" from the IP NFT during registration.
2. **Automatic IPAccount Deployment:** IPAccounts are now automatically deployed during the IP registration process, with the fetched metadata being stored directly.
3. **Simplified Registration Process:** The updates simplify the IP registration process, making it more accessible and reducing gas costs.
4. **100% Test Coverage:** Ensured that all new code paths introduced by PR are fully covered by tests.