### PR TITLE
Remove oz storage checks from GHA

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -53,7 +53,6 @@ jobs:
         run: |
           forge --version
           forge build --force --sizes --skip test --skip script
-          forge build
         id: build
 
       - name: Run Forge tests
@@ -63,9 +62,6 @@ jobs:
 
       - name: Run solhint
         run: npx solhint contracts/**/*.sol
-
-      - name: Run solhint
-        run: npx solhint contracts/*.sol
 
       # - name: Gas Difference
       #   run:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -52,7 +52,6 @@ jobs:
       - name: Run Forge build
         run: |
           forge --version
-          forge install OpenZeppelin/openzeppelin-foundry-upgrades --no-git
           forge build --force --sizes --skip test --skip script
           forge build
         id: build

--- a/script/foundry/deployment/Main.s.sol
+++ b/script/foundry/deployment/Main.s.sol
@@ -7,7 +7,9 @@ import { ERC20 } from "@openzeppelin/contracts/token/ERC20/ERC20.sol";
 import { console2 } from "forge-std/console2.sol";
 import { Script } from "forge-std/Script.sol";
 import { stdJson } from "forge-std/StdJson.sol";
-import { Upgrades } from "openzeppelin-foundry-upgrades/Upgrades.sol";
+// TODO: fix the install of this plugin for safer deployments
+// import { Upgrades } from "openzeppelin-foundry-upgrades/Upgrades.sol";
+import { TestProxyHelper } from "test/foundry/utils/TestProxyHelper.sol";
 
 // contracts
 import { AccessController } from "contracts/AccessController.sol";
@@ -205,9 +207,10 @@ contract Main is Script, BroadcastManager, JsonDeploymentHandler {
 
         contractKey = "LicenseRegistry";
         _predeploy(contractKey);
+        address impl = address(new LicenseRegistry());
         licenseRegistry = LicenseRegistry(
-            Upgrades.deployUUPSProxy(
-                "LicenseRegistry.sol",
+            TestProxyHelper.deployUUPSProxy(
+                impl,
                 abi.encodeCall(
                     LicenseRegistry.initialize, (
                         address(governance),

--- a/test/foundry/mocks/registry/MockLicenseRegistryV2.sol
+++ b/test/foundry/mocks/registry/MockLicenseRegistryV2.sol
@@ -2,9 +2,6 @@
 pragma solidity 0.8.23;
 
 import { LicenseRegistry } from "contracts/registries/LicenseRegistry.sol";
-import { ILicensingModule } from "contracts/interfaces/modules/licensing/ILicensingModule.sol";
-import { IDisputeModule } from "contracts/interfaces/modules/dispute/IDisputeModule.sol";
-import { Licensing } from "contracts/lib/Licensing.sol";
 
 /// @custom:oz-upgrades-from LicenseRegistry
 contract MockLicenseRegistryV2 is LicenseRegistry {

--- a/test/foundry/mocks/registry/MockLicenseRegistryV2.sol
+++ b/test/foundry/mocks/registry/MockLicenseRegistryV2.sol
@@ -8,7 +8,6 @@ import { Licensing } from "contracts/lib/Licensing.sol";
 
 /// @custom:oz-upgrades-from LicenseRegistry
 contract MockLicenseRegistryV2 is LicenseRegistry {
-
     // New storage
     /// @custom:storage-location erc7201:story-protocol.MockLicenseRegistryV2
     struct MockLicenseRegistryV2Storage {
@@ -16,7 +15,8 @@ contract MockLicenseRegistryV2 is LicenseRegistry {
     }
 
     // keccak256(abi.encode(uint256(keccak256("story-protocol.MockLicenseRegistryV2")) - 1)) & ~bytes32(uint256(0xff));
-    bytes32 private constant MockLicenseRegistryV2StorageLocation = 0x6e5bb326ebeeee96c5ce55286f71e5aa42dda8a70ba2a20389e489f13b57b300;
+    bytes32 private constant MockLicenseRegistryV2StorageLocation =
+        0x6e5bb326ebeeee96c5ce55286f71e5aa42dda8a70ba2a20389e489f13b57b300;
 
     function setFoo(string memory _foo) external {
         _getMockLicenseRegistryV2Storage().foo = _foo;
@@ -32,5 +32,4 @@ contract MockLicenseRegistryV2 is LicenseRegistry {
             $.slot := MockLicenseRegistryV2StorageLocation
         }
     }
-
 }

--- a/test/foundry/utils/DeployHelper.t.sol
+++ b/test/foundry/utils/DeployHelper.t.sol
@@ -5,7 +5,6 @@ pragma solidity 0.8.23;
 // external
 import { console2 } from "forge-std/console2.sol"; // console to indicate mock deployment calls.
 import { ERC6551Registry } from "erc6551/ERC6551Registry.sol";
-import { TestProxyHelper } from "./TestProxyHelper.sol";
 
 // contracts
 import { AccessController } from "../../../contracts/AccessController.sol";
@@ -43,6 +42,8 @@ import { MockLicenseRegistry } from "../mocks/registry/MockLicenseRegistry.sol";
 import { MockModuleRegistry } from "../mocks/registry/MockModuleRegistry.sol";
 import { MockERC20 } from "../mocks/token/MockERC20.sol";
 import { MockERC721 } from "../mocks/token/MockERC721.sol";
+import { TestProxyHelper } from "./TestProxyHelper.sol";
+
 
 contract DeployHelper {
     // TODO: three options, auto/mock/real in deploy condition, so that we don't need to manually

--- a/test/foundry/utils/DeployHelper.t.sol
+++ b/test/foundry/utils/DeployHelper.t.sol
@@ -257,12 +257,7 @@ contract DeployHelper {
             licenseRegistry = LicenseRegistry(
                 TestProxyHelper.deployUUPSProxy(
                     newIml,
-                    abi.encodeCall(
-                        LicenseRegistry.initialize, (
-                            address(getGovernance()),
-                            "deploy helper"
-                        )
-                    )
+                    abi.encodeCall(LicenseRegistry.initialize, (address(getGovernance()), "deploy helper"))
                 )
             );
             console2.log("DeployHelper: Using REAL LicenseRegistry");

--- a/test/foundry/utils/TestProxyHelper.sol
+++ b/test/foundry/utils/TestProxyHelper.sol
@@ -3,7 +3,6 @@ pragma solidity ^0.8.19;
 import { ERC1967Proxy } from "@openzeppelin/contracts/proxy/ERC1967/ERC1967Proxy.sol";
 
 library TestProxyHelper {
-
     /// Deploys a new UUPS proxy with the provided implementation and data
     /// @dev WARNING: DO NOT USE IN PRODUCTION, this doesn't check for storage layout compatibility
     /// @param impl address of the implementation contract

--- a/test/foundry/utils/TestProxyHelper.sol
+++ b/test/foundry/utils/TestProxyHelper.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-pragma solidity ^0.8.19;
+pragma solidity ^0.8.23;
 import { ERC1967Proxy } from "@openzeppelin/contracts/proxy/ERC1967/ERC1967Proxy.sol";
 
 library TestProxyHelper {


### PR DESCRIPTION
Temporarily remove OZ upgrades foundry lib install from GHA workflow.