### PR TITLE
Added storage layout safety check on deployment and GHA

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -47,6 +47,11 @@ jobs:
         run: |
           forge --version
           forge build --force --sizes --skip test --skip script
+      
+      - name: Upgrade Safety test
+        run: |
+          forge install OpenZeppelin/openzeppelin-foundry-upgrades --no-git
+          npx @openzeppelin/upgrades-core validate out/build-info
 
       - name: Run Forge tests
         run: |

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -50,7 +50,6 @@ jobs:
       
       - name: Upgrade Safety test
         run: |
-          forge install OpenZeppelin/openzeppelin-foundry-upgrades --no-git
           npx @openzeppelin/upgrades-core validate out/build-info
 
       - name: Run Forge tests

--- a/.gitignore
+++ b/.gitignore
@@ -33,5 +33,3 @@ typechain
 # converage
 lcov.info
 
-# forge lib folder
-/lib/

--- a/remappings.txt
+++ b/remappings.txt
@@ -1,5 +1,6 @@
 @ethereum-waffle/=node_modules/@ethereum-waffle/
 @openzeppelin/=node_modules/@openzeppelin/
+@openzeppelin-foundry-upgrades/=lib/openzeppelin-foundry-upgrades
 forge-std/=node_modules/forge-std/src/
 ds-test/=node_modules/ds-test/src/
 base64-sol/=node_modules/base64-sol/

--- a/script/foundry/deployment/Main.s.sol
+++ b/script/foundry/deployment/Main.s.sol
@@ -47,13 +47,14 @@ import { IHookModule } from "contracts/interfaces/modules/base/IHookModule.sol";
 import { StringUtil } from "../../../script/foundry/utils/StringUtil.sol";
 import { BroadcastManager } from "../../../script/foundry/utils/BroadcastManager.s.sol";
 import { JsonDeploymentHandler } from "../../../script/foundry/utils/JsonDeploymentHandler.s.sol";
+import { StorageLayoutChecker } from "../../../script/foundry/utils/upgrades/StorageLayoutCheck.s.sol";
 
 // test
 import { MockERC20 } from "test/foundry/mocks/token/MockERC20.sol";
 import { MockERC721 } from "test/foundry/mocks/token/MockERC721.sol";
 import { MockTokenGatedHook } from "test/foundry/mocks/MockTokenGatedHook.sol";
 
-contract Main is Script, BroadcastManager, JsonDeploymentHandler {
+contract Main is Script, BroadcastManager, JsonDeploymentHandler, StorageLayoutChecker {
     using StringUtil for uint256;
     using stdJson for string;
 
@@ -112,7 +113,9 @@ contract Main is Script, BroadcastManager, JsonDeploymentHandler {
     /// @dev To use, run the following command (e.g. for Sepolia):
     /// forge script script/foundry/deployment/Main.s.sol:Main --rpc-url $RPC_URL --broadcast --verify -vvvv
 
-    function run() public {
+    function run() virtual override public {
+        // This will run OZ storage layout check for all contracts. Requires --ffi flag.
+        super.run(); 
         _beginBroadcast(); // BroadcastManager.s.sol
 
         bool configByMultisig = vm.envBool("DEPLOYMENT_CONFIG_BY_MULTISIG");

--- a/script/foundry/utils/StringUtil.sol
+++ b/script/foundry/utils/StringUtil.sol
@@ -22,4 +22,8 @@ library StringUtil {
         }
         return string(buffer);
     }
+
+    function concat(string memory a, string memory b) internal pure returns (string memory) {
+        return string(abi.encodePacked(a, b));
+    }
 }

--- a/script/foundry/utils/upgrades/StorageLayoutCheck.s.sol
+++ b/script/foundry/utils/upgrades/StorageLayoutCheck.s.sol
@@ -4,7 +4,9 @@ pragma solidity ^0.8.23;
 import { Script } from "forge-std/Script.sol";
 import { Vm } from "forge-std/Vm.sol";
 import { console } from "forge-std/console.sol";
+import { strings } from "solidity-stringutils/src/strings.sol";
 
+import { Utils } from "@openzeppelin-foundry-upgrades/src/internal/Utils.sol";
 import { StringUtil } from "../StringUtil.sol";
 
 /// @title StorageLayoutChecker
@@ -15,7 +17,10 @@ import { StringUtil } from "../StringUtil.sol";
 /// MUST be called in scripts that deploy or upgrade contracts
 /// MUST be called with `--ffi` flag
 contract StorageLayoutChecker is Script {
-    function run() public {
+
+    using strings for *;
+
+    function run() virtual public {
         _validate();
     }
 
@@ -24,7 +29,7 @@ contract StorageLayoutChecker is Script {
     /// instead of going 1 by 1 using ffi.
     function _validate() private {
         string[] memory inputs = _buildValidateCommand();
-        Vm.FfiResult memory result = _runAsBashCommand(inputs);
+        Vm.FfiResult memory result = Utils.runAsBashCommand(inputs);
         string memory stdout = string(result.stdout);
 
         // CLI validate command uses exit code to indicate if the validation passed or failed.
@@ -40,44 +45,6 @@ contract StorageLayoutChecker is Script {
         }
     }
 
-    /**
-     * @dev Runs an arbitrary command using bash.
-     * @param inputs Inputs for a command, e.g. ["grep", "-rl", "0x1234", "out/build-info"]
-     * @return The result of the corresponding bash command as a Vm.FfiResult struct
-     */
-    function _runAsBashCommand(string[] memory inputs) internal returns (Vm.FfiResult memory) {
-        string[] memory bashCommand = _toBashCommand(inputs, "bash");
-        Vm.FfiResult memory result = vm.tryFfi(bashCommand);
-        if (result.exitCode != 0 && result.stdout.length == 0 && result.stderr.length == 0) {
-            // On Windows, using the bash executable from WSL leads to a non-zero exit code and no output
-            revert(StringUtil.concat('Failed to run bash command with "', bashCommand[0]));
-        } else {
-            return result;
-        }
-    }
-
-    /**
-     * @dev Converts an array of inputs to a bash command.
-     * @param inputs Inputs for a command, e.g. ["grep", "-rl", "0x1234", "out/build-info"]
-     * @param bashPath Path to the bash executable or just "bash" if it is in the PATH
-     * @return A bash command that runs the given inputs, e.g. ["bash", "-c", "grep -rl 0x1234 out/build-info"]
-     */
-    function _toBashCommand(string[] memory inputs, string memory bashPath) internal pure returns (string[] memory) {
-        string memory commandString;
-        for (uint i = 0; i < inputs.length; i++) {
-            commandString = string.concat(commandString, inputs[i]);
-            if (i != inputs.length - 1) {
-                commandString = string.concat(commandString, " ");
-            }
-        }
-
-        string[] memory result = new string[](3);
-        result[0] = bashPath;
-        result[1] = "-c";
-        result[2] = commandString;
-        return result;
-    }
-
     function _buildValidateCommand() private view returns (string[] memory) {
         string memory outDir = "out";
 
@@ -89,8 +56,6 @@ contract StorageLayoutChecker is Script {
         inputBuilder[i++] = string.concat("@openzeppelin/upgrades-core");
         inputBuilder[i++] = "validate";
         inputBuilder[i++] = string.concat(outDir, "/build-info");
-
-        inputBuilder[i++] = "--requireReference";
 
         // Create a copy of inputs but with the correct length
         string[] memory inputs = new string[](i);

--- a/script/foundry/utils/upgrades/StorageLayoutCheck.s.sol
+++ b/script/foundry/utils/upgrades/StorageLayoutCheck.s.sol
@@ -1,0 +1,103 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.23;
+
+import { Script } from "forge-std/Script.sol";
+import { Vm } from "forge-std/Vm.sol";
+import { console } from "forge-std/console.sol";
+
+import { StringUtil } from "../StringUtil.sol";
+
+/// @title StorageLayoutChecker
+/// @notice Helper contract to check if the storage layout of the contracts is compatible with upgrades
+/// @dev Picked relevant functionality from OpenZeppelin's `@openzeppelin/upgrades-core` package.
+/// NOTE: Replace this contract for their library, if these issues are resolved
+
+/// MUST be called in scripts that deploy or upgrade contracts
+/// MUST be called with `--ffi` flag
+contract StorageLayoutChecker is Script {
+    function run() public {
+        _validate();
+    }
+
+    /// @notice Runs the storage layout check
+    /// @dev For simplicity and efficiency, we check all the upgradeablecontracts in the project
+    /// instead of going 1 by 1 using ffi.
+    function _validate() private {
+        string[] memory inputs = _buildValidateCommand();
+        Vm.FfiResult memory result = _runAsBashCommand(inputs);
+        string memory stdout = string(result.stdout);
+
+        // CLI validate command uses exit code to indicate if the validation passed or failed.
+        // As an extra precaution, we also check stdout for "SUCCESS" to ensure it actually ran.
+        if (result.exitCode == 0 && stdout.toSlice().contains("SUCCESS".toSlice())) {
+            return;
+        } else if (result.stderr.length > 0) {
+            // Validations failed to run
+            revert(StringUtil.concat("Failed to run upgrade safety validation: ", string(result.stderr)));
+        } else {
+            // Validations ran but some contracts were not upgrade safe
+            revert(StringUtil.concat("Upgrade safety validation failed:\n", stdout));
+        }
+    }
+
+    /**
+     * @dev Runs an arbitrary command using bash.
+     * @param inputs Inputs for a command, e.g. ["grep", "-rl", "0x1234", "out/build-info"]
+     * @return The result of the corresponding bash command as a Vm.FfiResult struct
+     */
+    function _runAsBashCommand(string[] memory inputs) internal returns (Vm.FfiResult memory) {
+        string[] memory bashCommand = _toBashCommand(inputs, "bash");
+        Vm.FfiResult memory result = vm.tryFfi(bashCommand);
+        if (result.exitCode != 0 && result.stdout.length == 0 && result.stderr.length == 0) {
+            // On Windows, using the bash executable from WSL leads to a non-zero exit code and no output
+            revert(StringUtil.concat('Failed to run bash command with "', bashCommand[0]));
+        } else {
+            return result;
+        }
+    }
+
+    /**
+     * @dev Converts an array of inputs to a bash command.
+     * @param inputs Inputs for a command, e.g. ["grep", "-rl", "0x1234", "out/build-info"]
+     * @param bashPath Path to the bash executable or just "bash" if it is in the PATH
+     * @return A bash command that runs the given inputs, e.g. ["bash", "-c", "grep -rl 0x1234 out/build-info"]
+     */
+    function _toBashCommand(string[] memory inputs, string memory bashPath) internal pure returns (string[] memory) {
+        string memory commandString;
+        for (uint i = 0; i < inputs.length; i++) {
+            commandString = string.concat(commandString, inputs[i]);
+            if (i != inputs.length - 1) {
+                commandString = string.concat(commandString, " ");
+            }
+        }
+
+        string[] memory result = new string[](3);
+        result[0] = bashPath;
+        result[1] = "-c";
+        result[2] = commandString;
+        return result;
+    }
+
+    function _buildValidateCommand() private view returns (string[] memory) {
+        string memory outDir = "out";
+
+        string[] memory inputBuilder = new string[](255);
+
+        uint8 i = 0;
+        // npx @openzeppelin/upgrades-core validate <build-info-dir> --requireReference
+        inputBuilder[i++] = "npx";
+        inputBuilder[i++] = string.concat("@openzeppelin/upgrades-core");
+        inputBuilder[i++] = "validate";
+        inputBuilder[i++] = string.concat(outDir, "/build-info");
+
+        inputBuilder[i++] = "--requireReference";
+
+        // Create a copy of inputs but with the correct length
+        string[] memory inputs = new string[](i);
+        for (uint8 j = 0; j < i; j++) {
+            inputs[j] = inputBuilder[j];
+        }
+
+        return inputs;
+    }
+}


### PR DESCRIPTION
Instead of using the OZ Foundry plugin `deployProxy` methods, which check for layout safety but are slow and require us to use only clean builds and `--ffi` on tests, we are going to use a different strategy:

- Create a base contract for foundry scripts (`StorageLayoutChecker.sol`) that runs the OZ cli first thing on `run`, failing if layouts are not safe.
- Run the OZ cli check in GHA test workflow