### PR TITLE
Prevent Child IP from Linking to More Parent IPs More than Once

### DIFF
--- a/contracts/lib/Errors.sol
+++ b/contracts/lib/Errors.sol
@@ -133,6 +133,7 @@ library Errors {
     //                            LicensingModule                             //
     ////////////////////////////////////////////////////////////////////////////
 
+    error LicensingModule__IpAlreadyLinked();
     error LicensingModule__PolicyAlreadySetForIpId();
     error LicensingModule__FrameworkNotFound();
     error LicensingModule__EmptyLicenseUrl();

--- a/contracts/modules/licensing/LicensingModule.sol
+++ b/contracts/modules/licensing/LicensingModule.sol
@@ -284,6 +284,11 @@ contract LicensingModule is
         address childIpId,
         bytes calldata royaltyContext
     ) external nonReentrant verifyPermission(childIpId) {
+        LicensingModuleStorage storage $ = _getLicensingModuleStorage();
+        if ($.ipIdParents[childIpId].length() > 0) {
+            revert Errors.LicensingModule__IpAlreadyLinked();
+        }
+
         _verifyIpNotDisputed(childIpId);
         address holder = IIPAccount(payable(childIpId)).owner();
         address[] memory licensors = new address[](licenseIds.length);


### PR DESCRIPTION
This PR ensures that a child IP cannot link to more parent IPs again. Added validation logic in the IP linking function to check if the child IP is already associated with a parent IP. If so, the operation is aborted, and an error message is returned.