### PR TITLE
Dispute effects on royalty

### DIFF
--- a/contracts/interfaces/modules/royalty/IRoyaltyModule.sol
+++ b/contracts/interfaces/modules/royalty/IRoyaltyModule.sol
@@ -30,11 +30,15 @@ interface IRoyaltyModule is IModule {
     /// @param amount The amount paid
     event LicenseMintingFeePaid(address receiverIpId, address payerAddress, address token, uint256 amount);
 
-    /// @notice Sets the license registry
+    /// @notice Sets the licensing module
     /// @dev Enforced to be only callable by the protocol admin
-    /// @param licensing The address of the license registry
+    /// @param licensing The address of the license module
+    function setLicensingModule(address licensing) external;
+
+    /// @notice Sets the dispute module
+    /// @dev Enforced to be only callable by the protocol admin
     /// @param dispute The address of the dispute module
-    function setLicensingAndDisputeModules(address licensing, address dispute) external;
+    function setDisputeModule(address dispute) external;
 
     /// @notice Returns the licensing module address
     function licensingModule() external view returns (address);

--- a/contracts/interfaces/modules/royalty/IRoyaltyModule.sol
+++ b/contracts/interfaces/modules/royalty/IRoyaltyModule.sol
@@ -30,8 +30,17 @@ interface IRoyaltyModule is IModule {
     /// @param amount The amount paid
     event LicenseMintingFeePaid(address receiverIpId, address payerAddress, address token, uint256 amount);
 
+    /// @notice Sets the license registry
+    /// @dev Enforced to be only callable by the protocol admin
+    /// @param licensing The address of the license registry
+    /// @param dispute The address of the dispute module
+    function setLicensingAndDisputeModules(address licensing, address dispute) external;
+
     /// @notice Returns the licensing module address
     function licensingModule() external view returns (address);
+
+    /// @notice Returns the dispute module address
+    function disputeModule() external view returns (address);
 
     /// @notice Indicates if a royalty policy is whitelisted
     /// @param royaltyPolicy The address of the royalty policy

--- a/contracts/interfaces/modules/royalty/policies/IRoyaltyPolicyLAP.sol
+++ b/contracts/interfaces/modules/royalty/policies/IRoyaltyPolicyLAP.sol
@@ -24,7 +24,7 @@ interface IRoyaltyPolicyLAP is IRoyaltyPolicy {
     /// @param ipRoyaltyVault The ip royalty vault address
     /// @param royaltyStack The royalty stack of a given ipId is the sum of the royalties to be paid to each ancestors
     /// @param ancestorsAddresses The ancestors addresses array
-    /// @param ancestorsRoyalties The ancestors royalties array
+    /// @param ancestorsRoyalties Contains royalty token amounts for each ancestor in the same index as ancestorsAddresses
     struct LAPRoyaltyData {
         bool isUnlinkableToParents;
         address ipRoyaltyVault;

--- a/contracts/interfaces/modules/royalty/policies/IRoyaltyPolicyLAP.sol
+++ b/contracts/interfaces/modules/royalty/policies/IRoyaltyPolicyLAP.sol
@@ -24,7 +24,7 @@ interface IRoyaltyPolicyLAP is IRoyaltyPolicy {
     /// @param ipRoyaltyVault The ip royalty vault address
     /// @param royaltyStack The royalty stack of a given ipId is the sum of the royalties to be paid to each ancestors
     /// @param ancestorsAddresses The ancestors addresses array
-    /// @param ancestorsRoyalties Contains royalty token amounts for each ancestor in the same index as ancestorsAddresses
+    /// @param ancestorsRoyalties Contains royalty token amounts for each ancestor on same index as ancestorsAddresses
     struct LAPRoyaltyData {
         bool isUnlinkableToParents;
         address ipRoyaltyVault;

--- a/contracts/interfaces/modules/royalty/policies/IRoyaltyPolicyLAP.sol
+++ b/contracts/interfaces/modules/royalty/policies/IRoyaltyPolicyLAP.sol
@@ -19,6 +19,20 @@ interface IRoyaltyPolicyLAP is IRoyaltyPolicy {
         uint32[] targetRoyaltyAmount
     );
 
+    /// @notice The state data of the LAP royalty policy
+    /// @param isUnlinkableToParents Indicates if the ipId is unlinkable to new parents
+    /// @param ipRoyaltyVault The ip royalty vault address
+    /// @param royaltyStack The royalty stack of a given ipId is the sum of the royalties to be paid to each ancestors
+    /// @param ancestorsAddresses The ancestors addresses array
+    /// @param ancestorsRoyalties The ancestors royalties array
+    struct LAPRoyaltyData {
+        bool isUnlinkableToParents;
+        address ipRoyaltyVault;
+        uint32 royaltyStack;
+        address[] ancestorsAddresses;
+        uint32[] ancestorsRoyalties;
+    }
+
     /// @notice Returns the percentage scale - represents 100% of royalty tokens for an ip
     function TOTAL_RT_SUPPLY() external view returns (uint32);
 

--- a/contracts/lib/Errors.sol
+++ b/contracts/lib/Errors.sol
@@ -223,6 +223,8 @@ library Errors {
     error RoyaltyModule__ZeroLicensingModule();
     error RoyaltyModule__CanOnlyMintSelectedPolicy();
     error RoyaltyModule__NoParentsOnLinking();
+    error RoyaltyModule__ZeroDisputeModule();
+    error RoyaltyModule__IpIsTagged();
 
     error RoyaltyPolicyLAP__ZeroRoyaltyModule();
     error RoyaltyPolicyLAP__ZeroLiquidSplitFactory();
@@ -246,6 +248,8 @@ library Errors {
     error IpRoyaltyVault__SnapshotIntervalTooShort();
     error IpRoyaltyVault__AlreadyClaimed();
     error IpRoyaltyVault__ClaimerNotAnAncestor();
+    error IpRoyaltyVault__IpTagged();
+    error IpRoyaltyVault__ZeroDisputeModule();
 
     ////////////////////////////////////////////////////////////////////////////
     //                             ModuleRegistry                             //

--- a/contracts/modules/dispute/DisputeModule.sol
+++ b/contracts/modules/dispute/DisputeModule.sol
@@ -64,11 +64,11 @@ contract DisputeModule is
     IIPAssetRegistry public immutable IP_ASSET_REGISTRY;
 
     /// Constructor
-    /// @param _controller The address of the access controller
-    /// @param _assetRegistry The address of the asset registry
+    /// @param controller The address of the access controller
+    /// @param assetRegistry The address of the asset registry
     /// @custom:oz-upgrades-unsafe-allow constructor
-    constructor(address _controller, address _assetRegistry) AccessControlled(_controller, _assetRegistry) {
-        IP_ASSET_REGISTRY = IIPAssetRegistry(_assetRegistry);
+    constructor(address controller, address assetRegistry) AccessControlled(controller, assetRegistry) {
+        IP_ASSET_REGISTRY = IIPAssetRegistry(assetRegistry);
         _disableInitializers();
     }
 
@@ -169,9 +169,9 @@ contract DisputeModule is
         address arbitrationPolicy = $.arbitrationPolicies[targetIpId];
         if (!$.isWhitelistedArbitrationPolicy[arbitrationPolicy]) arbitrationPolicy = $.baseArbitrationPolicy;
 
-        uint256 disputeId_ = ++$.disputeCounter;
+        uint256 disputeId = ++$.disputeCounter;
 
-        $.disputes[disputeId_] = Dispute({
+        $.disputes[disputeId] = Dispute({
             targetIpId: targetIpId,
             disputeInitiator: msg.sender,
             arbitrationPolicy: arbitrationPolicy,
@@ -183,7 +183,7 @@ contract DisputeModule is
         IArbitrationPolicy(arbitrationPolicy).onRaiseDispute(msg.sender, data);
 
         emit DisputeRaised(
-            disputeId_,
+            disputeId,
             targetIpId,
             msg.sender,
             arbitrationPolicy,
@@ -192,7 +192,7 @@ contract DisputeModule is
             data
         );
 
-        return disputeId_;
+        return disputeId;
     }
 
     /// @notice Sets the dispute judgement on a given dispute. Only whitelisted arbitration relayers can call to judge.

--- a/contracts/modules/royalty/RoyaltyModule.sol
+++ b/contracts/modules/royalty/RoyaltyModule.sol
@@ -187,7 +187,8 @@ contract RoyaltyModule is
         if (!$.isWhitelistedRoyaltyToken[token]) revert Errors.RoyaltyModule__NotWhitelistedRoyaltyToken();
 
         IDisputeModule dispute = IDisputeModule($.disputeModule);
-        if (dispute.isIpTagged(receiverIpId) || dispute.isIpTagged(payerIpId)) revert Errors.RoyaltyModule__IpIsTagged();
+        if (dispute.isIpTagged(receiverIpId) || dispute.isIpTagged(payerIpId))
+            revert Errors.RoyaltyModule__IpIsTagged();
 
         address payerRoyaltyPolicy = $.royaltyPolicies[payerIpId];
         // if the payer does not have a royalty policy set, then the payer is not a derivative ip and does not pay

--- a/contracts/modules/royalty/RoyaltyModule.sol
+++ b/contracts/modules/royalty/RoyaltyModule.sol
@@ -69,15 +69,19 @@ contract RoyaltyModule is
         _;
     }
 
-    /// @notice Sets the license registry
+    /// @notice Sets the licensing module
     /// @dev Enforced to be only callable by the protocol admin
-    /// @param licensing The address of the license registry
-    /// @param dispute The address of the dispute module
-    function setLicensingAndDisputeModules(address licensing, address dispute) external onlyProtocolAdmin {
+    /// @param licensing The address of the license module
+    function setLicensingModule(address licensing) external onlyProtocolAdmin {
         if (licensing == address(0)) revert Errors.RoyaltyModule__ZeroLicensingModule();
-        if (dispute == address(0)) revert Errors.RoyaltyModule__ZeroDisputeModule();
-
         _getRoyaltyModuleStorage().licensingModule = licensing;
+    }
+
+    /// @notice Sets the dispute module
+    /// @dev Enforced to be only callable by the protocol admin
+    /// @param dispute The address of the dispute module
+    function setDisputeModule(address dispute) external onlyProtocolAdmin {
+        if (dispute == address(0)) revert Errors.RoyaltyModule__ZeroDisputeModule();
         _getRoyaltyModuleStorage().disputeModule = dispute;
     }
 
@@ -183,8 +187,7 @@ contract RoyaltyModule is
         if (!$.isWhitelistedRoyaltyToken[token]) revert Errors.RoyaltyModule__NotWhitelistedRoyaltyToken();
 
         IDisputeModule dispute = IDisputeModule($.disputeModule);
-        if (dispute.isIpTagged(receiverIpId)) revert Errors.RoyaltyModule__IpIsTagged();
-        if (dispute.isIpTagged(payerIpId)) revert Errors.RoyaltyModule__IpIsTagged();
+        if (dispute.isIpTagged(receiverIpId) || dispute.isIpTagged(payerIpId)) revert Errors.RoyaltyModule__IpIsTagged();
 
         address payerRoyaltyPolicy = $.royaltyPolicies[payerIpId];
         // if the payer does not have a royalty policy set, then the payer is not a derivative ip and does not pay

--- a/contracts/modules/royalty/RoyaltyModule.sol
+++ b/contracts/modules/royalty/RoyaltyModule.sol
@@ -10,6 +10,7 @@ import { BaseModule } from "../BaseModule.sol";
 import { GovernableUpgradeable } from "../../governance/GovernableUpgradeable.sol";
 import { IRoyaltyModule } from "../../interfaces/modules/royalty/IRoyaltyModule.sol";
 import { IRoyaltyPolicy } from "../../interfaces/modules/royalty/policies/IRoyaltyPolicy.sol";
+import { IDisputeModule } from "../../interfaces/modules/dispute/IDisputeModule.sol";
 import { Errors } from "../../lib/Errors.sol";
 import { ROYALTY_MODULE_KEY } from "../../lib/modules/Module.sol";
 import { BaseModule } from "../BaseModule.sol";
@@ -27,12 +28,14 @@ contract RoyaltyModule is
     using ERC165Checker for address;
 
     /// @dev Storage structure for the RoyaltyModule
+    /// @param disputeModule The address of the dispute module
     /// @param licensingModule The address of the licensing module
     /// @param isWhitelistedRoyaltyPolicy Indicates if a royalty policy is whitelisted
     /// @param isWhitelistedRoyaltyToken Indicates if a royalty token is whitelisted
     /// @param royaltyPolicies Indicates the royalty policy for a given IP asset
     /// @custom:storage-location erc7201:story-protocol.RoyaltyModule
     struct RoyaltyModuleStorage {
+        address disputeModule;
         address licensingModule;
         mapping(address royaltyPolicy => bool isWhitelisted) isWhitelistedRoyaltyPolicy;
         mapping(address token => bool) isWhitelistedRoyaltyToken;
@@ -69,9 +72,13 @@ contract RoyaltyModule is
     /// @notice Sets the license registry
     /// @dev Enforced to be only callable by the protocol admin
     /// @param licensing The address of the license registry
-    function setLicensingModule(address licensing) external onlyProtocolAdmin {
+    /// @param dispute The address of the dispute module
+    function setLicensingAndDisputeModules(address licensing, address dispute) external onlyProtocolAdmin {
         if (licensing == address(0)) revert Errors.RoyaltyModule__ZeroLicensingModule();
+        if (dispute == address(0)) revert Errors.RoyaltyModule__ZeroDisputeModule();
+
         _getRoyaltyModuleStorage().licensingModule = licensing;
+        _getRoyaltyModuleStorage().disputeModule = dispute;
     }
 
     /// @notice Whitelist a royalty policy
@@ -175,6 +182,10 @@ contract RoyaltyModule is
         RoyaltyModuleStorage storage $ = _getRoyaltyModuleStorage();
         if (!$.isWhitelistedRoyaltyToken[token]) revert Errors.RoyaltyModule__NotWhitelistedRoyaltyToken();
 
+        IDisputeModule dispute = IDisputeModule($.disputeModule);
+        if (dispute.isIpTagged(receiverIpId)) revert Errors.RoyaltyModule__IpIsTagged();
+        if (dispute.isIpTagged(payerIpId)) revert Errors.RoyaltyModule__IpIsTagged();
+
         address payerRoyaltyPolicy = $.royaltyPolicies[payerIpId];
         // if the payer does not have a royalty policy set, then the payer is not a derivative ip and does not pay
         // royalties while the receiver ip can have a zero royalty policy since that could mean it is an ip a root
@@ -202,7 +213,7 @@ contract RoyaltyModule is
     ) external onlyLicensingModule {
         RoyaltyModuleStorage storage $ = _getRoyaltyModuleStorage();
         if (!$.isWhitelistedRoyaltyToken[token]) revert Errors.RoyaltyModule__NotWhitelistedRoyaltyToken();
-
+        if (IDisputeModule($.disputeModule).isIpTagged(receiverIpId)) revert Errors.RoyaltyModule__IpIsTagged();
         if (licenseRoyaltyPolicy == address(0)) revert Errors.RoyaltyModule__NoRoyaltyPolicySet();
         if (!$.isWhitelistedRoyaltyPolicy[licenseRoyaltyPolicy])
             revert Errors.RoyaltyModule__NotWhitelistedRoyaltyPolicy();
@@ -215,6 +226,11 @@ contract RoyaltyModule is
     /// @notice Returns the licensing module address
     function licensingModule() external view returns (address) {
         return _getRoyaltyModuleStorage().licensingModule;
+    }
+
+    /// @notice Returns the dispute module address
+    function disputeModule() external view returns (address) {
+        return _getRoyaltyModuleStorage().disputeModule;
     }
 
     /// @notice Indicates if a royalty policy is whitelisted

--- a/contracts/modules/royalty/policies/RoyaltyPolicyLAP.sol
+++ b/contracts/modules/royalty/policies/RoyaltyPolicyLAP.sol
@@ -18,20 +18,6 @@ import { Errors } from "../../../lib/Errors.sol";
 contract RoyaltyPolicyLAP is IRoyaltyPolicyLAP, GovernableUpgradeable, ReentrancyGuardUpgradeable, UUPSUpgradeable {
     using SafeERC20 for IERC20;
 
-    /// @notice The state data of the LAP royalty policy
-    /// @param isUnlinkableToParents Indicates if the ipId is unlinkable to new parents
-    /// @param ipRoyaltyVault The ip royalty vault address
-    /// @param royaltyStack The royalty stack of a given ipId is the sum of the royalties to be paid to each ancestors
-    /// @param ancestorsAddresses The ancestors addresses array
-    /// @param ancestorsRoyalties The ancestors royalties array
-    struct LAPRoyaltyData {
-        bool isUnlinkableToParents;
-        address ipRoyaltyVault;
-        uint32 royaltyStack;
-        address[] ancestorsAddresses;
-        uint32[] ancestorsRoyalties;
-    }
-
     /// @dev Storage structure for the RoyaltyPolicyLAP
     /// @param ipRoyaltyVaultBeacon The ip royalty vault beacon address
     /// @param snapshotInterval The minimum timestamp interval between snapshots
@@ -118,7 +104,7 @@ contract RoyaltyPolicyLAP is IRoyaltyPolicyLAP, GovernableUpgradeable, Reentranc
         address ipId,
         bytes calldata licenseData,
         bytes calldata externalData
-    ) external onlyRoyaltyModule {
+    ) external onlyRoyaltyModule nonReentrant {
         uint32 newLicenseRoyalty = abi.decode(licenseData, (uint32));
         RoyaltyPolicyLAPStorage storage $ = _getRoyaltyPolicyLAPStorage();
 
@@ -153,7 +139,7 @@ contract RoyaltyPolicyLAP is IRoyaltyPolicyLAP, GovernableUpgradeable, Reentranc
         address[] calldata parentIpIds,
         bytes[] memory licenseData,
         bytes calldata externalData
-    ) external onlyRoyaltyModule {
+    ) external onlyRoyaltyModule nonReentrant {
         RoyaltyPolicyLAPStorage storage $ = _getRoyaltyPolicyLAPStorage();
         if ($.royaltyData[ipId].isUnlinkableToParents) revert Errors.RoyaltyPolicyLAP__UnlinkableToParents();
 

--- a/script/foundry/deployment/Main.s.sol
+++ b/script/foundry/deployment/Main.s.sol
@@ -345,7 +345,8 @@ contract Main is Script, BroadcastManager, JsonDeploymentHandler, StorageLayoutC
     }
 
     function _configureRoyaltyRelated() private {
-        royaltyModule.setLicensingAndDisputeModules(address(licensingModule), address(disputeModule));
+        royaltyModule.setLicensingModule(address(licensingModule));
+        royaltyModule.setDisputeModule(address(disputeModule));
         // whitelist
         royaltyModule.whitelistRoyaltyPolicy(address(royaltyPolicyLAP), true);
         royaltyModule.whitelistRoyaltyToken(address(erc20), true);

--- a/script/foundry/deployment/Main.s.sol
+++ b/script/foundry/deployment/Main.s.sol
@@ -345,7 +345,7 @@ contract Main is Script, BroadcastManager, JsonDeploymentHandler, StorageLayoutC
     }
 
     function _configureRoyaltyRelated() private {
-        royaltyModule.setLicensingModule(address(licensingModule));
+        royaltyModule.setLicensingAndDisputeModules(address(licensingModule), address(disputeModule));
         // whitelist
         royaltyModule.whitelistRoyaltyPolicy(address(royaltyPolicyLAP), true);
         royaltyModule.whitelistRoyaltyToken(address(erc20), true);

--- a/test/foundry/mocks/module/MockRoyaltyModule.sol
+++ b/test/foundry/mocks/module/MockRoyaltyModule.sol
@@ -11,6 +11,8 @@ contract MockRoyaltyModule is BaseModule, IRoyaltyModule {
 
     address public LICENSING_MODULE;
 
+    address public DISPUTE_MODULE;
+
     mapping(address royaltyPolicy => bool allowed) public isWhitelistedRoyaltyPolicy;
 
     mapping(address token => bool) public isWhitelistedRoyaltyToken;
@@ -19,12 +21,17 @@ contract MockRoyaltyModule is BaseModule, IRoyaltyModule {
 
     constructor() {}
 
-    function setLicensingModule(address _licensingModule) external {
+    function setLicensingAndDisputeModules(address _licensingModule, address _disputeModule) external {
         LICENSING_MODULE = _licensingModule;
+        DISPUTE_MODULE = _disputeModule;
     }
 
     function licensingModule() external view override returns (address) {
         return LICENSING_MODULE;
+    }
+
+    function disputeModule() external view override returns (address) {
+        return DISPUTE_MODULE;
     }
 
     function whitelistRoyaltyPolicy(address _royaltyPolicy, bool _allowed) external {

--- a/test/foundry/mocks/module/MockRoyaltyModule.sol
+++ b/test/foundry/mocks/module/MockRoyaltyModule.sol
@@ -21,9 +21,12 @@ contract MockRoyaltyModule is BaseModule, IRoyaltyModule {
 
     constructor() {}
 
-    function setLicensingAndDisputeModules(address _licensingModule, address _disputeModule) external {
-        LICENSING_MODULE = _licensingModule;
+    function setDisputeModule(address _disputeModule) external {
         DISPUTE_MODULE = _disputeModule;
+    }
+
+    function setLicensingModule(address _licensingModule) external {
+        LICENSING_MODULE = _licensingModule;
     }
 
     function licensingModule() external view override returns (address) {

--- a/test/foundry/modules/royalty/IpRoyaltyVault.t.sol
+++ b/test/foundry/modules/royalty/IpRoyaltyVault.t.sol
@@ -11,7 +11,6 @@ import { Errors } from "../../../../contracts/lib/Errors.sol";
 import { BaseTest } from "../../utils/BaseTest.t.sol";
 
 contract TestIpRoyaltyVault is BaseTest {
-
     IpRoyaltyVault ipRoyaltyVault;
 
     function setUp() public override {
@@ -257,7 +256,7 @@ contract TestIpRoyaltyVault is BaseTest {
         uint256 usdcClaimVaultBefore = ipRoyaltyVault.claimVaultAmount(address(USDC));
 
         uint256 expectedAmount = royaltyAmount - (royaltyAmount * royaltyStack2) / royaltyPolicyLAP.TOTAL_RT_SUPPLY();
-        
+
         vm.expectEmit(true, true, true, true, address(ipRoyaltyVault));
         emit IIpRoyaltyVault.RevenueTokenClaimed(address(2), address(USDC), expectedAmount);
 

--- a/test/foundry/modules/royalty/RoyaltyModule.t.sol
+++ b/test/foundry/modules/royalty/RoyaltyModule.t.sol
@@ -24,7 +24,7 @@ contract TestRoyaltyModule is BaseTest {
     address internal ipAccount2 = address(0x111000bbb);
     address internal ipAddr;
     address internal arbitrationRelayer;
-    
+
     struct InitParams {
         address[] targetAncestors;
         uint32[] targetRoyaltyAmount;

--- a/test/foundry/modules/royalty/RoyaltyModule.t.sol
+++ b/test/foundry/modules/royalty/RoyaltyModule.t.sol
@@ -172,35 +172,40 @@ contract TestRoyaltyModule is BaseTest {
         royaltyModule.onLinkToParents(address(3), address(royaltyPolicyLAP), parents, encodedLicenseData, encodedBytes);
     }
 
-    function test_RoyaltyModule_setLicensingAndDisputeModules_revert_ZeroLicensingModule() public {
-        address impl = address(new RoyaltyModule());
-        RoyaltyModule testRoyaltyModule = RoyaltyModule(
-            TestProxyHelper.deployUUPSProxy(impl, abi.encodeCall(RoyaltyModule.initialize, (address(getGovernance()))))
-        );
-        vm.expectRevert(Errors.RoyaltyModule__ZeroLicensingModule.selector);
-        vm.prank(u.admin);
-        testRoyaltyModule.setLicensingAndDisputeModules(address(0), address(1));
-    }
-
-    function test_RoyaltyModule_setLicensingAndDisputeModules_revert_ZeroDisputeModule() public {
+    function test_RoyaltyModule_setDisputeModule_revert_ZeroDisputeModule() public {
         address impl = address(new RoyaltyModule());
         RoyaltyModule testRoyaltyModule = RoyaltyModule(
             TestProxyHelper.deployUUPSProxy(impl, abi.encodeCall(RoyaltyModule.initialize, (address(getGovernance()))))
         );
         vm.expectRevert(Errors.RoyaltyModule__ZeroDisputeModule.selector);
         vm.prank(u.admin);
-        testRoyaltyModule.setLicensingAndDisputeModules(address(1), address(0));
+        testRoyaltyModule.setDisputeModule(address(0));
     }
 
-    function test_RoyaltyModule_setLicensingAndDisputeModules() public {
+    function test_RoyaltyModule_setDisputeModule() public {
         vm.startPrank(u.admin);
         address impl = address(new RoyaltyModule());
         RoyaltyModule testRoyaltyModule = RoyaltyModule(
             TestProxyHelper.deployUUPSProxy(impl, abi.encodeCall(RoyaltyModule.initialize, (address(getGovernance()))))
         );
-        testRoyaltyModule.setLicensingAndDisputeModules(address(licensingModule), address(disputeModule));
-        assertEq(testRoyaltyModule.licensingModule(), address(licensingModule));
+        testRoyaltyModule.setDisputeModule(address(disputeModule));
         assertEq(testRoyaltyModule.disputeModule(), address(disputeModule));
+    }
+
+    function test_RoyaltyModule_setLicensingModule_revert_ZeroLicensingModule() public {
+        vm.startPrank(u.admin);
+        vm.expectRevert(Errors.RoyaltyModule__ZeroLicensingModule.selector);
+        royaltyModule.setLicensingModule(address(0));
+    }
+
+    function test_RoyaltyModule_setLicensingModule() public {
+        vm.startPrank(u.admin);
+        address impl = address(new RoyaltyModule());
+        RoyaltyModule testRoyaltyModule = RoyaltyModule(
+            TestProxyHelper.deployUUPSProxy(impl, abi.encodeCall(RoyaltyModule.initialize, (address(getGovernance()))))
+        );
+        testRoyaltyModule.setLicensingModule(address(licensingModule));
+        assertEq(testRoyaltyModule.licensingModule(), address(licensingModule));
     }
 
     function test_RoyaltyModule_whitelistRoyaltyPolicy_revert_ZeroRoyaltyToken() public {

--- a/test/foundry/modules/royalty/RoyaltyModule.t.sol
+++ b/test/foundry/modules/royalty/RoyaltyModule.t.sol
@@ -1,10 +1,13 @@
 // SPDX-License-Identifier: BUSL-1.1
 pragma solidity 0.8.23;
 
+import { ERC6551AccountLib } from "erc6551/lib/ERC6551AccountLib.sol";
+
 // contracts
 import { Errors } from "../../../../contracts/lib/Errors.sol";
 import { RoyaltyModule } from "../../../../contracts/modules/royalty/RoyaltyModule.sol";
 import { RoyaltyPolicyLAP } from "../../../../contracts/modules/royalty/policies/RoyaltyPolicyLAP.sol";
+import { PILPolicy } from "contracts/modules/licensing/PILPolicyFrameworkManager.sol";
 import { TestProxyHelper } from "test/foundry/utils/TestProxyHelper.sol";
 
 // tests
@@ -19,6 +22,9 @@ contract TestRoyaltyModule is BaseTest {
 
     address internal ipAccount1 = address(0x111000aaa);
     address internal ipAccount2 = address(0x111000bbb);
+    address internal ipAddr;
+    address internal arbitrationRelayer;
+    
     struct InitParams {
         address[] targetAncestors;
         uint32[] targetRoyaltyAmount;
@@ -39,9 +45,9 @@ contract TestRoyaltyModule is BaseTest {
     function setUp() public override {
         super.setUp();
         buildDeployModuleCondition(
-            DeployModuleCondition({ disputeModule: false, royaltyModule: true, licensingModule: false })
+            DeployModuleCondition({ disputeModule: true, royaltyModule: true, licensingModule: false })
         );
-        buildDeployPolicyCondition(DeployPolicyCondition({ arbitrationPolicySP: false, royaltyPolicyLAP: true }));
+        buildDeployPolicyCondition(DeployPolicyCondition({ arbitrationPolicySP: true, royaltyPolicyLAP: true }));
         deployConditionally();
         postDeploymentSetup();
 
@@ -51,6 +57,8 @@ contract TestRoyaltyModule is BaseTest {
         royaltyPolicyLAP2 = RoyaltyPolicyLAP(
             TestProxyHelper.deployUUPSProxy(impl, abi.encodeCall(RoyaltyPolicyLAP.initialize, (getGovernance())))
         );
+
+        arbitrationRelayer = u.admin;
 
         vm.startPrank(u.admin);
         // whitelist royalty policy
@@ -63,6 +71,51 @@ contract TestRoyaltyModule is BaseTest {
         vm.startPrank(address(licensingModule));
         // split made to avoid stack too deep error
         _setupTree();
+        vm.stopPrank();
+
+        USDC.mint(ipAccount1, 1000 * 10 ** 6);
+
+        _setPILPolicyFrameworkManager();
+        _addPILPolicy(
+            "cheap_flexible",
+            true,
+            address(royaltyPolicyLAP),
+            PILPolicy({
+                attribution: false,
+                commercialUse: true,
+                commercialAttribution: true,
+                commercializerChecker: address(0),
+                commercializerCheckerData: "",
+                commercialRevShare: 10,
+                derivativesAllowed: true,
+                derivativesAttribution: true,
+                derivativesApproval: false,
+                derivativesReciprocal: false,
+                territories: new string[](0),
+                distributionChannels: new string[](0),
+                contentRestrictions: new string[](0)
+            })
+        );
+
+        mockNFT.mintId(u.alice, 0);
+
+        address expectedAddr = ERC6551AccountLib.computeAddress(
+            address(erc6551Registry),
+            address(ipAccountImpl),
+            ipAccountRegistry.IP_ACCOUNT_SALT(),
+            block.chainid,
+            address(mockNFT),
+            0
+        );
+        vm.label(expectedAddr, "IPAccount0");
+
+        vm.startPrank(u.alice);
+        ipAddr = ipAssetRegistry.register(address(mockNFT), 0);
+        licensingModule.addPolicyToIp(ipAddr, policyIds["pil_cheap_flexible"]);
+
+        // set arbitration policy
+        vm.startPrank(ipAddr);
+        disputeModule.setArbitrationPolicy(ipAddr, address(arbitrationPolicySP));
         vm.stopPrank();
     }
 
@@ -119,24 +172,35 @@ contract TestRoyaltyModule is BaseTest {
         royaltyModule.onLinkToParents(address(3), address(royaltyPolicyLAP), parents, encodedLicenseData, encodedBytes);
     }
 
-    function test_RoyaltyModule_setLicensingModule_revert_ZeroLicensingModule() public {
+    function test_RoyaltyModule_setLicensingAndDisputeModules_revert_ZeroLicensingModule() public {
         address impl = address(new RoyaltyModule());
         RoyaltyModule testRoyaltyModule = RoyaltyModule(
             TestProxyHelper.deployUUPSProxy(impl, abi.encodeCall(RoyaltyModule.initialize, (address(getGovernance()))))
         );
         vm.expectRevert(Errors.RoyaltyModule__ZeroLicensingModule.selector);
         vm.prank(u.admin);
-        testRoyaltyModule.setLicensingModule(address(0));
+        testRoyaltyModule.setLicensingAndDisputeModules(address(0), address(1));
     }
 
-    function test_RoyaltyModule_setLicensingModule() public {
+    function test_RoyaltyModule_setLicensingAndDisputeModules_revert_ZeroDisputeModule() public {
+        address impl = address(new RoyaltyModule());
+        RoyaltyModule testRoyaltyModule = RoyaltyModule(
+            TestProxyHelper.deployUUPSProxy(impl, abi.encodeCall(RoyaltyModule.initialize, (address(getGovernance()))))
+        );
+        vm.expectRevert(Errors.RoyaltyModule__ZeroDisputeModule.selector);
+        vm.prank(u.admin);
+        testRoyaltyModule.setLicensingAndDisputeModules(address(1), address(0));
+    }
+
+    function test_RoyaltyModule_setLicensingAndDisputeModules() public {
         vm.startPrank(u.admin);
         address impl = address(new RoyaltyModule());
         RoyaltyModule testRoyaltyModule = RoyaltyModule(
             TestProxyHelper.deployUUPSProxy(impl, abi.encodeCall(RoyaltyModule.initialize, (address(getGovernance()))))
         );
-        testRoyaltyModule.setLicensingModule(address(licensingModule));
+        testRoyaltyModule.setLicensingAndDisputeModules(address(licensingModule), address(disputeModule));
         assertEq(testRoyaltyModule.licensingModule(), address(licensingModule));
+        assertEq(testRoyaltyModule.disputeModule(), address(disputeModule));
     }
 
     function test_RoyaltyModule_whitelistRoyaltyPolicy_revert_ZeroRoyaltyToken() public {
@@ -449,6 +513,24 @@ contract TestRoyaltyModule is BaseTest {
         royaltyModule.payRoyaltyOnBehalf(receiverIpId, payerIpId, address(1), royaltyAmount);
     }
 
+    function test_RoyaltyModule_payRoyaltyOnBehalf_revert_IpIsTagged() public {
+        // raise dispute
+        vm.startPrank(ipAccount1);
+        USDC.approve(address(arbitrationPolicySP), ARBITRATION_PRICE);
+        disputeModule.raiseDispute(ipAddr, string("urlExample"), "PLAGIARISM", "");
+        vm.stopPrank();
+
+        // set dispute judgement
+        vm.startPrank(arbitrationRelayer);
+        disputeModule.setDisputeJudgement(1, true, "");
+
+        vm.expectRevert(Errors.RoyaltyModule__IpIsTagged.selector);
+        royaltyModule.payRoyaltyOnBehalf(ipAddr, ipAccount1, address(USDC), 100);
+
+        vm.expectRevert(Errors.RoyaltyModule__IpIsTagged.selector);
+        royaltyModule.payRoyaltyOnBehalf(ipAccount1, ipAddr, address(USDC), 100);
+    }
+
     function test_RoyaltyModule_payRoyaltyOnBehalf_revert_NotWhitelistedRoyaltyPolicy() public {
         uint256 royaltyAmount = 100 * 10 ** 6;
         address receiverIpId = address(7);
@@ -485,6 +567,23 @@ contract TestRoyaltyModule is BaseTest {
 
         assertEq(payerIpIdUSDCBalBefore - payerIpIdUSDCBalAfter, royaltyAmount);
         assertEq(ipRoyaltyVaultUSDCBalAfter - ipRoyaltyVaultUSDCBalBefore, royaltyAmount);
+    }
+
+    function test_RoyaltyModule_payLicenseMintingFee_revert_IpIsTagged() public {
+        // raise dispute
+        vm.startPrank(ipAccount1);
+        USDC.approve(address(arbitrationPolicySP), ARBITRATION_PRICE);
+        disputeModule.raiseDispute(ipAddr, string("urlExample"), "PLAGIARISM", "");
+        vm.stopPrank();
+
+        // set dispute judgement
+        vm.startPrank(arbitrationRelayer);
+        disputeModule.setDisputeJudgement(1, true, "");
+
+        vm.startPrank(address(licensingModule));
+
+        vm.expectRevert(Errors.RoyaltyModule__IpIsTagged.selector);
+        royaltyModule.payLicenseMintingFee(ipAddr, ipAccount1, address(royaltyPolicyLAP), address(USDC), 100);
     }
 
     function test_RoyaltyModule_payLicenseMintingFee() public {

--- a/test/foundry/utils/BaseTest.t.sol
+++ b/test/foundry/utils/BaseTest.t.sol
@@ -157,7 +157,7 @@ contract BaseTest is Test, DeployHelper, LicensingHelper {
         require(address(royaltyModule) != address(0), "royaltyModule not set");
 
         vm.startPrank(u.admin);
-        RoyaltyModule(address(royaltyModule)).setLicensingModule(getLicensingModule());
+        RoyaltyModule(address(royaltyModule)).setLicensingAndDisputeModules(getLicensingModule(), getDisputeModule());
         royaltyModule.whitelistRoyaltyToken(address(erc20), true);
         if (address(royaltyPolicyLAP) != address(0)) {
             royaltyModule.whitelistRoyaltyPolicy(address(royaltyPolicyLAP), true);

--- a/test/foundry/utils/BaseTest.t.sol
+++ b/test/foundry/utils/BaseTest.t.sol
@@ -157,7 +157,8 @@ contract BaseTest is Test, DeployHelper, LicensingHelper {
         require(address(royaltyModule) != address(0), "royaltyModule not set");
 
         vm.startPrank(u.admin);
-        RoyaltyModule(address(royaltyModule)).setLicensingAndDisputeModules(getLicensingModule(), getDisputeModule());
+        RoyaltyModule(address(royaltyModule)).setLicensingModule(getLicensingModule());
+        RoyaltyModule(address(royaltyModule)).setDisputeModule(getDisputeModule());
         royaltyModule.whitelistRoyaltyToken(address(erc20), true);
         if (address(royaltyPolicyLAP) != address(0)) {
             royaltyModule.whitelistRoyaltyPolicy(address(royaltyPolicyLAP), true);

--- a/test/foundry/utils/DeployHelper.t.sol
+++ b/test/foundry/utils/DeployHelper.t.sol
@@ -299,7 +299,9 @@ contract DeployHelper is Test {
 
             // deploy ip royalty vault implementation and beacon
             vm.startPrank(governanceAdmin);
-            address ipRoyaltyVaultImplementation = address(new IpRoyaltyVault(address(royaltyPolicyLAP)));
+            address ipRoyaltyVaultImplementation = address(
+                new IpRoyaltyVault(address(royaltyPolicyLAP), address(disputeModule))
+            );
             address ipRoyaltyVaultBeacon = address(
                 new UpgradeableBeacon(ipRoyaltyVaultImplementation, getGovernance())
             );


### PR DESCRIPTION
This pr adds royalty related restrictions when IP assets are tagged via dispute:
- tagged IP assets are unable to receive license minting fee
- tagged IP assets are unable to receive voluntary royalty payments
- tagged IP assets IpRoyaltyVault does not allow claiming revenue tokens nor collect of royalty tokens