### PR TITLE
Remove unused/redundant code in AccessControlled

### DIFF
--- a/contracts/lib/Errors.sol
+++ b/contracts/lib/Errors.sol
@@ -318,8 +318,6 @@ library Errors {
     //                             AccessControlled                           //
     ////////////////////////////////////////////////////////////////////////////
     error AccessControlled__ZeroAddress();
-    error AccessControlled__NotIpAccount(address ipAccount);
-    error AccessControlled__CallerIsNotIpAccount(address caller);
 
     ////////////////////////////////////////////////////////////////////////////
     //                         CoreMetadataModule                       //

--- a/contracts/modules/dispute/DisputeModule.sol
+++ b/contracts/modules/dispute/DisputeModule.sol
@@ -68,7 +68,7 @@ contract DisputeModule is
     /// @param controller The address of the access controller
     /// @param assetRegistry The address of the asset registry
     /// @custom:oz-upgrades-unsafe-allow constructor
-    constructor(address controller, address assetRegistry) AccessControlled(controller, assetRegistry) {
+    constructor(address controller, address assetRegistry) AccessControlled(controller) {
         IP_ASSET_REGISTRY = IIPAssetRegistry(assetRegistry);
         _disableInitializers();
     }

--- a/contracts/modules/external/TokenWithdrawalModule.sol
+++ b/contracts/modules/external/TokenWithdrawalModule.sol
@@ -23,10 +23,7 @@ contract TokenWithdrawalModule is AccessControlled, BaseModule, ITokenWithdrawal
 
     string public constant override name = TOKEN_WITHDRAWAL_MODULE_KEY;
 
-    constructor(
-        address accessController,
-        address ipAccountRegistry
-    ) AccessControlled(accessController, ipAccountRegistry) {}
+    constructor(address accessController) AccessControlled(accessController) {}
 
     /// @notice Withdraws ERC20 token from the IP account to the IP account owner.
     /// @dev When calling this function, the caller must have the permission to call `transfer` via the IP account.

--- a/contracts/modules/licensing/LicensingModule.sol
+++ b/contracts/modules/licensing/LicensingModule.sol
@@ -74,19 +74,18 @@ contract LicensingModule is
 
     /// Constructor
     /// @param accessController The address of the AccessController contract
-    /// @param ipAccountRegistry The address of the IPAccountRegistry contract
     /// @param royaltyModule The address of the RoyaltyModule contract
     /// @param registry The address of the LicenseRegistry contract
     /// @param disputeModule The address of the DisputeModule contract
+    /// @param licenseToken The address of the LicenseToken contract
     /// @custom:oz-upgrades-unsafe-allow constructor
     constructor(
         address accessController,
-        address ipAccountRegistry,
         address royaltyModule,
         address registry,
         address disputeModule,
         address licenseToken
-    ) AccessControlled(accessController, ipAccountRegistry) {
+    ) AccessControlled(accessController) {
         ROYALTY_MODULE = RoyaltyModule(royaltyModule);
         LICENSE_REGISTRY = ILicenseRegistry(registry);
         DISPUTE_MODULE = IDisputeModule(disputeModule);

--- a/contracts/modules/licensing/PILicenseTemplate.sol
+++ b/contracts/modules/licensing/PILicenseTemplate.sol
@@ -48,11 +48,10 @@ contract PILicenseTemplate is
     /// @custom:oz-upgrades-unsafe-allow constructor
     constructor(
         address accessController,
-        address ipAccountRegistry,
         address licenseRegistry,
         address royaltyModule,
         address licenseToken
-    ) LicensorApprovalChecker(accessController, ipAccountRegistry, licenseToken) {
+    ) LicensorApprovalChecker(accessController, licenseToken) {
         LICENSE_REGISTRY = ILicenseRegistry(licenseRegistry);
         ROYALTY_MODULE = IRoyaltyModule(royaltyModule);
         _disableInitializers();

--- a/contracts/modules/licensing/parameter-helpers/LicensorApprovalChecker.sol
+++ b/contracts/modules/licensing/parameter-helpers/LicensorApprovalChecker.sol
@@ -41,14 +41,9 @@ abstract contract LicensorApprovalChecker is AccessControlled, Initializable {
 
     /// @notice Constructor function
     /// @param accessController The address of the AccessController contract
-    /// @param ipAccountRegistry The address of the IPAccountRegistry contract
     /// @param licenseToken The address of the LicenseRegistry contract
     /// @custom:oz-upgrades-unsafe-allow constructor
-    constructor(
-        address accessController,
-        address ipAccountRegistry,
-        address licenseToken
-    ) AccessControlled(accessController, ipAccountRegistry) {
+    constructor(address accessController, address licenseToken) AccessControlled(accessController) {
         LICENSE_NFT = ILicenseToken(licenseToken);
     }
 

--- a/contracts/modules/metadata/CoreMetadataModule.sol
+++ b/contracts/modules/metadata/CoreMetadataModule.sol
@@ -32,11 +32,7 @@ contract CoreMetadataModule is BaseModule, AccessControlled, ICoreMetadataModule
 
     /// @notice Creates a new CoreMetadataModule instance.
     /// @param accessController The address of the AccessController contract.
-    /// @param ipAccountRegistry The address of the IPAccountRegistry contract.
-    constructor(
-        address accessController,
-        address ipAccountRegistry
-    ) AccessControlled(accessController, ipAccountRegistry) {}
+    constructor(address accessController) AccessControlled(accessController) {}
 
     /// @notice Update the nftTokenURI for an IP asset,
     /// by retrieve the latest TokenURI from IP NFT to which the IP Asset bound.

--- a/script/foundry/utils/DeployHelper.sol
+++ b/script/foundry/utils/DeployHelper.sol
@@ -262,7 +262,6 @@ contract DeployHelper is Script, BroadcastManager, JsonDeploymentHandler, Storag
         impl = address(
             new LicensingModule(
                 address(accessController),
-                address(ipAccountRegistry),
                 address(royaltyModule),
                 address(licenseRegistry),
                 address(disputeModule),
@@ -308,7 +307,6 @@ contract DeployHelper is Script, BroadcastManager, JsonDeploymentHandler, Storag
         impl = address(
             new PILicenseTemplate(
                 address(accessController),
-                address(ipAccountRegistry),
                 address(licenseRegistry),
                 address(royaltyModule),
                 address(licenseToken)
@@ -335,7 +333,7 @@ contract DeployHelper is Script, BroadcastManager, JsonDeploymentHandler, Storag
         _postdeploy("IpRoyaltyVaultBeacon", address(ipRoyaltyVaultBeacon));
 
         _predeploy("CoreMetadataModule");
-        coreMetadataModule = new CoreMetadataModule(address(accessController), address(ipAssetRegistry));
+        coreMetadataModule = new CoreMetadataModule(address(accessController));
         _postdeploy("CoreMetadataModule", address(coreMetadataModule));
 
         _predeploy("CoreMetadataViewModule");
@@ -343,7 +341,7 @@ contract DeployHelper is Script, BroadcastManager, JsonDeploymentHandler, Storag
         _postdeploy("CoreMetadataViewModule", address(coreMetadataViewModule));
 
         _predeploy("TokenWithdrawalModule");
-        tokenWithdrawalModule = new TokenWithdrawalModule(address(accessController), address(ipAccountRegistry));
+        tokenWithdrawalModule = new TokenWithdrawalModule(address(accessController));
         _postdeploy("TokenWithdrawalModule", address(tokenWithdrawalModule));
     }
 

--- a/test/foundry/access/AccessControlled.t.sol
+++ b/test/foundry/access/AccessControlled.t.sol
@@ -59,7 +59,7 @@ contract AccessControlledTest is BaseTest {
 
     function test_AccessControlled_revert_callOnlyIpAccountFunction_withNonIpAccount() public {
         address nonOwner = vm.addr(3);
-        vm.expectRevert(abi.encodeWithSelector(Errors.AccessControlled__CallerIsNotIpAccount.selector, nonOwner));
+        vm.expectRevert("onlyIpAccount");
         vm.prank(nonOwner);
         mockModule.onlyIpAccountFunction("test", true);
     }
@@ -176,7 +176,7 @@ contract AccessControlledTest is BaseTest {
 
     function test_AccessControlled_revert_callIpAccountOrPermissionFunction_passInNonIpAccount() public {
         address nonIpAccount = vm.addr(7);
-        vm.expectRevert(abi.encodeWithSelector(Errors.AccessControlled__NotIpAccount.selector, nonIpAccount));
+        vm.expectRevert(abi.encodeWithSelector(Errors.AccessController__IPAccountIsNotValid.selector, nonIpAccount));
         vm.prank(owner);
         mockModule.ipAccountOrPermissionFunction(nonIpAccount, "test", true);
     }
@@ -221,16 +221,6 @@ contract AccessControlledTest is BaseTest {
         new MockAccessControlledModule(
             address(0),
             address(ipAccountRegistry),
-            address(moduleRegistry),
-            "MockAccessControlledModule"
-        );
-    }
-
-    function test_AccessControlled_revert_constructor_zeroAddress_ipAccountRegistry() public {
-        vm.expectRevert(abi.encodeWithSelector(Errors.AccessControlled__ZeroAddress.selector));
-        new MockAccessControlledModule(
-            address(accessController),
-            address(0),
             address(moduleRegistry),
             "MockAccessControlledModule"
         );

--- a/test/foundry/integration/e2e/e2e.t.sol
+++ b/test/foundry/integration/e2e/e2e.t.sol
@@ -130,7 +130,6 @@ contract e2e is Test {
         impl = address(
             new LicensingModule(
                 address(accessController),
-                address(ipAssetRegistry),
                 address(royaltyModule),
                 address(licenseRegistry),
                 address(disputeModule),
@@ -167,7 +166,6 @@ contract e2e is Test {
         impl = address(
             new PILicenseTemplate(
                 address(accessController),
-                address(ipAssetRegistry),
                 address(licenseRegistry),
                 address(royaltyModule),
                 address(licenseToken)

--- a/test/foundry/mocks/module/MockAccessControlledModule.sol
+++ b/test/foundry/mocks/module/MockAccessControlledModule.sol
@@ -16,20 +16,17 @@ contract MockAccessControlledModule is BaseModule, AccessControlled {
     using ERC165Checker for address;
     using IPAccountChecker for IIPAccountRegistry;
 
+    IIPAccountRegistry public ipAccountRegistry;
     IModuleRegistry public moduleRegistry;
     string public name;
 
-    /// @notice Creates a new MockAccessControlledModule instance.
-    /// @param accessController The address of the AccessController contract.
-    /// @param ipAccountRegistry The address of the IPAccountRegistry contract.
-    /// @param moduleRegistry_ The address of the ModuleRegistry contract.
-    /// @param name_ The name of the module.
     constructor(
         address accessController,
-        address ipAccountRegistry,
+        address ipAccountRegistry_,
         address moduleRegistry_,
         string memory name_
-    ) AccessControlled(accessController, ipAccountRegistry) {
+    ) AccessControlled(accessController) {
+        ipAccountRegistry = IIPAccountRegistry(ipAccountRegistry_);
         moduleRegistry = IModuleRegistry(moduleRegistry_);
         name = name_;
     }
@@ -39,10 +36,9 @@ contract MockAccessControlledModule is BaseModule, AccessControlled {
     /// @param success A boolean to simulate function success or failure.
     /// @return The input string parameter if the call is successful.
     /// @dev This function reverts if the `success` parameter is false.
-    function onlyIpAccountFunction(
-        string memory param,
-        bool success
-    ) external view onlyIpAccount returns (string memory) {
+    function onlyIpAccountFunction(string memory param, bool success) external view returns (string memory) {
+        require(ipAccountRegistry.isIpAccount(msg.sender), "onlyIpAccount");
+
         if (!success) {
             revert("expected failure");
         }

--- a/test/foundry/mocks/module/MockMetadataModule.sol
+++ b/test/foundry/mocks/module/MockMetadataModule.sol
@@ -23,11 +23,7 @@ contract MockMetadataModule is BaseModule, AccessControlled {
 
     /// @notice Creates a new MockMetadataModule instance.
     /// @param accessController The address of the AccessController contract.
-    /// @param ipAccountRegistry The address of the IPAccountRegistry contract.
-    constructor(
-        address accessController,
-        address ipAccountRegistry
-    ) AccessControlled(accessController, ipAccountRegistry) {
+    constructor(address accessController) AccessControlled(accessController) {
         ipTypesSupported["STORY"] = true;
         ipTypesSupported["CHARACTOR"] = true;
         ipTypesSupported["BOOK"] = true;

--- a/test/foundry/modules/metadata/CoreMetadataModule.t.sol
+++ b/test/foundry/modules/metadata/CoreMetadataModule.t.sol
@@ -61,7 +61,7 @@ contract CoreMetadataModuleTest is BaseTest {
     }
 
     function test_CoreMetadata_NftTokenURI_InvalidIpAccount() public {
-        vm.expectRevert(abi.encodeWithSelector(Errors.AccessControlled__NotIpAccount.selector, address(0x1234)));
+        vm.expectRevert(abi.encodeWithSelector(Errors.AccessController__IPAccountIsNotValid.selector, address(0x1234)));
         vm.prank(alice);
         coreMetadataModule.updateNftTokenURI(address(0x1234), bytes32(0));
     }
@@ -119,7 +119,7 @@ contract CoreMetadataModuleTest is BaseTest {
     }
 
     function test_CoreMetadata_MetadataURI_InvalidIpAccount() public {
-        vm.expectRevert(abi.encodeWithSelector(Errors.AccessControlled__NotIpAccount.selector, address(0x1234)));
+        vm.expectRevert(abi.encodeWithSelector(Errors.AccessController__IPAccountIsNotValid.selector, address(0x1234)));
         vm.prank(alice);
         coreMetadataModule.setMetadataURI(address(0x1234), "My MetadataURI", bytes32(0));
     }
@@ -171,7 +171,7 @@ contract CoreMetadataModuleTest is BaseTest {
     }
 
     function test_CoreMetadata_All_InvalidIpAccount() public {
-        vm.expectRevert(abi.encodeWithSelector(Errors.AccessControlled__NotIpAccount.selector, address(0x1234)));
+        vm.expectRevert(abi.encodeWithSelector(Errors.AccessController__IPAccountIsNotValid.selector, address(0x1234)));
         vm.prank(alice);
         coreMetadataModule.setAll(address(0x1234), "My MetadataURI", bytes32("0x1234"), bytes32("0x5678"));
     }

--- a/test/foundry/modules/metadata/MetadataModule.t.sol
+++ b/test/foundry/modules/metadata/MetadataModule.t.sol
@@ -15,7 +15,7 @@ contract MetadataModuleTest is BaseTest {
     function setUp() public override {
         super.setUp();
 
-        metadataModule = new MockMetadataModule(address(accessController), address(ipAssetRegistry));
+        metadataModule = new MockMetadataModule(address(accessController));
         module = new MockModule(address(ipAssetRegistry), address(moduleRegistry), "MockModule");
 
         vm.etch(

--- a/test/foundry/modules/royalty/RoyaltyPolicyLAP.t.sol
+++ b/test/foundry/modules/royalty/RoyaltyPolicyLAP.t.sol
@@ -148,12 +148,7 @@ contract TestRoyaltyPolicyLAP is BaseTest {
     }
 
     function test_RoyaltyPolicyLAP_setSnapshotInterval_revert_NotOwner() public {
-        vm.expectRevert(
-            abi.encodeWithSelector(
-                IAccessManaged.AccessManagedUnauthorized.selector,
-                address(this)
-            )
-        );
+        vm.expectRevert(abi.encodeWithSelector(IAccessManaged.AccessManagedUnauthorized.selector, address(this)));
         royaltyPolicyLAP.setSnapshotInterval(100);
     }
 
@@ -164,12 +159,7 @@ contract TestRoyaltyPolicyLAP is BaseTest {
     }
 
     function test_RoyaltyPolicyLAP_setIpRoyaltyVaultBeacon_revert_NotOwner() public {
-        vm.expectRevert(
-            abi.encodeWithSelector(
-                IAccessManaged.AccessManagedUnauthorized.selector,
-                address(this)
-            )
-        );
+        vm.expectRevert(abi.encodeWithSelector(IAccessManaged.AccessManagedUnauthorized.selector, address(this)));
         royaltyPolicyLAP.setIpRoyaltyVaultBeacon(address(1));
     }
 


### PR DESCRIPTION
- Remove `onlyIpAccount`
- Remove redundant checks in `_verifyPermission` and `_hasPermission`
    - Move `ipAccount = signer` check in `checkPermission`
- Remove unused `ipAccountRegistry` in the constructor
- Remove obsolete tests
- Update test errors

Closes #62