### PR TITLE
Basic Modifications to IP Asset Registry register

### DIFF
--- a/contracts/registries/IPAssetRegistry.sol
+++ b/contracts/registries/IPAssetRegistry.sol
@@ -37,10 +37,6 @@ contract IPAssetRegistry is IIPAssetRegistry, IPAccountRegistry {
     /// @param tokenId The token identifier of the NFT.
     /// @return id The address of the newly registered IP.
     function register(address tokenContract, uint256 tokenId) external returns (address id) {
-        if (!tokenContract.supportsInterface(type(IERC721).interfaceId)) {
-            revert Errors.IPAssetRegistry__UnsupportedIERC721(tokenContract);
-        }
-
         if (IERC721(tokenContract).ownerOf(tokenId) == address(0)) {
             revert Errors.IPAssetRegistry__InvalidToken(tokenContract, tokenId);
         }
@@ -56,13 +52,7 @@ contract IPAssetRegistry is IIPAssetRegistry, IPAccountRegistry {
             revert Errors.IPAssetRegistry__AlreadyRegistered();
         }
 
-        string memory name = string.concat(
-            block.chainid.toString(),
-            ": ",
-            IERC721Metadata(tokenContract).name(),
-            " #",
-            tokenId.toString()
-        );
+        string memory name = string.concat(IERC721Metadata(tokenContract).name(), " #", tokenId.toString());
         string memory uri = IERC721Metadata(tokenContract).tokenURI(tokenId);
         uint256 registrationDate = block.timestamp;
         ipAccount.setString("NAME", name);

--- a/contracts/registries/IPAssetRegistry.sol
+++ b/contracts/registries/IPAssetRegistry.sol
@@ -37,12 +37,12 @@ contract IPAssetRegistry is IIPAssetRegistry, IPAccountRegistry {
     /// @param tokenId The token identifier of the NFT.
     /// @return id The address of the newly registered IP.
     function register(address tokenContract, uint256 tokenId) external returns (address id) {
-        if (IERC721(tokenContract).ownerOf(tokenId) == address(0)) {
-            revert Errors.IPAssetRegistry__InvalidToken(tokenContract, tokenId);
-        }
-
         if (!tokenContract.supportsInterface(type(IERC721Metadata).interfaceId)) {
             revert Errors.IPAssetRegistry__UnsupportedIERC721Metadata(tokenContract);
+        }
+
+        if (IERC721(tokenContract).ownerOf(tokenId) == address(0)) {
+            revert Errors.IPAssetRegistry__InvalidToken(tokenContract, tokenId);
         }
 
         id = registerIpAccount(block.chainid, tokenContract, tokenId);


### PR DESCRIPTION
- Remove check for `IERC721` interface support since we check for`IERC721Metadata` interface support, which inherits IERC721.
- Remove chainId from naming since contracts and offchain apps can already know the chain an IP is on.