### PR TITLE
Detect and Revert Duplicate License Terms

### DIFF
--- a/contracts/lib/Errors.sol
+++ b/contracts/lib/Errors.sol
@@ -133,7 +133,7 @@ library Errors {
     error LicenseRegistry__IndexOutOfBounds(address ipId, uint256 index, uint256 length);
     error LicenseRegistry__LicenseTermsAlreadyAttached(address ipId, address licenseTemplate, uint256 licenseTermsId);
     error LicenseRegistry__UnmatchedLicenseTemplate(address ipId, address licenseTemplate, address newLicenseTemplate);
-
+    error LicenseRegistry__DuplicateLicense(address ipId, address licenseTemplate, uint256 licenseTermsId);
     ////////////////////////////////////////////////////////////////////////////
     //                            LicenseToken                                  //
     ////////////////////////////////////////////////////////////////////////////

--- a/contracts/registries/LicenseRegistry.sol
+++ b/contracts/registries/LicenseRegistry.sol
@@ -238,9 +238,13 @@ contract LicenseRegistry is ILicenseRegistry, AccessManagedUpgradeable, UUPSUpgr
 
         for (uint256 i = 0; i < parentIpIds.length; i++) {
             _verifyDerivativeFromParent(parentIpIds[i], childIpId, licenseTemplate, licenseTermsIds[i]);
-            $.parentIps[childIpId].add(parentIpIds[i]);
             $.childIps[parentIpIds[i]].add(childIpId);
-            $.attachedLicenseTerms[childIpId].add(licenseTermsIds[i]);
+            // determine if duplicate license terms
+            bool isNewParent = $.parentIps[childIpId].add(parentIpIds[i]);
+            bool isNewTerms = $.attachedLicenseTerms[childIpId].add(licenseTermsIds[i]);
+            if (!isNewParent && !isNewTerms) {
+                revert Errors.LicenseRegistry__DuplicateLicense(parentIpIds[i], licenseTemplate, licenseTermsIds[i]);
+            }
         }
 
         $.licenseTemplates[childIpId] = licenseTemplate;

--- a/test/foundry/integration/flows/royalty/Royalty.t.sol
+++ b/test/foundry/integration/flows/royalty/Royalty.t.sol
@@ -82,7 +82,14 @@ contract Flows_Integration_Disputes is BaseIntegration {
 
             ipAcct[2] = registerIpAccount(address(mockNFT), 2, u.bob);
 
-            vm.expectRevert(Errors.RoyaltyPolicyLAP__AboveParentLimit.selector);
+            vm.expectRevert(
+                abi.encodeWithSelector(
+                    Errors.LicenseRegistry__DuplicateLicense.selector,
+                    ipAcct[1],
+                    address(pilTemplate),
+                    commRemixTermsId
+                )
+            );
             licensingModule.registerDerivativeWithLicenseTokens(ipAcct[2], licenseIds, "");
 
             // can link max two

--- a/test/foundry/registries/LicenseRegistry.t.sol
+++ b/test/foundry/registries/LicenseRegistry.t.sol
@@ -262,6 +262,40 @@ contract LicenseRegistryTest is BaseTest {
         licenseRegistry.getParentIp(ipId2, 1);
     }
 
+
+    function test_LicenseRegistry_registerDerivativeIp() public {
+        uint256 socialRemixTermsId = pilTemplate.registerLicenseTerms(PILFlavors.nonCommercialSocialRemixing());
+        vm.prank(ipOwner1);
+        licensingModule.attachLicenseTerms(ipId1, address(pilTemplate), socialRemixTermsId);
+        vm.prank(ipOwner2);
+        licensingModule.attachLicenseTerms(ipId2, address(pilTemplate), socialRemixTermsId);
+
+        address[] memory parentIpIds = new address[](2);
+        parentIpIds[0] = ipId1;
+        parentIpIds[1] = ipId2;
+        uint256[] memory licenseTermsIds = new uint256[](2);
+        licenseTermsIds[0] = socialRemixTermsId;
+        licenseTermsIds[1] = socialRemixTermsId;
+        vm.prank(address(licensingModule));
+        licenseRegistry.registerDerivativeIp(ipId3, parentIpIds, address(pilTemplate), licenseTermsIds);
+    }
+
+    function test_LicenseRegistry_registerDerivativeIp_revert_DuplicateLicense() public {
+        uint256 socialRemixTermsId = pilTemplate.registerLicenseTerms(PILFlavors.nonCommercialSocialRemixing());
+        vm.prank(ipOwner1);
+        licensingModule.attachLicenseTerms(ipId1, address(pilTemplate), socialRemixTermsId);
+
+        address[] memory parentIpIds = new address[](2);
+        parentIpIds[0] = ipId1;
+        parentIpIds[1] = ipId1;
+        uint256[] memory licenseTermsIds = new uint256[](2);
+        licenseTermsIds[0] = socialRemixTermsId;
+        licenseTermsIds[1] = socialRemixTermsId;
+        vm.expectRevert(abi.encodeWithSelector(Errors.LicenseRegistry__DuplicateLicense.selector, ipId1, address(pilTemplate), socialRemixTermsId));
+        vm.prank(address(licensingModule));
+        licenseRegistry.registerDerivativeIp(ipId2, parentIpIds, address(pilTemplate), licenseTermsIds);
+    }
+
     function onERC721Received(address, address, uint256, bytes memory) public pure returns (bytes4) {
         return this.onERC721Received.selector;
     }

--- a/test/foundry/registries/LicenseRegistry.t.sol
+++ b/test/foundry/registries/LicenseRegistry.t.sol
@@ -262,7 +262,6 @@ contract LicenseRegistryTest is BaseTest {
         licenseRegistry.getParentIp(ipId2, 1);
     }
 
-
     function test_LicenseRegistry_registerDerivativeIp() public {
         uint256 socialRemixTermsId = pilTemplate.registerLicenseTerms(PILFlavors.nonCommercialSocialRemixing());
         vm.prank(ipOwner1);
@@ -291,7 +290,14 @@ contract LicenseRegistryTest is BaseTest {
         uint256[] memory licenseTermsIds = new uint256[](2);
         licenseTermsIds[0] = socialRemixTermsId;
         licenseTermsIds[1] = socialRemixTermsId;
-        vm.expectRevert(abi.encodeWithSelector(Errors.LicenseRegistry__DuplicateLicense.selector, ipId1, address(pilTemplate), socialRemixTermsId));
+        vm.expectRevert(
+            abi.encodeWithSelector(
+                Errors.LicenseRegistry__DuplicateLicense.selector,
+                ipId1,
+                address(pilTemplate),
+                socialRemixTermsId
+            )
+        );
         vm.prank(address(licensingModule));
         licenseRegistry.registerDerivativeIp(ipId2, parentIpIds, address(pilTemplate), licenseTermsIds);
     }


### PR DESCRIPTION
This PR detects duplicate license terms when registering derivative and revert operations.

Closes #41 