### PR TITLE
Pause

### DIFF
--- a/contracts/interfaces/pause/IProtocolPauseAdmin.sol
+++ b/contracts/interfaces/pause/IProtocolPauseAdmin.sol
@@ -1,0 +1,40 @@
+// SPDX-License-Identifier: BUSL-1.1
+pragma solidity 0.8.23;
+
+/// @title ProtocolPauseAdmin
+/// @notice Contract that allows the pausing and unpausing of the protocol. It allows adding and removing
+/// pausable contracts, which are contracts that implement the `IPausable` interface.
+/// @dev The contract is restricted to be used only the admin role defined in the `AccessManaged` contract.
+/// NOTE: If a contract is upgraded to remove the `IPausable` interface, it should be removed from the list of pausables
+/// before the upgrade, otherwise pause() and unpause() will revert.
+interface IProtocolPauseAdmin {
+    /// @notice Emitted when a pausable contract is added.
+    event PausableAdded(address indexed pausable);
+    /// @notice Emitted when a pausable contract is removed.
+    event PausableRemoved(address indexed pausable);
+    /// @notice Emitted when the protocol is paused.
+    event ProtocolPaused();
+    /// @notice Emitted when the protocol is unpaused.
+    event ProtocolUnpaused();
+
+    /// @notice Adds a pausable contract to the list of pausables.
+    function addPausable(address pausable) external;
+
+    /// @notice Removes a pausable contract from the list of pausables.
+    function removePausable(address pausable) external;
+
+    /// @notice Pauses the protocol by calling the pause() function on all pausable contracts.
+    function pause() external;
+
+    /// @notice Unpauses the protocol by calling the unpause() function on all pausable contracts.
+    function unpause() external;
+
+    /// @notice Checks if a pausable contract is registered.
+    function isPausableRegistered(address pausable) external view returns (bool);
+
+    /// @notice Returns true if all the pausable contracts are paused.
+    function isAllProtocolPaused() external view returns (bool);
+
+    /// @notice Returns the list of pausable contracts.
+    function pausables() external view returns (address[] memory);
+}

--- a/contracts/lib/Errors.sol
+++ b/contracts/lib/Errors.sol
@@ -305,6 +305,7 @@ library Errors {
     error IpRoyaltyVault__ClaimerNotAnAncestor();
     error IpRoyaltyVault__IpTagged();
     error IpRoyaltyVault__ZeroDisputeModule();
+    error IpRoyaltyVault__EnforcedPause();
 
     ////////////////////////////////////////////////////////////////////////////
     //                             ModuleRegistry                             //
@@ -348,4 +349,12 @@ library Errors {
     //                         CoreMetadataModule                       //
     ////////////////////////////////////////////////////////////////////////////
     error CoreMetadataModule__MetadataAlreadyFrozen();
+
+    ////////////////////////////////////////////////////////////////////////////
+    //                            ProtocolPauseAdmin                              //
+    ////////////////////////////////////////////////////////////////////////////
+    error ProtocolPauseAdmin__ZeroAddress();
+    error ProtocolPauseAdmin__AddingPausedContract();
+    error ProtocolPauseAdmin__PausableAlreadyAdded();
+    error ProtocolPauseAdmin__PausableNotFound();
 }

--- a/contracts/lib/ProtocolAdmin.sol
+++ b/contracts/lib/ProtocolAdmin.sol
@@ -10,7 +10,10 @@ library ProtocolAdmin {
     string public constant PROTOCOL_ADMIN_ROLE_LABEL = "PROTOCOL_ADMIN_ROLE";
     /// @notice Public role, as it is used in AccessManager
     uint64 public constant PUBLIC_ROLE = type(uint64).max; // 2**64-1
-    /// @notice Upgrader role, as it is used in AccessManager
+    /// @notice Upgrader role. Grants ability to upgrade UUPS contracts.
     uint64 public constant UPGRADER_ROLE = 1;
     string public constant UPGRADER_ROLE_LABEL = "UPGRADER_ROLE";
+    /// @notice Pause admin role. Grants ability to pause and unpause contracts.
+    uint64 public constant PAUSE_ADMIN_ROLE = 2;
+    string public constant PAUSE_ADMIN_ROLE_LABEL = "PAUSE_ADMIN_ROLE";
 }

--- a/contracts/modules/royalty/RoyaltyModule.sol
+++ b/contracts/modules/royalty/RoyaltyModule.sol
@@ -5,8 +5,6 @@ import { ReentrancyGuardUpgradeable } from "@openzeppelin/contracts-upgradeable/
 import { UUPSUpgradeable } from "@openzeppelin/contracts-upgradeable/proxy/utils/UUPSUpgradeable.sol";
 import { ERC165Checker } from "@openzeppelin/contracts/utils/introspection/ERC165Checker.sol";
 import { IERC165 } from "@openzeppelin/contracts/utils/introspection/IERC165.sol";
-// solhint-disable-next-line max-line-length
-import { AccessManagedUpgradeable } from "@openzeppelin/contracts-upgradeable/access/manager/AccessManagedUpgradeable.sol";
 
 import { BaseModule } from "../BaseModule.sol";
 import { IRoyaltyModule } from "../../interfaces/modules/royalty/IRoyaltyModule.sol";
@@ -15,13 +13,14 @@ import { IDisputeModule } from "../../interfaces/modules/dispute/IDisputeModule.
 import { Errors } from "../../lib/Errors.sol";
 import { ROYALTY_MODULE_KEY } from "../../lib/modules/Module.sol";
 import { BaseModule } from "../BaseModule.sol";
+import { ProtocolPausableUpgradeable } from "../../pause/ProtocolPausableUpgradeable.sol";
 
 /// @title Story Protocol Royalty Module
 /// @notice The Story Protocol royalty module allows to set royalty policies an IP asset and pay royalties as a
 ///         derivative IP.
 contract RoyaltyModule is
     IRoyaltyModule,
-    AccessManagedUpgradeable,
+    ProtocolPausableUpgradeable,
     ReentrancyGuardUpgradeable,
     BaseModule,
     UUPSUpgradeable
@@ -61,7 +60,7 @@ contract RoyaltyModule is
         if (accessManager == address(0)) {
             revert Errors.RoyaltyModule__ZeroAccessManager();
         }
-        __AccessManaged_init(accessManager);
+        __ProtocolPausable_init(accessManager);
         __ReentrancyGuard_init();
         __UUPSUpgradeable_init();
     }
@@ -186,7 +185,7 @@ contract RoyaltyModule is
         address payerIpId,
         address token,
         uint256 amount
-    ) external nonReentrant {
+    ) external nonReentrant whenNotPaused {
         RoyaltyModuleStorage storage $ = _getRoyaltyModuleStorage();
         if (!$.isWhitelistedRoyaltyToken[token]) revert Errors.RoyaltyModule__NotWhitelistedRoyaltyToken();
 

--- a/contracts/modules/royalty/policies/RoyaltyPolicyLAP.sol
+++ b/contracts/modules/royalty/policies/RoyaltyPolicyLAP.sol
@@ -7,17 +7,21 @@ import { ReentrancyGuardUpgradeable } from "@openzeppelin/contracts-upgradeable/
 import { UUPSUpgradeable } from "@openzeppelin/contracts-upgradeable/proxy/utils/UUPSUpgradeable.sol";
 import { BeaconProxy } from "@openzeppelin/contracts/proxy/beacon/BeaconProxy.sol";
 import { UpgradeableBeacon } from "@openzeppelin/contracts/proxy/beacon/UpgradeableBeacon.sol";
-// solhint-disable-next-line max-line-length
-import { AccessManagedUpgradeable } from "@openzeppelin/contracts-upgradeable/access/manager/AccessManagedUpgradeable.sol";
 
 import { IIpRoyaltyVault } from "../../../interfaces/modules/royalty/policies/IIpRoyaltyVault.sol";
 import { IRoyaltyPolicyLAP } from "../../../interfaces/modules/royalty/policies/IRoyaltyPolicyLAP.sol";
 import { ArrayUtils } from "../../../lib/ArrayUtils.sol";
 import { Errors } from "../../../lib/Errors.sol";
+import { ProtocolPausableUpgradeable } from "../../../pause/ProtocolPausableUpgradeable.sol";
 
 /// @title Liquid Absolute Percentage Royalty Policy
 /// @notice Defines the logic for splitting royalties for a given ipId using a liquid absolute percentage mechanism
-contract RoyaltyPolicyLAP is IRoyaltyPolicyLAP, AccessManagedUpgradeable, ReentrancyGuardUpgradeable, UUPSUpgradeable {
+contract RoyaltyPolicyLAP is
+    IRoyaltyPolicyLAP,
+    ProtocolPausableUpgradeable,
+    ReentrancyGuardUpgradeable,
+    UUPSUpgradeable
+{
     using SafeERC20 for IERC20;
 
     /// @dev Storage structure for the RoyaltyPolicyLAP
@@ -76,7 +80,7 @@ contract RoyaltyPolicyLAP is IRoyaltyPolicyLAP, AccessManagedUpgradeable, Reentr
     /// @param accessManager The address of the protocol admin roles contract
     function initialize(address accessManager) external initializer {
         if (accessManager == address(0)) revert Errors.RoyaltyPolicyLAP__ZeroAccessManager();
-        __AccessManaged_init(accessManager);
+        __ProtocolPausable_init(accessManager);
         __ReentrancyGuard_init();
         __UUPSUpgradeable_init();
     }

--- a/contracts/pause/ProtocolPausableUpgradeable.sol
+++ b/contracts/pause/ProtocolPausableUpgradeable.sol
@@ -1,0 +1,31 @@
+// SPDX-License-Identifier: BUSL-1.1
+pragma solidity 0.8.23;
+
+// solhint-disable-next-line max-line-length
+import { AccessManagedUpgradeable } from "@openzeppelin/contracts-upgradeable/access/manager/AccessManagedUpgradeable.sol";
+import { PausableUpgradeable } from "@openzeppelin/contracts-upgradeable/utils/PausableUpgradeable.sol";
+
+/// @title ProtocolPausable
+/// @notice Contract that allows the pausing and unpausing of the a contract
+abstract contract ProtocolPausableUpgradeable is PausableUpgradeable, AccessManagedUpgradeable {
+    /// @notice Initializes the ProtocolPausable contract
+    /// @param accessManager The address of the access manager
+    function __ProtocolPausable_init(address accessManager) public initializer {
+        __AccessManaged_init(accessManager);
+        __Pausable_init();
+    }
+
+    /// @notice sets paused state
+    function pause() external restricted {
+        _pause();
+    }
+
+    /// @notice unsets unpaused state
+    function unpause() external restricted {
+        _unpause();
+    }
+
+    function paused() public view override returns (bool) {
+        return super.paused();
+    }
+}

--- a/contracts/pause/ProtocolPauseAdmin.sol
+++ b/contracts/pause/ProtocolPauseAdmin.sol
@@ -1,0 +1,94 @@
+// SPDX-License-Identifier: BUSL-1.1
+pragma solidity 0.8.23;
+
+import { AccessManaged } from "@openzeppelin/contracts/access/manager/AccessManaged.sol";
+import { EnumerableSet } from "@openzeppelin/contracts/utils/structs/EnumerableSet.sol";
+import { ProtocolPausableUpgradeable } from "./ProtocolPausableUpgradeable.sol";
+
+import { IProtocolPauseAdmin } from "../interfaces/pause/IProtocolPauseAdmin.sol";
+import { Errors } from "../lib/Errors.sol";
+
+/// @title ProtocolPauseAdmin
+/// @notice Contract that allows the pausing and unpausing of the protocol. It allows adding and removing
+/// pausable contracts, which are contracts that implement the `IPausable` interface.
+/// @dev The contract is restricted to be used only the admin role defined in the `AccessManaged` contract.
+/// NOTE: If a contract is upgraded to remove the `IPausable` interface, it should be removed from the list of pausables
+/// before the upgrade, otherwise pause() and unpause() will revert.
+contract ProtocolPauseAdmin is IProtocolPauseAdmin, AccessManaged {
+    using EnumerableSet for EnumerableSet.AddressSet;
+
+    EnumerableSet.AddressSet private _pausables;
+
+    constructor(address accessManager) AccessManaged(accessManager) {}
+
+    /// @notice Adds a pausable contract to the list of pausables.
+    /// @param pausable The address of the pausable contract.
+    function addPausable(address pausable) external restricted {
+        if (pausable == address(0)) {
+            revert Errors.ProtocolPauseAdmin__ZeroAddress();
+        }
+        if (ProtocolPausableUpgradeable(pausable).paused()) {
+            revert Errors.ProtocolPauseAdmin__AddingPausedContract();
+        }
+        if (!_pausables.add(pausable)) {
+            revert Errors.ProtocolPauseAdmin__PausableAlreadyAdded();
+        }
+        emit PausableAdded(pausable);
+    }
+
+    /// @notice Removes a pausable contract from the list of pausables.
+    /// @dev WARNING: If a contract is upgraded to remove the `IPausable` interface, it should be
+    /// removed from the list of pausables before the upgrade, otherwise pause() and unpause() will revert.
+    /// @param pausable The address of the pausable contract.
+    function removePausable(address pausable) external restricted {
+        if (!_pausables.remove(pausable)) {
+            revert Errors.ProtocolPauseAdmin__PausableNotFound();
+        }
+        emit PausableRemoved(pausable);
+    }
+
+    /// @notice Pauses the protocol by calling the pause() function on all pausable contracts.
+    function pause() external restricted {
+        uint256 length = _pausables.length();
+        for (uint256 i = 0; i < length; i++) {
+            ProtocolPausableUpgradeable p = ProtocolPausableUpgradeable(_pausables.at(i));
+            if (!p.paused()) {
+                p.pause();
+            }
+        }
+        emit ProtocolPaused();
+    }
+
+    /// @notice Unpauses the protocol by calling the unpause() function on all pausable contracts.
+    function unpause() external restricted {
+        uint256 length = _pausables.length();
+        for (uint256 i = 0; i < length; i++) {
+            ProtocolPausableUpgradeable p = ProtocolPausableUpgradeable(_pausables.at(i));
+            if (p.paused()) {
+                p.unpause();
+            }
+        }
+        emit ProtocolUnpaused();
+    }
+
+    /// @notice Checks if all pausable contracts are paused.
+    function isAllProtocolPaused() external view returns (bool) {
+        uint256 length = _pausables.length();
+        for (uint256 i = 0; i < length; i++) {
+            if (!ProtocolPausableUpgradeable(_pausables.at(i)).paused()) {
+                return false;
+            }
+        }
+        return true;
+    }
+
+    /// @notice Checks if a pausable contract is registered.
+    function isPausableRegistered(address pausable) external view returns (bool) {
+        return _pausables.contains(pausable);
+    }
+
+    /// @notice Checks if a pausable contract is registered.
+    function pausables() external view returns (address[] memory) {
+        return _pausables.values();
+    }
+}

--- a/contracts/registries/IPAssetRegistry.sol
+++ b/contracts/registries/IPAssetRegistry.sol
@@ -60,7 +60,11 @@ contract IPAssetRegistry is IIPAssetRegistry, IPAccountRegistry, ProtocolPausabl
     /// @param tokenContract The address of the NFT.
     /// @param tokenId The token identifier of the NFT.
     /// @return id The address of the newly registered IP.
-    function register(uint256 chainid, address tokenContract, uint256 tokenId) whenNotPaused external returns (address id) {
+    function register(
+        uint256 chainid,
+        address tokenContract,
+        uint256 tokenId
+    ) external whenNotPaused returns (address id) {
         id = registerIpAccount(chainid, tokenContract, tokenId);
         IIPAccount ipAccount = IIPAccount(payable(id));
 

--- a/contracts/registries/IPAssetRegistry.sol
+++ b/contracts/registries/IPAssetRegistry.sol
@@ -6,11 +6,10 @@ import { IERC721Metadata } from "@openzeppelin/contracts/token/ERC721/extensions
 import { ERC165Checker } from "@openzeppelin/contracts/utils/introspection/ERC165Checker.sol";
 import { Strings } from "@openzeppelin/contracts/utils/Strings.sol";
 import { UUPSUpgradeable } from "@openzeppelin/contracts-upgradeable/proxy/utils/UUPSUpgradeable.sol";
-// solhint-disable-next-line max-line-length
-import { AccessManagedUpgradeable } from "@openzeppelin/contracts-upgradeable/access/manager/AccessManagedUpgradeable.sol";
 
 import { IIPAccount } from "../interfaces/IIPAccount.sol";
 import { IIPAssetRegistry } from "../interfaces/registries/IIPAssetRegistry.sol";
+import { ProtocolPausableUpgradeable } from "../pause/ProtocolPausableUpgradeable.sol";
 import { IPAccountRegistry } from "../registries/IPAccountRegistry.sol";
 import { Errors } from "../lib/Errors.sol";
 import { IPAccountStorageOps } from "../lib/IPAccountStorageOps.sol";
@@ -24,7 +23,7 @@ import { IPAccountStorageOps } from "../lib/IPAccountStorageOps.sol";
 ///         attribution and an IP account for protocol authorization.
 ///         IMPORTANT: The IP account address, besides being used for protocol
 ///                    auth, is also the canonical IP identifier for the IP NFT.
-contract IPAssetRegistry is IIPAssetRegistry, IPAccountRegistry, AccessManagedUpgradeable, UUPSUpgradeable {
+contract IPAssetRegistry is IIPAssetRegistry, IPAccountRegistry, ProtocolPausableUpgradeable, UUPSUpgradeable {
     using ERC165Checker for address;
     using Strings for *;
     using IPAccountStorageOps for IIPAccount;
@@ -51,7 +50,7 @@ contract IPAssetRegistry is IIPAssetRegistry, IPAccountRegistry, AccessManagedUp
         if (accessManager == address(0)) {
             revert Errors.IPAssetRegistry__ZeroAccessManager();
         }
-        __AccessManaged_init(accessManager);
+        __ProtocolPausable_init(accessManager);
         __UUPSUpgradeable_init();
     }
 
@@ -61,7 +60,7 @@ contract IPAssetRegistry is IIPAssetRegistry, IPAccountRegistry, AccessManagedUp
     /// @param tokenContract The address of the NFT.
     /// @param tokenId The token identifier of the NFT.
     /// @return id The address of the newly registered IP.
-    function register(uint256 chainid, address tokenContract, uint256 tokenId) external returns (address id) {
+    function register(uint256 chainid, address tokenContract, uint256 tokenId) whenNotPaused external returns (address id) {
         id = registerIpAccount(chainid, tokenContract, tokenId);
         IIPAccount ipAccount = IIPAccount(payable(id));
 

--- a/script/foundry/utils/upgrades/ERC7201Helper.s.sol
+++ b/script/foundry/utils/upgrades/ERC7201Helper.s.sol
@@ -12,7 +12,7 @@ import { console2 } from "forge-std/console2.sol";
 contract ERC7201HelperScript is Script {
     
     string constant NAMESPACE = "story-protocol";
-    string constant CONTRACT_NAME = "MockIPRoyaltyVaultV2";
+    string constant CONTRACT_NAME = "IPAssetRegistry";
 
     function run() external {
         bytes memory erc7201Key = abi.encodePacked(NAMESPACE, ".", CONTRACT_NAME);

--- a/test/foundry/access/AccessController.t.sol
+++ b/test/foundry/access/AccessController.t.sol
@@ -1646,6 +1646,7 @@ contract AccessControllerTest is BaseTest {
             bytes4(0),
             AccessPermission.ALLOW
         );
+        
         vm.stopPrank();
         vm.expectRevert(abi.encodeWithSelector(PausableUpgradeable.EnforcedPause.selector));
         vm.prank(owner);

--- a/test/foundry/access/AccessController.t.sol
+++ b/test/foundry/access/AccessController.t.sol
@@ -11,6 +11,8 @@ import { MockERC1155 } from "../mocks/token/MockERC1155.sol";
 import { MockERC20 } from "../mocks/token/MockERC20.sol";
 import { BaseTest } from "../utils/BaseTest.t.sol";
 
+import { PausableUpgradeable } from "@openzeppelin/contracts-upgradeable/utils/PausableUpgradeable.sol";
+
 contract AccessControllerTest is BaseTest {
     MockModule public mockModule;
     MockModule public moduleWithoutPermission;
@@ -1630,5 +1632,34 @@ contract AccessControllerTest is BaseTest {
             abi.encodeWithSignature("balanceOf(address)", address(ipAccount))
         );
         assertEq(abi.decode(result, (uint256)), 1);
+    }
+
+    function test_AccessController_pause() public {
+        address signer = vm.addr(2);
+        vm.startPrank(u.admin);
+        accessController.pause();
+        vm.expectRevert(abi.encodeWithSelector(PausableUpgradeable.EnforcedPause.selector));
+        accessController.setPermission(
+            address(ipAccount),
+            signer,
+            address(mockModule),
+            bytes4(0),
+            AccessPermission.ALLOW
+        );
+        vm.stopPrank();
+        vm.expectRevert(abi.encodeWithSelector(PausableUpgradeable.EnforcedPause.selector));
+        vm.prank(owner);
+        ipAccount.execute(
+            address(accessController),
+            0,
+            abi.encodeWithSignature(
+                "setPermission(address,address,address,bytes4,uint8)",
+                address(ipAccount),
+                signer,
+                address(mockModule),
+                bytes4(0),
+                AccessPermission.ALLOW
+            )
+        );
     }
 }

--- a/test/foundry/mocks/MockProtocolPausable.sol
+++ b/test/foundry/mocks/MockProtocolPausable.sol
@@ -1,0 +1,10 @@
+// SPDX-License-Identifier: BUSL-1.1
+pragma solidity 0.8.23;
+
+import { ProtocolPausableUpgradeable } from "contracts/pause/ProtocolPausableUpgradeable.sol";
+
+contract MockProtocolPausable is ProtocolPausableUpgradeable {
+    function initialize(address accessManager) public initializer {
+        __ProtocolPausable_init(accessManager);
+    }
+}

--- a/test/foundry/modules/royalty/IpRoyaltyVault.t.sol
+++ b/test/foundry/modules/royalty/IpRoyaltyVault.t.sol
@@ -269,6 +269,16 @@ contract TestIpRoyaltyVault is BaseTest {
         ipRoyaltyVault.snapshot();
     }
 
+    function test_IpRoyaltyVault_Snapshot_revert_paused() public {
+        // payment is made to vault
+        vm.stopPrank();
+        vm.prank(u.admin);
+        royaltyPolicyLAP.pause();
+
+        vm.expectRevert(Errors.IpRoyaltyVault__EnforcedPause.selector);
+        ipRoyaltyVault.snapshot();
+    }
+
     function test_IpRoyaltyVault_Snapshot() public {
         // payment is made to vault
         uint256 royaltyAmount = 100000 * 10 ** 6;
@@ -408,5 +418,26 @@ contract TestIpRoyaltyVault is BaseTest {
             ancestorsVaultAmountBefore - ipRoyaltyVault.ancestorsVaultAmount(address(USDC)),
             accruedCollectableRevenue
         );
+    }
+
+    function test_IpRoyaltyVault_claimRevenue_revert_paused() public {
+        vm.stopPrank();
+        vm.prank(u.admin);
+        royaltyPolicyLAP.pause();
+
+        vm.expectRevert(Errors.IpRoyaltyVault__EnforcedPause.selector);
+        ipRoyaltyVault.claimRevenueBySnapshotBatch(new uint256[](0), address(USDC));
+
+        vm.expectRevert(Errors.IpRoyaltyVault__EnforcedPause.selector);
+        ipRoyaltyVault.claimRevenueByTokenBatch(1, new address[](0));
+    }
+
+    function test_IpRoyaltyVault_collectRoyaltyTokens_revert_paused() public {
+        vm.stopPrank();
+        vm.prank(u.admin);
+        royaltyPolicyLAP.pause();
+
+        vm.expectRevert(Errors.IpRoyaltyVault__EnforcedPause.selector);
+        ipRoyaltyVault.collectRoyaltyTokens(address(5));
     }
 }

--- a/test/foundry/pause/ProtocolPauseAdmin.t.sol
+++ b/test/foundry/pause/ProtocolPauseAdmin.t.sol
@@ -1,0 +1,119 @@
+// SPDX-License-Identifier: BUSL-1.1
+pragma solidity 0.8.23;
+
+import { Errors } from "contracts/lib/Errors.sol";
+import { ProtocolAdmin } from "contracts/lib/ProtocolAdmin.sol";
+import { IProtocolPauseAdmin } from "contracts/interfaces/pause/IProtocolPauseAdmin.sol";
+
+import { IAccessManaged } from "@openzeppelin/contracts/access/manager/IAccessManaged.sol";
+
+import { BaseTest } from "../utils/BaseTest.t.sol";
+import { MockProtocolPausable } from "../mocks/MockProtocolPausable.sol";
+import { TestProxyHelper } from "../utils/TestProxyHelper.sol";
+
+contract ProtocolPauseAdminTest is BaseTest {
+    MockProtocolPausable pausable;
+
+    function setUp() public override {
+        super.setUp();
+        address impl = address(new MockProtocolPausable());
+        pausable = MockProtocolPausable(
+            TestProxyHelper.deployUUPSProxy(
+                impl,
+                abi.encodeCall(MockProtocolPausable.initialize, address(protocolAccessManager))
+            )
+        );
+    }
+
+    function test_protocolPauser_validate_config() public {
+        assertTrue(protocolPauser.isPausableRegistered(address(accessController)));
+        assertTrue(protocolPauser.isPausableRegistered(address(disputeModule)));
+        assertTrue(protocolPauser.isPausableRegistered(address(licensingModule)));
+        assertTrue(protocolPauser.isPausableRegistered(address(royaltyModule)));
+        assertTrue(protocolPauser.isPausableRegistered(address(royaltyPolicyLAP)));
+        assertTrue(protocolPauser.isPausableRegistered(address(ipAssetRegistry)));
+    }
+
+    function test_protocolPauser_addPausable() public {
+        vm.expectEmit();
+        emit IProtocolPauseAdmin.PausableAdded(address(pausable));
+        vm.prank(u.admin);
+        protocolPauser.addPausable(address(pausable));
+        assertTrue(protocolPauser.isPausableRegistered(address(pausable)));
+    }
+
+    function test_protocolPauser_addPausable_revert_zero() public {
+        vm.prank(u.admin);
+        vm.expectRevert(Errors.ProtocolPauseAdmin__ZeroAddress.selector);
+        protocolPauser.addPausable(address(0));
+    }
+
+    function test_protocolPauser_addPausable_revert_notPausable() public {
+        vm.prank(u.admin);
+        vm.expectRevert();
+        protocolPauser.addPausable(address(u.admin));
+    }
+
+    function test_protocolPauser_addPausable_revert_paused() public {
+        vm.startPrank(u.admin);
+        pausable.pause();
+        vm.expectRevert();
+        protocolPauser.addPausable(address(pausable));
+        vm.stopPrank();
+    }
+
+    function test_protocolPauser_addPausable_revert_alreadyAdded() public {
+        vm.prank(u.admin);
+        vm.expectRevert(Errors.ProtocolPauseAdmin__PausableAlreadyAdded.selector);
+        protocolPauser.addPausable(address(licensingModule));
+    }
+
+    function test_protocolPauser_addPausable_revert_notAdmin() public {
+        vm.expectRevert(abi.encodeWithSelector(IAccessManaged.AccessManagedUnauthorized.selector, address(this)));
+        protocolPauser.addPausable(address(protocolPauser));
+    }
+
+    function test_protocolPauser_removePausable() public {
+        vm.startPrank(u.admin);
+        protocolPauser.addPausable(address(pausable));
+
+        vm.expectEmit();
+        emit IProtocolPauseAdmin.PausableRemoved(address(pausable));
+        protocolPauser.removePausable(address(pausable));
+        assertFalse(protocolPauser.isPausableRegistered(address(pausable)));
+        vm.stopPrank();
+    }
+
+    function test_protocolPauser_removePausable_notFound() public {
+        vm.prank(u.admin);
+        vm.expectRevert(Errors.ProtocolPauseAdmin__PausableNotFound.selector);
+        protocolPauser.removePausable(address(u.admin));
+    }
+
+    function test_ProtocolPauseAdmin_pause() public {
+        vm.prank(u.admin);
+        protocolAccessManager.grantRole(ProtocolAdmin.PAUSE_ADMIN_ROLE, address(u.bob), 0);
+
+        vm.prank(u.bob);
+        vm.expectEmit();
+        protocolPauser.pause();
+        assertTrue(protocolPauser.isAllProtocolPaused());
+    }
+
+    function test_ProtocolPauseAdmin_pause_revert_notPauser() public {
+        vm.expectRevert(abi.encodeWithSelector(IAccessManaged.AccessManagedUnauthorized.selector, address(this)));
+        protocolPauser.pause();
+    }
+
+    function test_ProtocolPauseAdmin_unpause() public {
+        vm.prank(u.admin);
+        protocolAccessManager.grantRole(ProtocolAdmin.PAUSE_ADMIN_ROLE, u.bob, 0);
+
+        vm.startPrank(u.bob);
+        protocolPauser.pause();
+        vm.expectEmit();
+        emit IProtocolPauseAdmin.ProtocolUnpaused();
+        protocolPauser.unpause();
+        assertFalse(protocolPauser.isAllProtocolPaused());
+    }
+}

--- a/test/foundry/registries/IPAssetRegistry.t.sol
+++ b/test/foundry/registries/IPAssetRegistry.t.sol
@@ -11,6 +11,7 @@ import { IPAccountStorageOps } from "contracts/lib/IPAccountStorageOps.sol";
 import { ShortStrings } from "@openzeppelin/contracts/utils/ShortStrings.sol";
 import { Strings } from "@openzeppelin/contracts/utils/Strings.sol";
 import { MockERC721WithoutMetadata } from "test/foundry/mocks/token/MockERC721WithoutMetadata.sol";
+import { PausableUpgradeable } from "@openzeppelin/contracts-upgradeable/utils/PausableUpgradeable.sol";
 
 import { BaseTest } from "../utils/BaseTest.t.sol";
 
@@ -116,6 +117,14 @@ contract IPAssetRegistryTest is BaseTest {
         registry.register(block.chainid, tokenAddress, tokenId);
     }
 
+    function test_IPAssetRegistry_revert_paused() public {
+        vm.prank(u.admin);
+        registry.pause();
+
+        vm.expectRevert(abi.encodeWithSelector(PausableUpgradeable.EnforcedPause.selector));
+        registry.register(1, tokenAddress, tokenId);
+    }
+
     /// @notice Tests registration of IP with non ERC721 token.
     function test_IPAssetRegistry_revert_InvalidTokenContract() public {
         // not an ERC721 contract
@@ -195,14 +204,14 @@ contract IPAssetRegistryTest is BaseTest {
     }
 
     /// @notice Helper function for generating an account address.
-    function _getIPAccount(uint256 chainid, uint256 tokenId) internal view returns (address) {
+    function _getIPAccount(uint256 chainid, uint256 _tokenId) internal view returns (address) {
         return
             erc6551Registry.account(
                 address(ipAccountImpl),
                 ipAccountRegistry.IP_ACCOUNT_SALT(),
                 chainid,
                 tokenAddress,
-                tokenId
+                _tokenId
             );
     }
 


### PR DESCRIPTION
Add pausing to the protocol. The PauseAdmin role can trigger individual pause in:
- accessController
- disputeModule
- licensingModule
- royaltyModule
- royaltyPolicyLAP (pauses all royalty vaults)
- ipAssetRegistry

We have a central `ProtocolPauser` that can be used to trigger them all.
`ProtocolPauser` must be configured with new modules and removed/upgraded modules that are not pausable anymore.
Individual pauses allows more flexibility to recover.