### PR TITLE
Add `isExpiredNow` Function to LicenseRegistry

### DIFF
--- a/contracts/interfaces/registries/ILicenseRegistry.sol
+++ b/contracts/interfaces/registries/ILicenseRegistry.sol
@@ -189,4 +189,9 @@ interface ILicenseRegistry {
     /// @param ipId The address of the IP.
     /// @return The expiration time, 0 means never expired.
     function getExpireTime(address ipId) external view returns (uint256);
+
+    /// @notice Checks if an IP is expired.
+    /// @param ipId The address of the IP.
+    /// @return Whether the IP is expired.
+    function isExpiredNow(address ipId) external view returns (bool);
 }

--- a/contracts/registries/LicenseRegistry.sol
+++ b/contracts/registries/LicenseRegistry.sol
@@ -422,6 +422,13 @@ contract LicenseRegistry is ILicenseRegistry, AccessManagedUpgradeable, UUPSUpgr
         return IIPAccount(payable(ipId)).getUint256(EXPIRATION_TIME);
     }
 
+    /// @notice Checks if an IP is expired.
+    /// @param ipId The address of the IP.
+    /// @return Whether the IP is expired.
+    function isExpiredNow(address ipId) external view returns (bool) {
+        return _isExpiredNow(ipId);
+    }
+
     /// @notice Returns the default license terms.
     function getDefaultLicenseTerms() external view returns (address licenseTemplate, uint256 licenseTermsId) {
         LicenseRegistryStorage storage $ = _getLicenseRegistryStorage();

--- a/test/foundry/registries/LicenseRegistry.t.sol
+++ b/test/foundry/registries/LicenseRegistry.t.sol
@@ -302,6 +302,22 @@ contract LicenseRegistryTest is BaseTest {
         licenseRegistry.registerDerivativeIp(ipId2, parentIpIds, address(pilTemplate), licenseTermsIds);
     }
 
+
+    function test_LicenseRegistry_isExpiredNow() public {
+        vm.startPrank(address(licensingModule));
+        licenseRegistry.setExpireTime(ipId1, block.timestamp + 100);
+        licenseRegistry.setExpireTime(ipId2, block.timestamp + 200);
+        vm.warp(block.timestamp + 101);
+        assertTrue(licenseRegistry.isExpiredNow(ipId1));
+        assertFalse(licenseRegistry.isExpiredNow(ipId2));
+        assertFalse(licenseRegistry.isExpiredNow(ipId3));
+        vm.warp(block.timestamp + 201);
+        assertTrue(licenseRegistry.isExpiredNow(ipId1));
+        assertTrue(licenseRegistry.isExpiredNow(ipId2));
+        assertFalse(licenseRegistry.isExpiredNow(ipId3));
+        vm.stopPrank();
+    }
+
     function onERC721Received(address, address, uint256, bytes memory) public pure returns (bytes4) {
         return this.onERC721Received.selector;
     }

--- a/test/foundry/registries/LicenseRegistry.t.sol
+++ b/test/foundry/registries/LicenseRegistry.t.sol
@@ -302,7 +302,6 @@ contract LicenseRegistryTest is BaseTest {
         licenseRegistry.registerDerivativeIp(ipId2, parentIpIds, address(pilTemplate), licenseTermsIds);
     }
 
-
     function test_LicenseRegistry_isExpiredNow() public {
         vm.startPrank(address(licensingModule));
         licenseRegistry.setExpireTime(ipId1, block.timestamp + 100);


### PR DESCRIPTION
This PR introduces the isExpiredNow function to the LicenseRegistry. This function checks the current expiration time of an IP and determines if it has expired based on the system's current time. This change is to address the requirements outlined in issue #68.