### PR TITLE
Upgrade beacon through RoyaltyPolicyLAP

### DIFF
--- a/contracts/modules/royalty/policies/RoyaltyPolicyLAP.sol
+++ b/contracts/modules/royalty/policies/RoyaltyPolicyLAP.sol
@@ -6,6 +6,7 @@ import { SafeERC20 } from "@openzeppelin/contracts/token/ERC20/utils/SafeERC20.s
 import { ReentrancyGuardUpgradeable } from "@openzeppelin/contracts-upgradeable/utils/ReentrancyGuardUpgradeable.sol";
 import { UUPSUpgradeable } from "@openzeppelin/contracts-upgradeable/proxy/utils/UUPSUpgradeable.sol";
 import { BeaconProxy } from "@openzeppelin/contracts/proxy/beacon/BeaconProxy.sol";
+import { UpgradeableBeacon } from "@openzeppelin/contracts/proxy/beacon/UpgradeableBeacon.sol";
 // solhint-disable-next-line max-line-length
 import { AccessManagedUpgradeable } from "@openzeppelin/contracts-upgradeable/access/manager/AccessManagedUpgradeable.sol";
 
@@ -95,6 +96,16 @@ contract RoyaltyPolicyLAP is IRoyaltyPolicyLAP, AccessManagedUpgradeable, Reentr
         if (beacon == address(0)) revert Errors.RoyaltyPolicyLAP__ZeroIpRoyaltyVaultBeacon();
         RoyaltyPolicyLAPStorage storage $ = _getRoyaltyPolicyLAPStorage();
         $.ipRoyaltyVaultBeacon = beacon;
+    }
+
+    /// @dev Upgrades the ip royalty vault beacon
+    /// @dev Enforced to be only callable by the upgrader admin
+    /// @param newVault The new ip royalty vault beacon address
+    function upgradeVaults(address newVault) public restricted {
+        // UpgradeableBeacon already checks for newImplementation.bytecode.length > 0,
+        // no need to check for zero address
+        RoyaltyPolicyLAPStorage storage $ = _getRoyaltyPolicyLAPStorage();
+        UpgradeableBeacon($.ipRoyaltyVaultBeacon).upgradeTo(newVault);
     }
 
     /// @notice Executes royalty related logic on minting a license

--- a/script/foundry/utils/upgrades/ERC7201Helper.s.sol
+++ b/script/foundry/utils/upgrades/ERC7201Helper.s.sol
@@ -12,7 +12,7 @@ import { console2 } from "forge-std/console2.sol";
 contract ERC7201HelperScript is Script {
     
     string constant NAMESPACE = "story-protocol";
-    string constant CONTRACT_NAME = "IPAssetRegistry";
+    string constant CONTRACT_NAME = "MockIPRoyaltyVaultV2";
 
     function run() external {
         bytes memory erc7201Key = abi.encodePacked(NAMESPACE, ".", CONTRACT_NAME);

--- a/test/foundry/mocks/module/MockIpRoyaltyVaultV2.sol
+++ b/test/foundry/mocks/module/MockIpRoyaltyVaultV2.sol
@@ -4,7 +4,6 @@ import { IpRoyaltyVault } from "contracts/modules/royalty/policies/IpRoyaltyVaul
 pragma solidity 0.8.23;
 
 contract MockIpRoyaltyVaultV2 is IpRoyaltyVault {
-
     /// @dev Storage structure for the MockIPRoyaltyVaultV2
     /// @custom:storage-location erc7201:story-protocol.MockIPRoyaltyVaultV2
     struct MockIPRoyaltyVaultV2Storage {
@@ -12,7 +11,8 @@ contract MockIpRoyaltyVaultV2 is IpRoyaltyVault {
     }
 
     // keccak256(abi.encode(uint256(keccak256("story-protocol.MockIPRoyaltyVaultV2")) - 1)) & ~bytes32(uint256(0xff));
-    bytes32 private constant MockIPRoyaltyVaultV2StorageLocation = 0x2942176f94974e015a9b06f79a3a2280d18f1872591c134ba237fa184e378300;
+    bytes32 private constant MockIPRoyaltyVaultV2StorageLocation =
+        0x2942176f94974e015a9b06f79a3a2280d18f1872591c134ba237fa184e378300;
 
     /// @custom:oz-upgrades-unsafe-allow constructor
     constructor(address royaltyPolicyLAP, address disputeModule) IpRoyaltyVault(royaltyPolicyLAP, disputeModule) {
@@ -33,5 +33,4 @@ contract MockIpRoyaltyVaultV2 is IpRoyaltyVault {
             $.slot := MockIPRoyaltyVaultV2StorageLocation
         }
     }
-        
 }

--- a/test/foundry/mocks/module/MockIpRoyaltyVaultV2.sol
+++ b/test/foundry/mocks/module/MockIpRoyaltyVaultV2.sol
@@ -1,0 +1,37 @@
+import { IpRoyaltyVault } from "contracts/modules/royalty/policies/IpRoyaltyVault.sol";
+
+// SPDX-License-Identifier: BUSL-1.1
+pragma solidity 0.8.23;
+
+contract MockIpRoyaltyVaultV2 is IpRoyaltyVault {
+
+    /// @dev Storage structure for the MockIPRoyaltyVaultV2
+    /// @custom:storage-location erc7201:story-protocol.MockIPRoyaltyVaultV2
+    struct MockIPRoyaltyVaultV2Storage {
+        string newState;
+    }
+
+    // keccak256(abi.encode(uint256(keccak256("story-protocol.MockIPRoyaltyVaultV2")) - 1)) & ~bytes32(uint256(0xff));
+    bytes32 private constant MockIPRoyaltyVaultV2StorageLocation = 0x2942176f94974e015a9b06f79a3a2280d18f1872591c134ba237fa184e378300;
+
+    /// @custom:oz-upgrades-unsafe-allow constructor
+    constructor(address royaltyPolicyLAP, address disputeModule) IpRoyaltyVault(royaltyPolicyLAP, disputeModule) {
+        _disableInitializers();
+    }
+
+    function set(string calldata value) external {
+        _getMockIPRoyaltyVaultV2Storage().newState = value;
+    }
+
+    function get() external view returns (string memory) {
+        return _getMockIPRoyaltyVaultV2Storage().newState;
+    }
+
+    /// @dev Returns the storage struct of MockIPRoyaltyVaultV2.
+    function _getMockIPRoyaltyVaultV2Storage() private pure returns (MockIPRoyaltyVaultV2Storage storage $) {
+        assembly {
+            $.slot := MockIPRoyaltyVaultV2StorageLocation
+        }
+    }
+        
+}

--- a/test/foundry/upgrades/IPRoyaltyVaults.t.sol
+++ b/test/foundry/upgrades/IPRoyaltyVaults.t.sol
@@ -1,0 +1,42 @@
+// SPDX-License-Identifier: BUSL-1.1
+pragma solidity 0.8.23;
+
+import { Errors } from "contracts/lib/Errors.sol";
+import { ProtocolAdmin } from "contracts/lib/ProtocolAdmin.sol";
+import { RoyaltyPolicyLAP } from "contracts/modules/royalty/policies/RoyaltyPolicyLAP.sol";
+
+import { UpgradeableBeacon } from "@openzeppelin/contracts/proxy/beacon/UpgradeableBeacon.sol";
+
+import { BaseTest } from "../utils/BaseTest.t.sol";
+
+
+import { MockIpRoyaltyVaultV2 } from "../mocks/module/MockIpRoyaltyVaultV2.sol";
+
+contract IPRoyaltyVaults is BaseTest {
+
+    function setUp() public override {
+        super.setUp();
+        vm.prank(u.admin);
+        protocolAccessManager.grantRole(ProtocolAdmin.UPGRADER_ROLE, u.alice, upgraderExecDelay);
+    }
+
+    function test_upgradeVaults() public {
+        address newVault = address(new MockIpRoyaltyVaultV2(address(royaltyPolicyLAP), address(disputeModule)));
+        (bool immediate, uint32 delay) = protocolAccessManager.canCall(u.alice, address(royaltyPolicyLAP), RoyaltyPolicyLAP.upgradeVaults.selector);
+        assertFalse(immediate);
+        assertEq(delay, 600);
+        vm.prank(u.alice);
+        (bytes32 operationId, uint32 nonce) = protocolAccessManager.schedule(
+            address(royaltyPolicyLAP),
+            abi.encodeCall(RoyaltyPolicyLAP.upgradeVaults, (newVault)),
+            0 // earliest time possible, upgraderExecDelay
+        );
+        vm.warp(upgraderExecDelay + 1);
+        
+        vm.prank(u.alice);
+        royaltyPolicyLAP.upgradeVaults(newVault);
+
+        assertEq(ipRoyaltyVaultBeacon.implementation(), newVault);
+    }
+
+}

--- a/test/foundry/upgrades/IPRoyaltyVaults.t.sol
+++ b/test/foundry/upgrades/IPRoyaltyVaults.t.sol
@@ -1,19 +1,14 @@
 // SPDX-License-Identifier: BUSL-1.1
 pragma solidity 0.8.23;
 
-import { Errors } from "contracts/lib/Errors.sol";
 import { ProtocolAdmin } from "contracts/lib/ProtocolAdmin.sol";
 import { RoyaltyPolicyLAP } from "contracts/modules/royalty/policies/RoyaltyPolicyLAP.sol";
 
-import { UpgradeableBeacon } from "@openzeppelin/contracts/proxy/beacon/UpgradeableBeacon.sol";
-
 import { BaseTest } from "../utils/BaseTest.t.sol";
-
 
 import { MockIpRoyaltyVaultV2 } from "../mocks/module/MockIpRoyaltyVaultV2.sol";
 
 contract IPRoyaltyVaults is BaseTest {
-
     function setUp() public override {
         super.setUp();
         vm.prank(u.admin);
@@ -22,7 +17,11 @@ contract IPRoyaltyVaults is BaseTest {
 
     function test_upgradeVaults() public {
         address newVault = address(new MockIpRoyaltyVaultV2(address(royaltyPolicyLAP), address(disputeModule)));
-        (bool immediate, uint32 delay) = protocolAccessManager.canCall(u.alice, address(royaltyPolicyLAP), RoyaltyPolicyLAP.upgradeVaults.selector);
+        (bool immediate, uint32 delay) = protocolAccessManager.canCall(
+            u.alice,
+            address(royaltyPolicyLAP),
+            RoyaltyPolicyLAP.upgradeVaults.selector
+        );
         assertFalse(immediate);
         assertEq(delay, 600);
         vm.prank(u.alice);
@@ -32,11 +31,10 @@ contract IPRoyaltyVaults is BaseTest {
             0 // earliest time possible, upgraderExecDelay
         );
         vm.warp(upgraderExecDelay + 1);
-        
+
         vm.prank(u.alice);
         royaltyPolicyLAP.upgradeVaults(newVault);
 
         assertEq(ipRoyaltyVaultBeacon.implementation(), newVault);
     }
-
 }


### PR DESCRIPTION
Although the royalty vault's beacon was already upgradeable by AccessManager contract (since it was the original admin), we are doing the following to make the process more consistent with the rest of `UPGRADER_ROLE` reserved methods
- Add method to upgrade royalty vaults in RoyaltyPolicyLAP, `restricted`
- Transfer ownership of the vault to RoyaltyPolicyLAP in `DeployHelper`
- Set the new method to be called by `UPGRADER_ROLE` like the others.
- Test it


Closes #49 