### PR TITLE
Move build-info into just the CI, for faster recompiles

### DIFF
--- a/.github/workflows/foundry_ci.yml
+++ b/.github/workflows/foundry_ci.yml
@@ -42,7 +42,7 @@ jobs:
       # This step requires full build to be run first
       - name: Upgrade Safety test
         run: |
-          forge clean && forge build
+          forge clean && forge build --build-info
       # npx @openzeppelin/upgrades-core validate out/build-info
 
       - name: Run Forge tests

--- a/README.md
+++ b/README.md
@@ -72,7 +72,7 @@ make # this builds
 
 ```sh
 forge clean
-forge compile
+forge compile --build-info
 npx @openzeppelin/upgrades-core@^1.32.3 validate out/build-info 
 ```
 

--- a/foundry.toml
+++ b/foundry.toml
@@ -9,7 +9,6 @@ optimizer_runs = 20000
 test = 'test'
 solc = '0.8.23'
 fs_permissions = [{ access = 'read-write', path = './deploy-out' }, { access = 'read', path = './out' }]
-build_info = true
 extra_output = ["storageLayout"]
 
 [rpc_endpoints]


### PR DESCRIPTION
So that running `forge test` won't recompile all the files.