### PR TITLE
Refactor ABSTAIN to UNSET

### DIFF
--- a/contracts/interfaces/access/IAccessController.sol
+++ b/contracts/interfaces/access/IAccessController.sol
@@ -26,9 +26,9 @@ interface IAccessController {
 
     /// @notice Sets the permission for a specific function call
     /// @dev Each policy is represented as a mapping from an IP account address to a signer address to a recipient
-    /// address to a function selector to a permission level. The permission level can be 0 (ABSTAIN), 1 (ALLOW), or
+    /// address to a function selector to a permission level. The permission level can be 0 (UNSET), 1 (ALLOW), or
     /// 2 (DENY).
-    /// @dev By default, all policies are set to 0 (ABSTAIN), which means that the permission is not set.
+    /// @dev By default, all policies are set to 0 (UNSET), which means that the permission is not set.
     /// The owner of ipAccount by default has all permission.
     /// address(0) => wildcard
     /// bytes4(0) => wildcard
@@ -44,7 +44,7 @@ interface IAccessController {
     /// Otherwise, the function is a noop.
     /// @dev This function checks the permission level for a specific function call.
     /// If a specific permission is set, it overrides the general (wildcard) permission.
-    /// If the current level permission is ABSTAIN, the final permission is determined by the upper level.
+    /// If the current level permission is UNSET, the final permission is determined by the upper level.
     /// @param ipAccount The address of the IP account that grants the permission for `signer`
     /// @param signer The address that can call `to` on behalf of the `ipAccount`
     /// @param to The address that can be called by the `signer` (currently only modules can be `to`)

--- a/contracts/lib/AccessPermission.sol
+++ b/contracts/lib/AccessPermission.sol
@@ -5,9 +5,9 @@ pragma solidity 0.8.23;
 /// @notice Library for IPAccount access control permissions.
 ///         These permissions are used by the AccessController.
 library AccessPermission {
-    /// @notice ABSTAIN means having not enough information to make decision at current level, deferred decision to up
+    /// @notice UNSET means having not enough information to make decision at current level, deferred decision to up
     /// level permission.
-    uint8 public constant ABSTAIN = 0;
+    uint8 public constant UNSET = 0;
 
     /// @notice ALLOW means the permission is granted to transaction signer to call the function.
     uint8 public constant ALLOW = 1;
@@ -20,7 +20,7 @@ library AccessPermission {
     /// @param signer The address that can call `to` on behalf of the `ipAccount`
     /// @param to The address that can be called by the `signer` (currently only modules can be `to`)
     /// @param func The function selector of `to` that can be called by the `signer` on behalf of the `ipAccount`
-    /// @param permission The permission level for the transaction (0 = ABSTAIN, 1 = ALLOW, 2 = DENY).
+    /// @param permission The permission level for the transaction (0 = UNSET, 1 = ALLOW, 2 = DENY).
     struct Permission {
         address ipAccount;
         address signer;

--- a/test/foundry/access/AccessController.t.sol
+++ b/test/foundry/access/AccessController.t.sol
@@ -224,7 +224,7 @@ contract AccessControllerTest is BaseTest {
                 address(mockModule),
                 mockModule.executeSuccessfully.selector
             ),
-            AccessPermission.ABSTAIN
+            AccessPermission.UNSET
         );
 
         accessController.checkPermission(
@@ -261,7 +261,7 @@ contract AccessControllerTest is BaseTest {
                 address(mockModule),
                 mockModule.executeSuccessfully.selector
             ),
-            AccessPermission.ABSTAIN
+            AccessPermission.UNSET
         );
         vm.expectRevert(
             abi.encodeWithSelector(
@@ -306,7 +306,7 @@ contract AccessControllerTest is BaseTest {
                 address(mockModule),
                 mockModule.executeSuccessfully.selector
             ),
-            AccessPermission.ABSTAIN
+            AccessPermission.UNSET
         );
         accessController.checkPermission(
             address(ipAccount),
@@ -342,7 +342,7 @@ contract AccessControllerTest is BaseTest {
                 address(mockModule),
                 mockModule.executeSuccessfully.selector
             ),
-            AccessPermission.ABSTAIN
+            AccessPermission.UNSET
         );
         vm.expectRevert(
             abi.encodeWithSelector(
@@ -626,7 +626,7 @@ contract AccessControllerTest is BaseTest {
                 address(mockModule),
                 mockModule.executeSuccessfully.selector
             ),
-            AccessPermission.ABSTAIN
+            AccessPermission.UNSET
         );
 
         accessController.checkPermission(
@@ -682,7 +682,7 @@ contract AccessControllerTest is BaseTest {
                 address(mockModule),
                 mockModule.executeSuccessfully.selector
             ),
-            AccessPermission.ABSTAIN
+            AccessPermission.UNSET
         );
         vm.expectRevert(
             abi.encodeWithSelector(
@@ -1211,7 +1211,7 @@ contract AccessControllerTest is BaseTest {
                 address(mockModule),
                 mockModule.executeSuccessfully.selector
             ),
-            AccessPermission.ABSTAIN
+            AccessPermission.UNSET
         );
     }
 
@@ -1292,7 +1292,7 @@ contract AccessControllerTest is BaseTest {
                 address(mockModule),
                 mockModule.executeSuccessfully.selector
             ),
-            AccessPermission.ABSTAIN
+            AccessPermission.UNSET
         );
 
         vm.prank(address(0xbeefbeef));


### PR DESCRIPTION
Reviewing AccessController logic, ABSTAIN confused me because of the connotations.
It's used as indicative of 0, no value set yet.
UNSET helped me understand better.