### PR TITLE
Introduction of CREATE3 for Deployment to Deterministic Addresses to Resolve Cyclical Dependencies 

### DIFF
--- a/package.json
+++ b/package.json
@@ -59,6 +59,7 @@
         "@openzeppelin/contracts": "5.0.2",
         "@openzeppelin/contracts-upgradeable": "5.0.2",
         "@openzeppelin/contracts-upgradeable-v4": "npm:@openzeppelin/contracts-upgradeable@4.9.6",
-        "erc6551": "^0.3.1"
+        "erc6551": "^0.3.1",
+        "solady": "^0.0.191"
     }
 }

--- a/remappings.txt
+++ b/remappings.txt
@@ -2,3 +2,4 @@ ds-test/=node_modules/ds-test/src/
 forge-std/=node_modules/forge-std/src/
 @openzeppelin/=node_modules/@openzeppelin/
 @openzeppelin-foundry-upgrades/=lib/openzeppelin-foundry-upgrades
+@solady/=node_modules/solady/

--- a/script/foundry/utils/DeployHelper.sol
+++ b/script/foundry/utils/DeployHelper.sol
@@ -11,6 +11,7 @@ import { stdJson } from "forge-std/StdJson.sol";
 import { ERC6551Registry } from "erc6551/ERC6551Registry.sol";
 import { AccessManager } from "@openzeppelin/contracts/access/manager/AccessManager.sol";
 import { UUPSUpgradeable } from "@openzeppelin/contracts-upgradeable/proxy/utils/UUPSUpgradeable.sol";
+import { CREATE3 } from "@solady/src/utils/CREATE3.sol";
 
 // contracts
 import { ProtocolPauseAdmin } from "contracts/pause/ProtocolPauseAdmin.sol";
@@ -157,8 +158,16 @@ contract DeployHelper is Script, BroadcastManager, JsonDeploymentHandler, Storag
         _endBroadcast(); // BroadcastManager.s.sol
     }
 
+    function create3Deploy(bytes32 salt, bytes calldata creationCode, uint256 value) external returns (address) {
+        return CREATE3.deploy(salt, creationCode, value);
+    }
+
     function _deployProtocolContracts() private {
         require(address(erc20) != address(0), "Deploy: Asset Not Set");
+        bytes32 ipAccountImplSalt = keccak256(
+            abi.encode(type(IPAccountImpl).creationCode, address(this), block.timestamp)
+        );
+        address ipAccountImplAddr = CREATE3.getDeployed(ipAccountImplSalt);
 
         string memory contractKey;
 
@@ -187,11 +196,6 @@ contract DeployHelper is Script, BroadcastManager, JsonDeploymentHandler, Storag
         impl = address(0); // Make sure we don't deploy wrong impl
         _postdeploy(contractKey, address(accessController));
 
-        contractKey = "IPAccountImpl";
-        _predeploy(contractKey);
-        ipAccountImpl = new IPAccountImpl(address(accessController));
-        _postdeploy(contractKey, address(ipAccountImpl));
-
         contractKey = "ModuleRegistry";
         _predeploy(contractKey);
         impl = address(new ModuleRegistry());
@@ -206,12 +210,7 @@ contract DeployHelper is Script, BroadcastManager, JsonDeploymentHandler, Storag
 
         contractKey = "IPAssetRegistry";
         _predeploy(contractKey);
-        impl = address(
-            new IPAssetRegistry(
-                address(erc6551Registry),
-                address(ipAccountImpl)
-            )
-        );
+        impl = address(new IPAssetRegistry(address(erc6551Registry), ipAccountImplAddr));
         ipAssetRegistry = IPAssetRegistry(
             TestProxyHelper.deployUUPSProxy(
                 impl,
@@ -246,6 +245,18 @@ contract DeployHelper is Script, BroadcastManager, JsonDeploymentHandler, Storag
         );
         impl = address(0); // Make sure we don't deploy wrong impl
         _postdeploy(contractKey, address(licenseRegistry));
+
+        contractKey = "IPAccountImpl";
+        bytes memory ipAccountImplCode = abi.encodePacked(
+            type(IPAccountImpl).creationCode,
+            abi.encode(
+                address(accessController)
+            )
+        );
+        _predeploy(contractKey);
+        this.create3Deploy(ipAccountImplSalt, ipAccountImplCode, 0);
+        ipAccountImpl = IPAccountImpl(payable(ipAccountImplAddr));
+        _postdeploy(contractKey, address(ipAccountImpl));
 
         contractKey = "DisputeModule";
         _predeploy(contractKey);

--- a/test/foundry/integration/flows/licensing/LicensingIntegration.t.sol
+++ b/test/foundry/integration/flows/licensing/LicensingIntegration.t.sol
@@ -6,6 +6,7 @@ import { Test } from "forge-std/Test.sol";
 import { ERC6551Registry } from "erc6551/ERC6551Registry.sol";
 import { UpgradeableBeacon } from "@openzeppelin/contracts/proxy/beacon/UpgradeableBeacon.sol";
 import { AccessManager } from "@openzeppelin/contracts/access/manager/AccessManager.sol";
+import { CREATE3 } from "@solady/src/utils/CREATE3.sol";
 
 // contracts
 import { AccessController } from "../../../../../contracts/access/AccessController.sol";
@@ -74,6 +75,12 @@ contract e2e is Test {
         protocolAccessManager = new AccessManager(admin);
 
         // Deploy contracts
+
+        bytes32 ipAccountImplSalt = keccak256(
+            abi.encode(type(IPAccountImpl).creationCode, address(this), block.timestamp)
+        );
+        address ipAccountImplAddr = CREATE3.getDeployed(ipAccountImplSalt);
+
         address impl = address(new AccessController());
         accessController = AccessController(
             TestProxyHelper.deployUUPSProxy(
@@ -91,8 +98,7 @@ contract e2e is Test {
         );
 
         erc6551Registry = new ERC6551Registry();
-        ipAccountImpl = new IPAccountImpl(address(accessController));
-        impl = address(new IPAssetRegistry(address(erc6551Registry), address(ipAccountImpl)));
+        impl = address(new IPAssetRegistry(address(erc6551Registry), ipAccountImplAddr));
         ipAssetRegistry = IPAssetRegistry(
             TestProxyHelper.deployUUPSProxy(
                 impl,
@@ -107,6 +113,18 @@ contract e2e is Test {
                 abi.encodeCall(LicenseRegistry.initialize, (address(protocolAccessManager)))
             )
         );
+
+        bytes memory ipAccountImplCode = abi.encodePacked(
+            type(IPAccountImpl).creationCode,
+            abi.encode(
+                address(accessController),
+                address(ipAssetRegistry),
+                address(licenseRegistry),
+                address(moduleRegistry)
+            )
+        );
+        this.create3Deploy(ipAccountImplSalt, ipAccountImplCode, 0);
+        ipAccountImpl = IPAccountImpl(payable(ipAccountImplAddr));
 
         impl = address(new LicenseToken());
         licenseToken = LicenseToken(
@@ -228,6 +246,10 @@ contract e2e is Test {
         licenseToken.setLicensingModule(address(licensingModule));
 
         vm.stopPrank();
+    }
+
+    function create3Deploy(bytes32 salt, bytes calldata creationCode, uint256 value) external returns (address) {
+        return CREATE3.deploy(salt, creationCode, value);
     }
 
     function test_e2e() public {


### PR DESCRIPTION
This PR introduces an enhancement to our deployment process with the introduction of `CREATE3`. Here's a brief overview of the changes:

1. **Introduction of `CREATE3`:** We have introduced `CREATE3`, a feature that allows deployment to a deterministic address using only a salt. This is a major advancement in resolving cyclical dependencies within our system. 

2. **Immutable Addresses for Dependencies:** The introduction of `CREATE3` allows us to store dependencies as immutable addresses. This eliminates the need for governed functions to set these addresses, further simplifying our protocol.

3. **Simplified Protocol Post Configurations:**  No need to configure dependencies' addresses through the governance process after deployment.