### PR TITLE
Optimize License Token Metadata Struct

### DIFF
--- a/contracts/LicenseToken.sol
+++ b/contracts/LicenseToken.sol
@@ -101,7 +101,7 @@ contract LicenseToken is ILicenseToken, ERC721EnumerableUpgradeable, AccessManag
     function mintLicenseTokens(
         address licensorIpId,
         address licenseTemplate,
-        uint256 licenseTermsId,
+        uint32 licenseTermsId,
         uint256 amount, // mint amount
         address minter,
         address receiver
@@ -111,8 +111,8 @@ contract LicenseToken is ILicenseToken, ERC721EnumerableUpgradeable, AccessManag
             licenseTemplate: licenseTemplate,
             licenseTermsId: licenseTermsId,
             transferable: ILicenseTemplate(licenseTemplate).isLicenseTransferable(licenseTermsId),
-            mintedAt: block.timestamp,
-            expiresAt: ILicenseTemplate(licenseTemplate).getExpireTime(licenseTermsId, block.timestamp)
+            mintedAt: uint40(block.timestamp),
+            expiresAt: ILicenseTemplate(licenseTemplate).getExpireTime(licenseTermsId, uint40(block.timestamp))
         });
 
         LicenseTokenStorage storage $ = _getLicenseTokenStorage();
@@ -149,15 +149,11 @@ contract LicenseToken is ILicenseToken, ERC721EnumerableUpgradeable, AccessManag
         address childIpId,
         address childIpOwner,
         uint256[] calldata tokenIds
-    )
-        external
-        view
-        returns (address licenseTemplate, address[] memory licensorIpIds, uint256[] memory licenseTermsIds)
-    {
+    ) external view returns (address licenseTemplate, address[] memory licensorIpIds, uint32[] memory licenseTermsIds) {
         LicenseTokenStorage storage $ = _getLicenseTokenStorage();
         licenseTemplate = $.licenseTokenMetadatas[tokenIds[0]].licenseTemplate;
         licensorIpIds = new address[](tokenIds.length);
-        licenseTermsIds = new uint256[](tokenIds.length);
+        licenseTermsIds = new uint32[](tokenIds.length);
 
         for (uint256 i = 0; i < tokenIds.length; i++) {
             LicenseTokenMetadata memory ltm = $.licenseTokenMetadatas[tokenIds[i]];
@@ -203,7 +199,7 @@ contract LicenseToken is ILicenseToken, ERC721EnumerableUpgradeable, AccessManag
 
     /// @notice Returns the ID of the license terms that are used for the given license ID
     /// @param tokenId The ID of the license token
-    function getLicenseTermsId(uint256 tokenId) external view returns (uint256) {
+    function getLicenseTermsId(uint256 tokenId) external view returns (uint32) {
         return _getLicenseTokenStorage().licenseTokenMetadatas[tokenId].licenseTermsId;
     }
 

--- a/contracts/interfaces/ILicenseToken.sol
+++ b/contracts/interfaces/ILicenseToken.sol
@@ -15,19 +15,20 @@ import { IERC721Enumerable } from "@openzeppelin/contracts/token/ERC721/extensio
 /// metadata.
 interface ILicenseToken is IERC721Metadata, IERC721Enumerable {
     /// @notice Metadata struct for License Tokens.
+    /// @dev Struct layout for 2 storage slots.
     /// @param licensorIpId The ID of the licensor IP for which the License Token was minted.
-    /// @param licenseTemplate The address of the License Template associated with the License Token.
-    /// @param licenseTermsId The ID of the License Terms associated with the License Token.
     /// @param transferable Whether the License Token is transferable, determined by the License Terms.
+    /// @param licenseTermsId The ID of the License Terms associated with the License Token.
+    /// @param licenseTemplate The address of the License Template associated with the License Token.
     /// @param mintedAt The timestamp at which the License Token was minted.
     /// @param expiresAt The timestamp at which the License Token expires.
     struct LicenseTokenMetadata {
         address licensorIpId;
-        address licenseTemplate;
-        uint256 licenseTermsId;
         bool transferable;
-        uint256 mintedAt;
-        uint256 expiresAt;
+        uint32 licenseTermsId;
+        address licenseTemplate;
+        uint40 mintedAt;
+        uint40 expiresAt;
     }
 
     /// @notice Emitted when a License Token is minted.
@@ -48,7 +49,7 @@ interface ILicenseToken is IERC721Metadata, IERC721Enumerable {
     function mintLicenseTokens(
         address licensorIpId,
         address licenseTemplate,
-        uint256 licenseTermsId,
+        uint32 licenseTermsId,
         uint256 amount, // mint amount
         address minter,
         address receiver
@@ -71,7 +72,7 @@ interface ILicenseToken is IERC721Metadata, IERC721Enumerable {
 
     /// @notice Returns the ID of the license terms that are used for the given license ID
     /// @param tokenId The ID of the license token
-    function getLicenseTermsId(uint256 tokenId) external view returns (uint256);
+    function getLicenseTermsId(uint256 tokenId) external view returns (uint32);
 
     /// @notice Returns the address of the license template that is used for the given license ID
     /// @param tokenId The ID of the license token
@@ -107,5 +108,5 @@ interface ILicenseToken is IERC721Metadata, IERC721Enumerable {
         address childIpId,
         address childIpOwner,
         uint256[] calldata tokenIds
-    ) external view returns (address licenseTemplate, address[] memory licensorIpIds, uint256[] memory licenseTermsIds);
+    ) external view returns (address licenseTemplate, address[] memory licensorIpIds, uint32[] memory licenseTermsIds);
 }

--- a/contracts/interfaces/modules/licensing/ILicenseTemplate.sol
+++ b/contracts/interfaces/modules/licensing/ILicenseTemplate.sol
@@ -16,7 +16,7 @@ interface ILicenseTemplate is IERC165 {
     /// @param licenseTermsId The ID of the license terms.
     /// @param licenseTemplate The address of the license template.
     /// @param licenseTerms The data of the license.
-    event LicenseTermsRegistered(uint256 indexed licenseTermsId, address indexed licenseTemplate, bytes licenseTerms);
+    event LicenseTermsRegistered(uint32 indexed licenseTermsId, address indexed licenseTemplate, bytes licenseTerms);
 
     /// @notice Returns the name of the license template.
     /// @return The name of the license template.
@@ -27,7 +27,7 @@ interface ILicenseTemplate is IERC165 {
     /// hence the json format should follow the common NFT metadata standard.
     /// @param licenseTermsId The ID of the license terms.
     /// @return The JSON string of the license terms.
-    function toJson(uint256 licenseTermsId) external view returns (string memory);
+    function toJson(uint32 licenseTermsId) external view returns (string memory);
 
     /// @notice Returns the metadata URI of the license template.
     /// @return The metadata URI of the license template.
@@ -36,33 +36,33 @@ interface ILicenseTemplate is IERC165 {
     /// @notice Returns the URI of the license terms.
     /// @param licenseTermsId The ID of the license terms.
     /// @return The URI of the license terms.
-    function getLicenseTermsURI(uint256 licenseTermsId) external view returns (string memory);
+    function getLicenseTermsURI(uint32 licenseTermsId) external view returns (string memory);
 
     /// @notice Returns the total number of registered license terms.
     /// @return The total number of registered license terms.
-    function totalRegisteredLicenseTerms() external view returns (uint256);
+    function totalRegisteredLicenseTerms() external view returns (uint32);
 
     /// @notice Checks if a license terms exists.
     /// @param licenseTermsId The ID of the license terms.
     /// @return True if the license terms exists, false otherwise.
-    function exists(uint256 licenseTermsId) external view returns (bool);
+    function exists(uint32 licenseTermsId) external view returns (bool);
 
     /// @notice Checks if a license terms is transferable.
     /// @param licenseTermsId The ID of the license terms.
     /// @return True if the license terms is transferable, false otherwise.
-    function isLicenseTransferable(uint256 licenseTermsId) external view returns (bool);
+    function isLicenseTransferable(uint32 licenseTermsId) external view returns (bool);
 
     /// @notice Returns the earliest expiration time among the given license terms.
-    /// @param start The start time to calculate the expiration time.
     /// @param licenseTermsIds The IDs of the license terms.
+    /// @param start The start time to calculate the expiration time.
     /// @return The earliest expiration time.
-    function getEarlierExpireTime(uint256[] calldata licenseTermsIds, uint256 start) external view returns (uint256);
+    function getEarlierExpireTime(uint32[] calldata licenseTermsIds, uint40 start) external view returns (uint40);
 
     /// @notice Returns the expiration time of a license terms.
-    /// @param start The start time.
     /// @param licenseTermsId The ID of the license terms.
+    /// @param start The start time.
     /// @return The expiration time.
-    function getExpireTime(uint256 licenseTermsId, uint256 start) external view returns (uint256);
+    function getExpireTime(uint32 licenseTermsId, uint40 start) external view returns (uint40);
 
     /// @notice Returns the royalty policy of a license terms.
     /// @dev All License Templates should implement this method.
@@ -76,7 +76,7 @@ interface ILicenseTemplate is IERC165 {
     /// @return currencyToken The address of the ERC20 token, used for minting license fee and royalties.
     /// the currency token will used for pay for license token minting fee and royalties.
     function getRoyaltyPolicy(
-        uint256 licenseTermsId
+        uint32 licenseTermsId
     )
         external
         view
@@ -91,7 +91,7 @@ interface ILicenseTemplate is IERC165 {
     /// @param amount The amount of licenses to mint.
     /// @return True if the minting is verified, false otherwise.
     function verifyMintLicenseToken(
-        uint256 licenseTermsId,
+        uint32 licenseTermsId,
         address licensee,
         address licensorIpId,
         uint256 amount
@@ -109,7 +109,7 @@ interface ILicenseTemplate is IERC165 {
     function verifyRegisterDerivative(
         address childIpId,
         address parentIpId,
-        uint256 licenseTermsId,
+        uint32 licenseTermsId,
         address licensee
     ) external returns (bool);
 
@@ -119,7 +119,7 @@ interface ILicenseTemplate is IERC165 {
     /// It ensures that the licenses of all parent IPs are compatible with each other during the registration process.
     /// @param licenseTermsIds The IDs of the license terms.
     /// @return True if the licenses are compatible, false otherwise.
-    function verifyCompatibleLicenses(uint256[] calldata licenseTermsIds) external view returns (bool);
+    function verifyCompatibleLicenses(uint32[] calldata licenseTermsIds) external view returns (bool);
 
     /// @notice Verifies the registration of a derivative for all parent IPs.
     /// @dev This function is called by the LicensingModule to verify licenses for registering a derivative IP
@@ -134,7 +134,7 @@ interface ILicenseTemplate is IERC165 {
     function verifyRegisterDerivativeForAllParents(
         address childIpId,
         address[] calldata parentIpId,
-        uint256[] calldata licenseTermsIds,
+        uint32[] calldata licenseTermsIds,
         address childIpOwner
     ) external returns (bool);
 }

--- a/contracts/interfaces/modules/licensing/ILicensingModule.sol
+++ b/contracts/interfaces/modules/licensing/ILicensingModule.sol
@@ -19,7 +19,7 @@ interface ILicensingModule is IModule {
         address indexed caller,
         address indexed ipId,
         address licenseTemplate,
-        uint256 licenseTermsId
+        uint32 licenseTermsId
     );
 
     /// @notice Emitted when license tokens are minted.
@@ -34,7 +34,7 @@ interface ILicensingModule is IModule {
         address indexed caller,
         address indexed licensorIpId,
         address licenseTemplate,
-        uint256 indexed licenseTermsId,
+        uint32 indexed licenseTermsId,
         uint256 amount,
         address receiver,
         uint256 startLicenseTokenId
@@ -52,7 +52,7 @@ interface ILicensingModule is IModule {
         address indexed childIpId,
         uint256[] licenseTokenIds,
         address[] parentIpIds,
-        uint256[] licenseTermsIds,
+        uint32[] licenseTermsIds,
         address licenseTemplate
     );
 
@@ -61,7 +61,7 @@ interface ILicensingModule is IModule {
     /// @param ipId The IP ID.
     /// @param licenseTemplate The address of the license template.
     /// @param licenseTermsId The ID of the license terms.
-    function attachLicenseTerms(address ipId, address licenseTemplate, uint256 licenseTermsId) external;
+    function attachLicenseTerms(address ipId, address licenseTemplate, uint32 licenseTermsId) external;
 
     /// @notice Mints license tokens for the license terms attached to an IP.
     /// The license tokens are minted to the receiver.
@@ -85,7 +85,7 @@ interface ILicensingModule is IModule {
     function mintLicenseTokens(
         address licensorIpId,
         address licenseTemplate,
-        uint256 licenseTermsId,
+        uint32 licenseTermsId,
         uint256 amount,
         address receiver,
         bytes calldata royaltyContext
@@ -104,7 +104,7 @@ interface ILicensingModule is IModule {
     function registerDerivative(
         address childIpId,
         address[] calldata parentIpIds,
-        uint256[] calldata licenseTermsIds,
+        uint32[] calldata licenseTermsIds,
         address licenseTemplate,
         bytes calldata royaltyContext
     ) external;

--- a/contracts/interfaces/modules/licensing/IPILicenseTemplate.sol
+++ b/contracts/interfaces/modules/licensing/IPILicenseTemplate.sol
@@ -29,7 +29,7 @@ struct PILTerms {
     bool transferable;
     address royaltyPolicy;
     uint256 mintingFee;
-    uint256 expiration;
+    uint40 expiration;
     bool commercialUse;
     bool commercialAttribution;
     address commercializerChecker;
@@ -53,15 +53,15 @@ interface IPILicenseTemplate is ILicenseTemplate {
     /// @notice Registers new license terms.
     /// @param terms The PILTerms to register.
     /// @return selectedLicenseTermsId The ID of the newly registered license terms.
-    function registerLicenseTerms(PILTerms calldata terms) external returns (uint256 selectedLicenseTermsId);
+    function registerLicenseTerms(PILTerms calldata terms) external returns (uint32 selectedLicenseTermsId);
 
     /// @notice Gets the ID of the given license terms.
     /// @param terms The PILTerms to get the ID for.
     /// @return selectedLicenseTermsId The ID of the given license terms.
-    function getLicenseTermsId(PILTerms calldata terms) external view returns (uint256 selectedLicenseTermsId);
+    function getLicenseTermsId(PILTerms calldata terms) external view returns (uint32 selectedLicenseTermsId);
 
     /// @notice Gets license terms of the given ID.
     /// @param selectedLicenseTermsId The ID of the license terms.
     /// @return terms The PILTerms associate with the given ID.
-    function getLicenseTerms(uint256 selectedLicenseTermsId) external view returns (PILTerms memory terms);
+    function getLicenseTerms(uint32 selectedLicenseTermsId) external view returns (PILTerms memory terms);
 }

--- a/contracts/interfaces/registries/ILicenseRegistry.sol
+++ b/contracts/interfaces/registries/ILicenseRegistry.sol
@@ -16,7 +16,7 @@ interface ILicenseRegistry {
     event MintingLicenseConfigSetLicense(
         address indexed ipId,
         address indexed licenseTemplate,
-        uint256 indexed licenseTermsId
+        uint32 indexed licenseTermsId
     );
 
     /// @notice Emitted when a minting license configuration is set for all licenses of an IP.
@@ -28,10 +28,10 @@ interface ILicenseRegistry {
     /// @notice Sets the default license terms that are attached to all IPs by default.
     /// @param newLicenseTemplate The address of the new default license template.
     /// @param newLicenseTermsId The ID of the new default license terms.
-    function setDefaultLicenseTerms(address newLicenseTemplate, uint256 newLicenseTermsId) external;
+    function setDefaultLicenseTerms(address newLicenseTemplate, uint32 newLicenseTermsId) external;
 
     /// @notice Returns the default license terms.
-    function getDefaultLicenseTerms() external view returns (address licenseTemplate, uint256 licenseTermsId);
+    function getDefaultLicenseTerms() external view returns (address licenseTemplate, uint32 licenseTermsId);
 
     /// @notice Registers a new license template in the Story Protocol.
     /// @param licenseTemplate The address of the license template to register.
@@ -51,7 +51,7 @@ interface ILicenseRegistry {
         address ipId,
         address[] calldata parentIpIds,
         address licenseTemplate,
-        uint256[] calldata licenseTermsIds
+        uint32[] calldata licenseTermsIds
     ) external;
 
     /// @notice Checks if an IP is a derivative IP.
@@ -75,7 +75,7 @@ interface ILicenseRegistry {
     function verifyMintLicenseToken(
         address licensorIpId,
         address licenseTemplate,
-        uint256 licenseTermsId,
+        uint32 licenseTermsId,
         bool isMintedByIpOwner
     ) external view returns (Licensing.MintingLicenseConfig memory);
 
@@ -83,13 +83,13 @@ interface ILicenseRegistry {
     /// @param ipId The address of the IP to which the license terms are attached.
     /// @param licenseTemplate The address of the license template.
     /// @param licenseTermsId The ID of the license terms.
-    function attachLicenseTermsToIp(address ipId, address licenseTemplate, uint256 licenseTermsId) external;
+    function attachLicenseTermsToIp(address ipId, address licenseTemplate, uint32 licenseTermsId) external;
 
     /// @notice Checks if license terms exist.
     /// @param licenseTemplate The address of the license template where the license terms are defined.
     /// @param licenseTermsId The ID of the license terms.
     /// @return Whether the license terms exist.
-    function exists(address licenseTemplate, uint256 licenseTermsId) external view returns (bool);
+    function exists(address licenseTemplate, uint32 licenseTermsId) external view returns (bool);
 
     /// @notice Checks if an IP has attached any license terms.
     /// @param ipId The address of the IP to check.
@@ -99,7 +99,7 @@ interface ILicenseRegistry {
     function hasIpAttachedLicenseTerms(
         address ipId,
         address licenseTemplate,
-        uint256 licenseTermsId
+        uint32 licenseTermsId
     ) external view returns (bool);
 
     /// @notice Gets the attached license terms of an IP by its index.
@@ -110,7 +110,7 @@ interface ILicenseRegistry {
     function getAttachedLicenseTerms(
         address ipId,
         uint256 index
-    ) external view returns (address licenseTemplate, uint256 licenseTermsId);
+    ) external view returns (address licenseTemplate, uint32 licenseTermsId);
 
     /// @notice Gets the count of attached license terms of an IP.
     /// @param ipId The address of the IP.
@@ -154,7 +154,7 @@ interface ILicenseRegistry {
     function getMintingLicenseConfig(
         address ipId,
         address licenseTemplate,
-        uint256 licenseTermsId
+        uint32 licenseTermsId
     ) external view returns (Licensing.MintingLicenseConfig memory);
 
     /// @notice Sets the minting license configuration for a specific license attached to a specific IP.
@@ -166,7 +166,7 @@ interface ILicenseRegistry {
     function setMintingLicenseConfigForLicense(
         address ipId,
         address licenseTemplate,
-        uint256 licenseTermsId,
+        uint32 licenseTermsId,
         Licensing.MintingLicenseConfig calldata mintingLicenseConfig
     ) external;
 

--- a/contracts/modules/licensing/LicensingModule.sol
+++ b/contracts/modules/licensing/LicensingModule.sol
@@ -112,7 +112,7 @@ contract LicensingModule is
     function attachLicenseTerms(
         address ipId,
         address licenseTemplate,
-        uint256 licenseTermsId
+        uint32 licenseTermsId
     ) external verifyPermission(ipId) {
         _verifyIpNotDisputed(ipId);
         LICENSE_REGISTRY.attachLicenseTermsToIp(ipId, licenseTemplate, licenseTermsId);
@@ -141,7 +141,7 @@ contract LicensingModule is
     function mintLicenseTokens(
         address licensorIpId,
         address licenseTemplate,
-        uint256 licenseTermsId,
+        uint32 licenseTermsId,
         uint256 amount,
         address receiver,
         bytes calldata royaltyContext
@@ -207,7 +207,7 @@ contract LicensingModule is
     function registerDerivative(
         address childIpId,
         address[] calldata parentIpIds,
-        uint256[] calldata licenseTermsIds,
+        uint32[] calldata licenseTermsIds,
         address licenseTemplate,
         bytes calldata royaltyContext
     ) external whenNotPaused nonReentrant verifyPermission(childIpId) {
@@ -283,7 +283,7 @@ contract LicensingModule is
         // Confirm that the license token has not been revoked.
         // Validate that the owner of the derivative IP is also the owner of the license tokens.
         address childIpOwner = IIPAccount(payable(childIpId)).owner();
-        (address licenseTemplate, address[] memory parentIpIds, uint256[] memory licenseTermsIds) = LICENSE_NFT
+        (address licenseTemplate, address[] memory parentIpIds, uint32[] memory licenseTermsIds) = LICENSE_NFT
             .validateLicenseTokensForDerivative(childIpId, childIpOwner, licenseTokenIds);
 
         _verifyIpNotDisputed(childIpId);
@@ -342,7 +342,7 @@ contract LicensingModule is
     /// finally returns the common royalty policy and data for the parent IPs
     function _payMintingFeeForAllParentIps(
         address[] calldata parentIpIds,
-        uint256[] calldata licenseTermsIds,
+        uint32[] calldata licenseTermsIds,
         address licenseTemplate,
         address childIpOwner,
         bytes calldata royaltyContext
@@ -352,7 +352,7 @@ contract LicensingModule is
 
         // pay minting fee for all parent IPs
         for (uint256 i = 0; i < parentIpIds.length; i++) {
-            uint256 lcId = licenseTermsIds[i];
+            uint32 lcId = licenseTermsIds[i];
             Licensing.MintingLicenseConfig memory mlc = LICENSE_REGISTRY.getMintingLicenseConfig(
                 parentIpIds[i],
                 licenseTemplate,
@@ -398,7 +398,7 @@ contract LicensingModule is
     function _payMintingFee(
         address parentIpId,
         address licenseTemplate,
-        uint256 licenseTermsId,
+        uint32 licenseTermsId,
         uint256 amount,
         bytes calldata royaltyContext,
         Licensing.MintingLicenseConfig memory mlc
@@ -431,7 +431,7 @@ contract LicensingModule is
         Licensing.MintingLicenseConfig memory mintingLicenseConfig,
         address licensorIpId,
         address licenseTemplate,
-        uint256 licenseTermsId,
+        uint32 licenseTermsId,
         uint256 mintingFeeSetByLicenseTerms,
         uint256 amount
     ) private view returns (uint256) {

--- a/test/foundry/integration/big-bang/SingleNftCollection.t.sol
+++ b/test/foundry/integration/big-bang/SingleNftCollection.t.sol
@@ -29,9 +29,9 @@ contract BigBang_Integration_SingleNftCollection is BaseIntegration {
 
     uint256 internal constant mintingFee = 100 ether;
 
-    uint256 internal ncSocialRemixTermsId;
+    uint32 internal ncSocialRemixTermsId;
 
-    uint256 internal commDerivTermsId;
+    uint32 internal commDerivTermsId;
 
     function setUp() public override {
         super.setUp();
@@ -106,7 +106,7 @@ contract BigBang_Integration_SingleNftCollection is BaseIntegration {
             address(licensingModule),
             0,
             abi.encodeWithSignature(
-                "attachLicenseTerms(address,address,uint256)",
+                "attachLicenseTerms(address,address,uint32)",
                 ipAcct[3],
                 address(pilTemplate),
                 ncSocialRemixTermsId

--- a/test/foundry/integration/flows/disputes/Disputes.t.sol
+++ b/test/foundry/integration/flows/disputes/Disputes.t.sol
@@ -17,7 +17,7 @@ contract Flows_Integration_Disputes is BaseIntegration {
     using Strings for *;
 
     mapping(uint256 tokenId => address ipAccount) internal ipAcct;
-    uint256 internal ncSocialRemixTermsId;
+    uint32 internal ncSocialRemixTermsId;
 
     function setUp() public override {
         super.setUp();

--- a/test/foundry/integration/flows/licensing/LicensingIntegration.t.sol
+++ b/test/foundry/integration/flows/licensing/LicensingIntegration.t.sol
@@ -243,10 +243,10 @@ contract e2e is Test {
         ipId7 = ipAssetRegistry.register(block.chainid, address(mockNft), tokenId7);
 
         // register license terms
-        uint256 lcId1 = piLicenseTemplate.registerLicenseTerms(PILFlavors.nonCommercialSocialRemixing());
+        uint32 lcId1 = piLicenseTemplate.registerLicenseTerms(PILFlavors.nonCommercialSocialRemixing());
         assertEq(lcId1, 1);
 
-        uint256 lcId2 = piLicenseTemplate.registerLicenseTerms(
+        uint32 lcId2 = piLicenseTemplate.registerLicenseTerms(
             PILFlavors.commercialRemix(100, 10, address(royaltyPolicyLAP), address(erc20))
         );
         assertEq(lcId2, 2);
@@ -267,7 +267,7 @@ contract e2e is Test {
         assertEq(licenseRegistry.hasIpAttachedLicenseTerms(ipId1, address(piLicenseTemplate), 1), true);
         assertEq(licenseRegistry.getAttachedLicenseTermsCount(ipId1), 1);
 
-        (address attachedTemplate, uint256 attachedId) = licenseRegistry.getAttachedLicenseTerms(ipId1, 0);
+        (address attachedTemplate, uint32 attachedId) = licenseRegistry.getAttachedLicenseTerms(ipId1, 0);
         assertEq(attachedTemplate, address(piLicenseTemplate));
         assertEq(attachedId, 1);
 
@@ -284,7 +284,7 @@ contract e2e is Test {
         // register derivative directly
         vm.startPrank(bob);
         address[] memory parentIpIds = new address[](1);
-        uint256[] memory licenseTermsIds = new uint256[](1);
+        uint32[] memory licenseTermsIds = new uint32[](1);
         parentIpIds[0] = ipId1;
         licenseTermsIds[0] = 1;
 
@@ -389,7 +389,7 @@ contract e2e is Test {
         erc20.mint(eve, 1000);
         erc20.approve(address(royaltyPolicyLAP), 100);
         parentIpIds = new address[](1);
-        licenseTermsIds = new uint256[](1);
+        licenseTermsIds = new uint32[](1);
         parentIpIds[0] = ipId1;
         licenseTermsIds[0] = 2;
 

--- a/test/foundry/integration/flows/licensing/LicensingScenarios.t.sol
+++ b/test/foundry/integration/flows/licensing/LicensingScenarios.t.sol
@@ -30,13 +30,13 @@ contract Licensing_Scenarios is BaseIntegration {
     }
 
     function test_Integration_LicensingScenarios_PILFlavors_getId() public {
-        uint256 ncSocialRemixTermsId = registerSelectedPILicenseTerms_NonCommercialSocialRemixing();
+        uint32 ncSocialRemixTermsId = registerSelectedPILicenseTerms_NonCommercialSocialRemixing();
         assertEq(ncSocialRemixTermsId, PILFlavors.getNonCommercialSocialRemixingId(pilTemplate));
 
         uint32 commercialRevShare = 10;
         uint256 mintingFee = 100;
 
-        uint256 commRemixTermsId = registerSelectedPILicenseTerms(
+        uint32 commRemixTermsId = registerSelectedPILicenseTerms(
             "commercial_remix",
             PILFlavors.commercialRemix({
                 commercialRevShare: commercialRevShare,
@@ -56,7 +56,7 @@ contract Licensing_Scenarios is BaseIntegration {
             })
         );
 
-        uint256 commTermsId = registerSelectedPILicenseTerms(
+        uint32 commTermsId = registerSelectedPILicenseTerms(
             "commercial_use",
             PILFlavors.commercialUse({
                 mintingFee: mintingFee,
@@ -83,10 +83,10 @@ contract Licensing_Scenarios is BaseIntegration {
         uint256 mintingFee = 100;
 
         // Register non-commercial social remixing policy
-        uint256 ncSocialRemixTermsId = registerSelectedPILicenseTerms_NonCommercialSocialRemixing();
+        uint32 ncSocialRemixTermsId = registerSelectedPILicenseTerms_NonCommercialSocialRemixing();
 
         // Register commercial remixing policy
-        uint256 commRemixTermsId = registerSelectedPILicenseTerms(
+        uint32 commRemixTermsId = registerSelectedPILicenseTerms(
             "commercial_remix",
             PILFlavors.commercialRemix({
                 commercialRevShare: commercialRevShare,
@@ -97,7 +97,7 @@ contract Licensing_Scenarios is BaseIntegration {
         );
 
         // Register commercial use policy
-        uint256 commTermsId = registerSelectedPILicenseTerms(
+        uint32 commTermsId = registerSelectedPILicenseTerms(
             "commercial_use",
             PILFlavors.commercialUse({
                 mintingFee: mintingFee,

--- a/test/foundry/integration/flows/royalty/Royalty.t.sol
+++ b/test/foundry/integration/flows/royalty/Royalty.t.sol
@@ -24,7 +24,7 @@ contract Flows_Integration_Disputes is BaseIntegration {
 
     uint32 internal defaultCommRevShare = 10 * 10 ** 6; // 10%
     uint256 internal mintingFee = 7 ether;
-    uint256 internal commRemixTermsId;
+    uint32 internal commRemixTermsId;
 
     function setUp() public override {
         super.setUp();

--- a/test/foundry/mocks/module/MockAccessControllerV2.sol
+++ b/test/foundry/mocks/module/MockAccessControllerV2.sol
@@ -11,7 +11,8 @@ contract MockAccessControllerV2 is AccessController {
     }
 
     // keccak256(abi.encode(uint256(keccak256("story-protocol.AccessControllerV2")) - 1)) & ~bytes32(uint256(0xff));
-    bytes32 private constant AccessControllerV2StorageLocation = 0xf328f2cdee4ae4df23921504bfa43e3156fb4d18b23549ca0a43fd1e64947a00;
+    bytes32 private constant AccessControllerV2StorageLocation =
+        0xf328f2cdee4ae4df23921504bfa43e3156fb4d18b23549ca0a43fd1e64947a00;
 
     function initialize() public reinitializer(2) {
         _getAccessControllerV2Storage().newState = "initialized";

--- a/test/foundry/mocks/module/MockLicenseTemplate.sol
+++ b/test/foundry/mocks/module/MockLicenseTemplate.sol
@@ -5,10 +5,10 @@ pragma solidity 0.8.23;
 import { BaseLicenseTemplateUpgradeable } from "contracts/modules/licensing/BaseLicenseTemplateUpgradeable.sol";
 
 contract MockLicenseTemplate is BaseLicenseTemplateUpgradeable {
-    uint256 public licenseTermsCounter;
-    mapping(uint256 => bool) public licenseTerms;
+    uint32 public licenseTermsCounter;
+    mapping(uint32 => bool) public licenseTerms;
 
-    function registerLicenseTerms() external returns (uint256 id) {
+    function registerLicenseTerms() external returns (uint32 id) {
         id = licenseTermsCounter++;
         licenseTerms[id] = true;
     }
@@ -16,7 +16,7 @@ contract MockLicenseTemplate is BaseLicenseTemplateUpgradeable {
     /// @notice Checks if a license terms exists.
     /// @param licenseTermsId The ID of the license terms.
     /// @return True if the license terms exists, false otherwise.
-    function exists(uint256 licenseTermsId) external view override returns (bool) {
+    function exists(uint32 licenseTermsId) external view override returns (bool) {
         return licenseTerms[licenseTermsId];
     }
 
@@ -28,7 +28,7 @@ contract MockLicenseTemplate is BaseLicenseTemplateUpgradeable {
     /// @param licensorIpId The IP ID of the licensor who attached the license terms minting the license token.
     /// @return True if the minting is verified, false otherwise.
     function verifyMintLicenseToken(
-        uint256 licenseTermsId,
+        uint32 licenseTermsId,
         address licensee,
         address licensorIpId,
         uint256 amount
@@ -48,7 +48,7 @@ contract MockLicenseTemplate is BaseLicenseTemplateUpgradeable {
     function verifyRegisterDerivative(
         address childIpId,
         address parentIpId,
-        uint256 licenseTermsId,
+        uint32 licenseTermsId,
         address licensee
     ) external override returns (bool) {
         return true;
@@ -60,7 +60,7 @@ contract MockLicenseTemplate is BaseLicenseTemplateUpgradeable {
     /// It ensures that the licenses of all parent IPs are compatible with each other during the registration process.
     /// @param licenseTermsIds The IDs of the license terms.
     /// @return True if the licenses are compatible, false otherwise.
-    function verifyCompatibleLicenses(uint256[] calldata licenseTermsIds) external view override returns (bool) {
+    function verifyCompatibleLicenses(uint32[] calldata licenseTermsIds) external view override returns (bool) {
         return true;
     }
 
@@ -77,7 +77,7 @@ contract MockLicenseTemplate is BaseLicenseTemplateUpgradeable {
     function verifyRegisterDerivativeForAllParents(
         address childIpId,
         address[] calldata parentIpIds,
-        uint256[] calldata licenseTermsIds,
+        uint32[] calldata licenseTermsIds,
         address childIpOwner
     ) external override returns (bool) {
         return true;
@@ -91,7 +91,7 @@ contract MockLicenseTemplate is BaseLicenseTemplateUpgradeable {
     /// @return currency The address of the ERC20 token, used for minting license fee and royalties.
     /// the currency token will used for pay for license token minting fee and royalties.
     function getRoyaltyPolicy(
-        uint256 licenseTermsId
+        uint32 licenseTermsId
     ) external view returns (address royaltyPolicy, bytes memory royaltyData, uint256 mintingFee, address currency) {
         return (address(0), "", 0, address(0));
     }
@@ -99,7 +99,7 @@ contract MockLicenseTemplate is BaseLicenseTemplateUpgradeable {
     /// @notice Checks if a license terms is transferable.
     /// @param licenseTermsId The ID of the license terms.
     /// @return True if the license terms is transferable, false otherwise.
-    function isLicenseTransferable(uint256 licenseTermsId) external view override returns (bool) {
+    function isLicenseTransferable(uint32 licenseTermsId) external view override returns (bool) {
         return true;
     }
 
@@ -108,9 +108,9 @@ contract MockLicenseTemplate is BaseLicenseTemplateUpgradeable {
     /// @param licenseTermsIds The IDs of the license terms.
     /// @return The earliest expiration time.
     function getEarlierExpireTime(
-        uint256[] calldata licenseTermsIds,
-        uint256 start
-    ) external view override returns (uint256) {
+        uint32[] calldata licenseTermsIds,
+        uint40 start
+    ) external view override returns (uint40) {
         return 0;
     }
 
@@ -118,13 +118,13 @@ contract MockLicenseTemplate is BaseLicenseTemplateUpgradeable {
     /// @param start The start time.
     /// @param licenseTermsId The ID of the license terms.
     /// @return The expiration time.
-    function getExpireTime(uint256 licenseTermsId, uint256 start) external view returns (uint256) {
+    function getExpireTime(uint32 licenseTermsId, uint40 start) external view returns (uint40) {
         return 0;
     }
 
     /// @notice Returns the total number of registered license terms.
     /// @return The total number of registered license terms.
-    function totalRegisteredLicenseTerms() external view returns (uint256) {
+    function totalRegisteredLicenseTerms() external view returns (uint32) {
         return licenseTermsCounter;
     }
 
@@ -139,14 +139,14 @@ contract MockLicenseTemplate is BaseLicenseTemplateUpgradeable {
     /// @dev Must return OpenSea standard compliant metadata.
     /// @param licenseTermsId The ID of the license terms.
     /// @return The JSON string of the license terms, follow the OpenSea metadata standard.
-    function toJson(uint256 licenseTermsId) public view returns (string memory) {
+    function toJson(uint32 licenseTermsId) public view returns (string memory) {
         return "";
     }
 
     /// @notice Returns the URI of the license terms.
     /// @param licenseTermsId The ID of the license terms.
     /// @return The URI of the license terms.
-    function getLicenseTermsURI(uint256 licenseTermsId) external view returns (string memory) {
+    function getLicenseTermsURI(uint32 licenseTermsId) external view returns (string memory) {
         return "";
     }
 }

--- a/test/foundry/modules/licensing/LicensingModule.t.sol
+++ b/test/foundry/modules/licensing/LicensingModule.t.sol
@@ -61,7 +61,7 @@ contract LicensingModuleTest is BaseTest {
     }
 
     function test_LicensingModule_attachLicenseTerms_attachOneLicenseToOneIP() public {
-        uint256 termsId = pilTemplate.registerLicenseTerms(PILFlavors.defaultValuesLicenseTerms());
+        uint32 termsId = pilTemplate.registerLicenseTerms(PILFlavors.defaultValuesLicenseTerms());
         vm.expectEmit();
         emit ILicensingModule.LicenseTermsAttached(ipOwner1, ipId1, address(pilTemplate), termsId);
         vm.prank(ipOwner1);
@@ -80,7 +80,7 @@ contract LicensingModuleTest is BaseTest {
     }
 
     function test_LicensingModule_attachLicenseTerms_sameLicenseAttachMultipleIP() public {
-        uint256 termsId = pilTemplate.registerLicenseTerms(PILFlavors.defaultValuesLicenseTerms());
+        uint32 termsId = pilTemplate.registerLicenseTerms(PILFlavors.defaultValuesLicenseTerms());
 
         vm.expectEmit();
         emit ILicensingModule.LicenseTermsAttached(ipOwner1, ipId1, address(pilTemplate), termsId);
@@ -117,12 +117,12 @@ contract LicensingModuleTest is BaseTest {
     }
 
     function test_LicensingModule_attachLicenseTerms_DifferentLicensesAttachToSameIP() public {
-        uint256 termsId1 = pilTemplate.registerLicenseTerms(PILFlavors.defaultValuesLicenseTerms());
+        uint32 termsId1 = pilTemplate.registerLicenseTerms(PILFlavors.defaultValuesLicenseTerms());
         vm.expectEmit();
         emit ILicensingModule.LicenseTermsAttached(ipOwner1, ipId1, address(pilTemplate), termsId1);
         vm.prank(ipOwner1);
         licensingModule.attachLicenseTerms(ipId1, address(pilTemplate), termsId1);
-        (address licenseTemplate1, uint256 licenseTermsId1) = licenseRegistry.getAttachedLicenseTerms(ipId1, 0);
+        (address licenseTemplate1, uint32 licenseTermsId1) = licenseRegistry.getAttachedLicenseTerms(ipId1, 0);
         assertEq(licenseTemplate1, address(pilTemplate));
         assertEq(licenseTermsId1, termsId1);
         assertTrue(licenseRegistry.hasIpAttachedLicenseTerms(ipId1, address(pilTemplate), termsId1));
@@ -134,12 +134,12 @@ contract LicensingModuleTest is BaseTest {
         assertFalse(licenseRegistry.isDerivativeIp(ipId1));
         assertTrue(licenseRegistry.exists(address(pilTemplate), termsId1));
 
-        uint256 termsId2 = pilTemplate.registerLicenseTerms(PILFlavors.nonCommercialSocialRemixing());
+        uint32 termsId2 = pilTemplate.registerLicenseTerms(PILFlavors.nonCommercialSocialRemixing());
         vm.expectEmit();
         emit ILicensingModule.LicenseTermsAttached(ipOwner1, ipId1, address(pilTemplate), termsId2);
         vm.prank(ipOwner1);
         licensingModule.attachLicenseTerms(ipId1, address(pilTemplate), termsId2);
-        (address licenseTemplate2, uint256 licenseTermsId2) = licenseRegistry.getAttachedLicenseTerms(ipId1, 1);
+        (address licenseTemplate2, uint32 licenseTermsId2) = licenseRegistry.getAttachedLicenseTerms(ipId1, 1);
         assertEq(licenseTemplate2, address(pilTemplate));
         assertEq(licenseTermsId2, termsId2);
         assertTrue(licenseRegistry.hasIpAttachedLicenseTerms(ipId1, address(pilTemplate), termsId2));
@@ -153,7 +153,7 @@ contract LicensingModuleTest is BaseTest {
     }
 
     function test_LicensingModule_attachLicenseTerms_revert_licenseNotExist() public {
-        uint256 nonExistTermsId = 9999;
+        uint32 nonExistTermsId = 9999;
         assertFalse(licenseRegistry.exists(address(pilTemplate), nonExistTermsId));
 
         vm.expectRevert(
@@ -190,7 +190,7 @@ contract LicensingModuleTest is BaseTest {
             uri: ""
         });
 
-        uint256 termsId = pilTemplate.registerLicenseTerms(terms);
+        uint32 termsId = pilTemplate.registerLicenseTerms(terms);
         vm.prank(ipOwner1);
         licensingModule.attachLicenseTerms(ipId1, address(pilTemplate), termsId);
 
@@ -246,14 +246,14 @@ contract LicensingModuleTest is BaseTest {
         });
 
         vm.warp(11 days);
-        uint256 anotherTermsId = pilTemplate.registerLicenseTerms(PILFlavors.defaultValuesLicenseTerms());
+        uint32 anotherTermsId = pilTemplate.registerLicenseTerms(PILFlavors.defaultValuesLicenseTerms());
         vm.expectRevert(abi.encodeWithSelector(Errors.LicenseRegistry__IpExpired.selector, ipId2));
         vm.prank(ipOwner2);
         licensingModule.attachLicenseTerms(ipId2, address(pilTemplate), anotherTermsId);
     }
 
     function test_LicensingModule_attachLicenseTerms_revert_attachSameLicenseToIpTwice() public {
-        uint256 termsId = pilTemplate.registerLicenseTerms(PILFlavors.defaultValuesLicenseTerms());
+        uint32 termsId = pilTemplate.registerLicenseTerms(PILFlavors.defaultValuesLicenseTerms());
         vm.prank(ipOwner1);
         licensingModule.attachLicenseTerms(ipId1, address(pilTemplate), termsId);
         vm.expectRevert(
@@ -269,14 +269,14 @@ contract LicensingModuleTest is BaseTest {
     }
 
     function test_LicensingModule_attachLicenseTerms_revert_attachLicenseDifferentTemplate() public {
-        uint256 termsId = pilTemplate.registerLicenseTerms(PILFlavors.defaultValuesLicenseTerms());
+        uint32 termsId = pilTemplate.registerLicenseTerms(PILFlavors.defaultValuesLicenseTerms());
         vm.prank(ipOwner1);
         licensingModule.attachLicenseTerms(ipId1, address(pilTemplate), termsId);
 
         MockLicenseTemplate mockLicenseTemplate = new MockLicenseTemplate();
         vm.prank(admin);
         licenseRegistry.registerLicenseTemplate(address(mockLicenseTemplate));
-        uint256 mockTermsId = mockLicenseTemplate.registerLicenseTerms();
+        uint32 mockTermsId = mockLicenseTemplate.registerLicenseTerms();
         vm.expectRevert(
             abi.encodeWithSelector(
                 Errors.LicenseRegistry__UnmatchedLicenseTemplate.selector,
@@ -291,7 +291,7 @@ contract LicensingModuleTest is BaseTest {
 
     function test_LicensingModule_attachLicenseTerms_revert_Unregistered_LicenseTemplate() public {
         MockLicenseTemplate mockLicenseTemplate = new MockLicenseTemplate();
-        uint256 mockTermsId = mockLicenseTemplate.registerLicenseTerms();
+        uint32 mockTermsId = mockLicenseTemplate.registerLicenseTerms();
         vm.expectRevert(
             abi.encodeWithSelector(
                 Errors.LicensingModule__LicenseTermsNotFound.selector,
@@ -304,7 +304,7 @@ contract LicensingModuleTest is BaseTest {
     }
 
     function test_LicensingModule_attachLicenseTerms_revert_NonExists_LicenseTerms() public {
-        uint256 nonExistsTermsId = 9999;
+        uint32 nonExistsTermsId = 9999;
         vm.expectRevert(
             abi.encodeWithSelector(
                 Errors.LicensingModule__LicenseTermsNotFound.selector,
@@ -317,7 +317,7 @@ contract LicensingModuleTest is BaseTest {
     }
 
     function test_LicensingModule_mintLicenseTokens_singleToken() public {
-        uint256 termsId = pilTemplate.registerLicenseTerms(PILFlavors.defaultValuesLicenseTerms());
+        uint32 termsId = pilTemplate.registerLicenseTerms(PILFlavors.defaultValuesLicenseTerms());
         vm.prank(ipOwner1);
         licensingModule.attachLicenseTerms(ipId1, address(pilTemplate), termsId);
 
@@ -344,7 +344,7 @@ contract LicensingModuleTest is BaseTest {
     }
 
     function test_LicensingModule_mintLicenseTokens_mintMultipleTokens() public {
-        uint256 termsId = pilTemplate.registerLicenseTerms(PILFlavors.defaultValuesLicenseTerms());
+        uint32 termsId = pilTemplate.registerLicenseTerms(PILFlavors.defaultValuesLicenseTerms());
         vm.prank(ipOwner1);
         licensingModule.attachLicenseTerms(ipId1, address(pilTemplate), termsId);
 
@@ -380,7 +380,7 @@ contract LicensingModuleTest is BaseTest {
     }
 
     function test_LicensingModule_mintLicenseTokens_mintMultipleTimes() public {
-        uint256 termsId = pilTemplate.registerLicenseTerms(PILFlavors.defaultValuesLicenseTerms());
+        uint32 termsId = pilTemplate.registerLicenseTerms(PILFlavors.defaultValuesLicenseTerms());
         vm.prank(ipOwner1);
         licensingModule.attachLicenseTerms(ipId1, address(pilTemplate), termsId);
 
@@ -439,7 +439,7 @@ contract LicensingModuleTest is BaseTest {
             uri: ""
         });
 
-        uint256 termsId = pilTemplate.registerLicenseTerms(terms);
+        uint32 termsId = pilTemplate.registerLicenseTerms(terms);
         vm.prank(ipOwner1);
         licensingModule.attachLicenseTerms(ipId1, address(pilTemplate), termsId);
 
@@ -462,7 +462,7 @@ contract LicensingModuleTest is BaseTest {
     }
 
     function test_LicensingModule_mintLicenseTokens_revert_invalidInputs() public {
-        uint256 termsId = pilTemplate.registerLicenseTerms(PILFlavors.defaultValuesLicenseTerms());
+        uint32 termsId = pilTemplate.registerLicenseTerms(PILFlavors.defaultValuesLicenseTerms());
         vm.prank(ipOwner1);
         licensingModule.attachLicenseTerms(ipId1, address(pilTemplate), termsId);
 
@@ -489,7 +489,7 @@ contract LicensingModuleTest is BaseTest {
     }
 
     function test_LicensingModule_mintLicenseTokens_revert_NonIpOwnerMintNotAttachedLicense() public {
-        uint256 termsId = pilTemplate.registerLicenseTerms(PILFlavors.defaultValuesLicenseTerms());
+        uint32 termsId = pilTemplate.registerLicenseTerms(PILFlavors.defaultValuesLicenseTerms());
         address receiver = address(0x111);
         vm.expectRevert(
             abi.encodeWithSelector(
@@ -526,7 +526,7 @@ contract LicensingModuleTest is BaseTest {
     }
 
     function test_LicensingModule_mintLicenseTokens_revert_paused() public {
-        uint256 termsId = pilTemplate.registerLicenseTerms(PILFlavors.defaultValuesLicenseTerms());
+        uint32 termsId = pilTemplate.registerLicenseTerms(PILFlavors.defaultValuesLicenseTerms());
         vm.prank(ipOwner1);
         licensingModule.attachLicenseTerms(ipId1, address(pilTemplate), termsId);
 
@@ -547,7 +547,7 @@ contract LicensingModuleTest is BaseTest {
     }
 
     function test_LicensingModule_mintLicenseTokens_IpOwnerMintNotAttachedLicense() public {
-        uint256 termsId = pilTemplate.registerLicenseTerms(PILFlavors.defaultValuesLicenseTerms());
+        uint32 termsId = pilTemplate.registerLicenseTerms(PILFlavors.defaultValuesLicenseTerms());
         address receiver = address(0x111);
         vm.prank(ipOwner1);
         uint256 lcTokenId = licensingModule.mintLicenseTokens({
@@ -570,7 +570,7 @@ contract LicensingModuleTest is BaseTest {
     }
 
     function test_LicensingModule_registerDerivativeWithLicenseTokens_singleParent() public {
-        uint256 termsId = pilTemplate.registerLicenseTerms(PILFlavors.nonCommercialSocialRemixing());
+        uint32 termsId = pilTemplate.registerLicenseTerms(PILFlavors.nonCommercialSocialRemixing());
         vm.prank(ipOwner1);
         licensingModule.attachLicenseTerms(ipId1, address(pilTemplate), termsId);
 
@@ -618,7 +618,7 @@ contract LicensingModuleTest is BaseTest {
     }
 
     function test_LicensingModule_registerDerivativeWithLicenseTokens_revert_pause() public {
-        uint256 termsId = pilTemplate.registerLicenseTerms(PILFlavors.nonCommercialSocialRemixing());
+        uint32 termsId = pilTemplate.registerLicenseTerms(PILFlavors.nonCommercialSocialRemixing());
         vm.prank(ipOwner1);
         licensingModule.attachLicenseTerms(ipId1, address(pilTemplate), termsId);
 
@@ -642,7 +642,7 @@ contract LicensingModuleTest is BaseTest {
     }
 
     function test_LicensingModule_registerDerivativeWithLicenseTokens_twoParents() public {
-        uint256 termsId = pilTemplate.registerLicenseTerms(PILFlavors.nonCommercialSocialRemixing());
+        uint32 termsId = pilTemplate.registerLicenseTerms(PILFlavors.nonCommercialSocialRemixing());
         vm.prank(ipOwner1);
         licensingModule.attachLicenseTerms(ipId1, address(pilTemplate), termsId);
         vm.prank(ipOwner2);
@@ -721,7 +721,7 @@ contract LicensingModuleTest is BaseTest {
     }
 
     function test_LicensingModule_registerDerivativeWithLicenseTokens_revert_parentIsChild() public {
-        uint256 termsId = pilTemplate.registerLicenseTerms(PILFlavors.nonCommercialSocialRemixing());
+        uint32 termsId = pilTemplate.registerLicenseTerms(PILFlavors.nonCommercialSocialRemixing());
         vm.prank(ipOwner1);
 
         uint256 lcTokenId = licensingModule.mintLicenseTokens({
@@ -764,7 +764,7 @@ contract LicensingModuleTest is BaseTest {
             uri: ""
         });
 
-        uint256 termsId = pilTemplate.registerLicenseTerms(terms);
+        uint32 termsId = pilTemplate.registerLicenseTerms(terms);
         vm.prank(ipOwner1);
         licensingModule.attachLicenseTerms(ipId1, address(pilTemplate), termsId);
 
@@ -805,10 +805,10 @@ contract LicensingModuleTest is BaseTest {
     }
 
     function test_LicensingModule_registerDerivativeWithLicenseTokens_revert_ParentExpired() public {
-        uint256 termsId = pilTemplate.registerLicenseTerms(PILFlavors.nonCommercialSocialRemixing());
+        uint32 termsId = pilTemplate.registerLicenseTerms(PILFlavors.nonCommercialSocialRemixing());
         PILTerms memory expiredTerms = PILFlavors.nonCommercialSocialRemixing();
         expiredTerms.expiration = 10 days;
-        uint256 expiredTermsId = pilTemplate.registerLicenseTerms(expiredTerms);
+        uint32 expiredTermsId = pilTemplate.registerLicenseTerms(expiredTerms);
 
         vm.prank(ipOwner1);
         licensingModule.attachLicenseTerms(ipId1, address(pilTemplate), termsId);
@@ -885,7 +885,7 @@ contract LicensingModuleTest is BaseTest {
         );
         assertEq(anotherLicenseTemplate, address(pilTemplate));
         assertEq(anotherLicenseTermsId, expiredTermsId);
-        uint256[] memory licenseTerms = new uint256[](2);
+        uint32[] memory licenseTerms = new uint32[](2);
         licenseTerms[0] = termsId;
         licenseTerms[1] = expiredTermsId;
 
@@ -912,7 +912,7 @@ contract LicensingModuleTest is BaseTest {
     }
 
     function test_LicensingModule_registerDerivativeWithLicenseTokens_revert_childAlreadyAttachedLicense() public {
-        uint256 termsId = pilTemplate.registerLicenseTerms(PILFlavors.nonCommercialSocialRemixing());
+        uint32 termsId = pilTemplate.registerLicenseTerms(PILFlavors.nonCommercialSocialRemixing());
         vm.prank(ipOwner1);
         licensingModule.attachLicenseTerms(ipId1, address(pilTemplate), termsId);
 
@@ -934,7 +934,7 @@ contract LicensingModuleTest is BaseTest {
     }
 
     function test_LicensingModule_registerDerivativeWithLicenseTokens_revert_AlreadyRegisteredAsDerivative() public {
-        uint256 termsId = pilTemplate.registerLicenseTerms(PILFlavors.nonCommercialSocialRemixing());
+        uint32 termsId = pilTemplate.registerLicenseTerms(PILFlavors.nonCommercialSocialRemixing());
         vm.prank(ipOwner1);
         licensingModule.attachLicenseTerms(ipId1, address(pilTemplate), termsId);
         vm.prank(ipOwner2);
@@ -971,7 +971,7 @@ contract LicensingModuleTest is BaseTest {
     }
 
     function test_LicensingModule_registerDerivativeWithLicenseTokens_revert_notLicensee() public {
-        uint256 termsId = pilTemplate.registerLicenseTerms(PILFlavors.nonCommercialSocialRemixing());
+        uint32 termsId = pilTemplate.registerLicenseTerms(PILFlavors.nonCommercialSocialRemixing());
         vm.prank(ipOwner1);
         licensingModule.attachLicenseTerms(ipId1, address(pilTemplate), termsId);
 
@@ -995,7 +995,7 @@ contract LicensingModuleTest is BaseTest {
     }
 
     function test_LicensingModule_singleTransfer_verifyOk() public {
-        uint256 termsId = pilTemplate.registerLicenseTerms(PILFlavors.nonCommercialSocialRemixing());
+        uint32 termsId = pilTemplate.registerLicenseTerms(PILFlavors.nonCommercialSocialRemixing());
         vm.prank(ipOwner1);
         licensingModule.attachLicenseTerms(ipId1, address(pilTemplate), termsId);
 
@@ -1062,7 +1062,7 @@ contract LicensingModuleTest is BaseTest {
             uri: ""
         });
 
-        uint256 termsId = pilTemplate.registerLicenseTerms(terms);
+        uint32 termsId = pilTemplate.registerLicenseTerms(terms);
         vm.prank(ipOwner1);
         licensingModule.attachLicenseTerms(ipId1, address(pilTemplate), termsId);
 
@@ -1112,7 +1112,7 @@ contract LicensingModuleTest is BaseTest {
             uri: ""
         });
 
-        uint256 termsId = pilTemplate.registerLicenseTerms(terms);
+        uint32 termsId = pilTemplate.registerLicenseTerms(terms);
         vm.prank(ipOwner1);
         licensingModule.attachLicenseTerms(ipId1, address(pilTemplate), termsId);
 
@@ -1159,7 +1159,7 @@ contract LicensingModuleTest is BaseTest {
             uri: ""
         });
 
-        uint256 termsId = pilTemplate.registerLicenseTerms(terms);
+        uint32 termsId = pilTemplate.registerLicenseTerms(terms);
         vm.prank(ipOwner1);
         licensingModule.attachLicenseTerms(ipId1, address(pilTemplate), termsId);
 
@@ -1209,7 +1209,7 @@ contract LicensingModuleTest is BaseTest {
     function test_LicensingModule_registerDerivative_revert_emptyParentIpIds() public {
         vm.expectRevert(Errors.LicensingModule__NoParentIp.selector);
         vm.prank(ipOwner2);
-        licensingModule.registerDerivative(ipId2, new address[](0), new uint256[](0), address(0), "");
+        licensingModule.registerDerivative(ipId2, new address[](0), new uint32[](0), address(0), "");
     }
 
     function test_LicensingModule_registerDerivative_revert_parentIdsLengthMismatchWithLicenseIds() public {
@@ -1217,12 +1217,12 @@ contract LicensingModuleTest is BaseTest {
         parentIpIds[0] = ipId1;
         vm.expectRevert(abi.encodeWithSelector(Errors.LicensingModule__LicenseTermsLengthMismatch.selector, 1, 0));
         vm.prank(ipOwner2);
-        licensingModule.registerDerivative(ipId2, parentIpIds, new uint256[](0), address(0), "");
+        licensingModule.registerDerivative(ipId2, parentIpIds, new uint32[](0), address(0), "");
     }
 
     function test_LicensingModule_registerDerivative_revert_IncompatibleLicenses() public {
-        uint256 socialRemixTermsId = pilTemplate.registerLicenseTerms(PILFlavors.nonCommercialSocialRemixing());
-        uint256 commUseTermsId = pilTemplate.registerLicenseTerms(
+        uint32 socialRemixTermsId = pilTemplate.registerLicenseTerms(PILFlavors.nonCommercialSocialRemixing());
+        uint32 commUseTermsId = pilTemplate.registerLicenseTerms(
             PILFlavors.commercialUse({
                 mintingFee: 0,
                 currencyToken: address(erc20),
@@ -1239,7 +1239,7 @@ contract LicensingModuleTest is BaseTest {
         parentIpIds[0] = ipId1;
         parentIpIds[1] = ipId2;
 
-        uint256[] memory licenseTermsIds = new uint256[](2);
+        uint32[] memory licenseTermsIds = new uint32[](2);
         licenseTermsIds[0] = socialRemixTermsId;
         licenseTermsIds[1] = commUseTermsId;
 

--- a/test/foundry/modules/licensing/PILicenseTemplate.t.sol
+++ b/test/foundry/modules/licensing/PILicenseTemplate.t.sol
@@ -56,7 +56,7 @@ contract PILicenseTemplateTest is BaseTest {
     // this contract is for testing for each PILicenseTemplate's functions
     // register license terms with PILTerms struct
     function test_PILicenseTemplate_registerLicenseTerms() public {
-        uint256 defaultTermsId = pilTemplate.registerLicenseTerms(PILFlavors.defaultValuesLicenseTerms());
+        uint32 defaultTermsId = pilTemplate.registerLicenseTerms(PILFlavors.defaultValuesLicenseTerms());
         assertEq(defaultTermsId, 1);
         (address royaltyPolicy, bytes memory royaltyData, uint256 mintingFee, address currency) = pilTemplate
             .getRoyaltyPolicy(defaultTermsId);
@@ -66,10 +66,10 @@ contract PILicenseTemplateTest is BaseTest {
         assertEq(currency, address(0), "currency should be address(0)");
         assertTrue(pilTemplate.isLicenseTransferable(defaultTermsId), "license should be transferable");
         assertEq(pilTemplate.getLicenseTermsId(PILFlavors.defaultValuesLicenseTerms()), 1);
-        assertEq(pilTemplate.getExpireTime(defaultTermsId, block.timestamp), 0, "expire time should be 0");
+        assertEq(pilTemplate.getExpireTime(defaultTermsId, uint40(block.timestamp)), 0, "expire time should be 0");
         assertTrue(pilTemplate.exists(defaultTermsId), "license terms should exist");
 
-        uint256 socialRemixTermsId = pilTemplate.registerLicenseTerms(PILFlavors.nonCommercialSocialRemixing());
+        uint32 socialRemixTermsId = pilTemplate.registerLicenseTerms(PILFlavors.nonCommercialSocialRemixing());
         assertEq(socialRemixTermsId, 2);
         (royaltyPolicy, royaltyData, mintingFee, currency) = pilTemplate.getRoyaltyPolicy(socialRemixTermsId);
         assertEq(royaltyPolicy, address(0));
@@ -78,10 +78,10 @@ contract PILicenseTemplateTest is BaseTest {
         assertEq(currency, address(0));
         assertTrue(pilTemplate.isLicenseTransferable(socialRemixTermsId));
         assertEq(pilTemplate.getLicenseTermsId(PILFlavors.nonCommercialSocialRemixing()), 2);
-        assertEq(pilTemplate.getExpireTime(socialRemixTermsId, block.timestamp), 0, "expire time should be 0");
+        assertEq(pilTemplate.getExpireTime(socialRemixTermsId, uint40(block.timestamp)), 0, "expire time should be 0");
         assertTrue(pilTemplate.exists(socialRemixTermsId), "license terms should exist");
 
-        uint256 commUseTermsId = pilTemplate.registerLicenseTerms(
+        uint32 commUseTermsId = pilTemplate.registerLicenseTerms(
             PILFlavors.commercialUse({
                 mintingFee: 100,
                 currencyToken: address(erc20),
@@ -99,10 +99,10 @@ contract PILicenseTemplateTest is BaseTest {
             pilTemplate.getLicenseTermsId(PILFlavors.commercialUse(100, address(erc20), address(royaltyPolicyLAP))),
             3
         );
-        assertEq(pilTemplate.getExpireTime(commUseTermsId, block.timestamp), 0, "expire time should be 0");
+        assertEq(pilTemplate.getExpireTime(commUseTermsId, uint40(block.timestamp)), 0, "expire time should be 0");
         assertEq(pilTemplate.totalRegisteredLicenseTerms(), 3);
 
-        uint256 commRemixTermsId = pilTemplate.registerLicenseTerms(
+        uint32 commRemixTermsId = pilTemplate.registerLicenseTerms(
             PILFlavors.commercialRemix({
                 mintingFee: 100,
                 commercialRevShare: 10,
@@ -123,24 +123,24 @@ contract PILicenseTemplateTest is BaseTest {
             ),
             4
         );
-        assertEq(pilTemplate.getExpireTime(commRemixTermsId, block.timestamp), 0, "expire time should be 0");
+        assertEq(pilTemplate.getExpireTime(commRemixTermsId, uint40(block.timestamp)), 0, "expire time should be 0");
         assertTrue(pilTemplate.exists(commRemixTermsId), "license terms should exist");
 
         assertEq(pilTemplate.totalRegisteredLicenseTerms(), 4);
 
-        uint256[] memory licenseTermsIds = new uint256[](4);
+        uint32[] memory licenseTermsIds = new uint32[](4);
         licenseTermsIds[0] = defaultTermsId;
         licenseTermsIds[1] = socialRemixTermsId;
         licenseTermsIds[2] = commUseTermsId;
         licenseTermsIds[3] = commRemixTermsId;
-        assertEq(pilTemplate.getEarlierExpireTime(licenseTermsIds, block.timestamp), 0);
+        assertEq(pilTemplate.getEarlierExpireTime(licenseTermsIds, uint40(block.timestamp)), 0);
 
         assertEq(pilTemplate.toJson(defaultTermsId), _DefaultToJson());
     }
     // register license terms twice
     function test_PILicenseTemplate_registerLicenseTerms_twice() public {
-        uint256 defaultTermsId = pilTemplate.registerLicenseTerms(PILFlavors.defaultValuesLicenseTerms());
-        uint256 defaultTermsId1 = pilTemplate.registerLicenseTerms(PILFlavors.defaultValuesLicenseTerms());
+        uint32 defaultTermsId = pilTemplate.registerLicenseTerms(PILFlavors.defaultValuesLicenseTerms());
+        uint32 defaultTermsId1 = pilTemplate.registerLicenseTerms(PILFlavors.defaultValuesLicenseTerms());
         assertEq(defaultTermsId, defaultTermsId1);
     }
 
@@ -237,7 +237,7 @@ contract PILicenseTemplateTest is BaseTest {
 
     // get license terms ID by PILTerms struct
     function test_PILicenseTemplate_getLicenseTermsId() public {
-        uint256 commUseTermsId = pilTemplate.registerLicenseTerms(
+        uint32 commUseTermsId = pilTemplate.registerLicenseTerms(
             PILFlavors.commercialUse({
                 mintingFee: 100,
                 currencyToken: address(erc20),
@@ -257,7 +257,7 @@ contract PILicenseTemplateTest is BaseTest {
 
     // get license terms struct by ID
     function test_PILicenseTemplate_getLicenseTerms() public {
-        uint256 commUseTermsId = pilTemplate.registerLicenseTerms(
+        uint32 commUseTermsId = pilTemplate.registerLicenseTerms(
             PILFlavors.commercialUse({
                 mintingFee: 100,
                 currencyToken: address(erc20),
@@ -272,7 +272,7 @@ contract PILicenseTemplateTest is BaseTest {
 
     // test license terms exists
     function test_PILicenseTemplate_exists() public {
-        uint256 commUseTermsId = pilTemplate.registerLicenseTerms(
+        uint32 commUseTermsId = pilTemplate.registerLicenseTerms(
             PILFlavors.commercialUse({
                 mintingFee: 100,
                 currencyToken: address(erc20),
@@ -285,7 +285,7 @@ contract PILicenseTemplateTest is BaseTest {
 
     // test verifyMintLicenseToken
     function test_PILicenseTemplate_verifyMintLicenseToken() public {
-        uint256 commUseTermsId = pilTemplate.registerLicenseTerms(
+        uint32 commUseTermsId = pilTemplate.registerLicenseTerms(
             PILFlavors.commercialUse({
                 mintingFee: 100,
                 currencyToken: address(erc20),
@@ -297,7 +297,7 @@ contract PILicenseTemplateTest is BaseTest {
     }
 
     function test_PILicenseTemplate_verifyMintLicenseToken_FromDerivativeIp_ButNotAttachedLicense() public {
-        uint256 commUseTermsId = pilTemplate.registerLicenseTerms(
+        uint32 commUseTermsId = pilTemplate.registerLicenseTerms(
             PILFlavors.commercialUse({
                 mintingFee: 0,
                 currencyToken: address(erc20),
@@ -309,19 +309,19 @@ contract PILicenseTemplateTest is BaseTest {
 
         address[] memory parentIpIds = new address[](1);
         parentIpIds[0] = ipId1;
-        uint256[] memory licenseTermsIds = new uint256[](1);
+        uint32[] memory licenseTermsIds = new uint32[](1);
         licenseTermsIds[0] = commUseTermsId;
         vm.prank(ipOwner2);
         licensingModule.registerDerivative(ipId2, parentIpIds, licenseTermsIds, address(pilTemplate), "");
 
-        uint256 anotherTermsId = pilTemplate.registerLicenseTerms(PILFlavors.nonCommercialSocialRemixing());
+        uint32 anotherTermsId = pilTemplate.registerLicenseTerms(PILFlavors.nonCommercialSocialRemixing());
 
         bool result = pilTemplate.verifyMintLicenseToken(anotherTermsId, ipOwner3, ipId2, 1);
         assertFalse(result);
     }
 
     function test_PILicenseTemplate_verifyMintLicenseToken_FromDerivativeIp_NotReciprocal() public {
-        uint256 commUseTermsId = pilTemplate.registerLicenseTerms(
+        uint32 commUseTermsId = pilTemplate.registerLicenseTerms(
             PILFlavors.commercialUse({
                 mintingFee: 0,
                 currencyToken: address(erc20),
@@ -333,7 +333,7 @@ contract PILicenseTemplateTest is BaseTest {
 
         address[] memory parentIpIds = new address[](1);
         parentIpIds[0] = ipId1;
-        uint256[] memory licenseTermsIds = new uint256[](1);
+        uint32[] memory licenseTermsIds = new uint32[](1);
         licenseTermsIds[0] = commUseTermsId;
         vm.prank(ipOwner2);
         licensingModule.registerDerivative(ipId2, parentIpIds, licenseTermsIds, address(pilTemplate), "");
@@ -344,7 +344,7 @@ contract PILicenseTemplateTest is BaseTest {
 
     // test verifyRegisterDerivative
     function test_PILicenseTemplate_verifyRegisterDerivative() public {
-        uint256 commUseTermsId = pilTemplate.registerLicenseTerms(
+        uint32 commUseTermsId = pilTemplate.registerLicenseTerms(
             PILFlavors.commercialUse({
                 mintingFee: 100,
                 currencyToken: address(erc20),
@@ -359,7 +359,7 @@ contract PILicenseTemplateTest is BaseTest {
     function test_PILicenseTemplate_verifyRegisterDerivative_WithApproval() public {
         PILTerms memory terms = PILFlavors.nonCommercialSocialRemixing();
         terms.derivativesApproval = true;
-        uint256 socialRemixTermsId = pilTemplate.registerLicenseTerms(terms);
+        uint32 socialRemixTermsId = pilTemplate.registerLicenseTerms(terms);
         vm.prank(ipId1);
         pilTemplate.setApproval(ipId1, socialRemixTermsId, ipId2, true);
         assertTrue(pilTemplate.isDerivativeApproved(ipId1, socialRemixTermsId, ipId2));
@@ -371,7 +371,7 @@ contract PILicenseTemplateTest is BaseTest {
     function test_PILicenseTemplate_verifyRegisterDerivative_WithoutApproval() public {
         PILTerms memory terms = PILFlavors.nonCommercialSocialRemixing();
         terms.derivativesApproval = true;
-        uint256 socialRemixTermsId = pilTemplate.registerLicenseTerms(terms);
+        uint32 socialRemixTermsId = pilTemplate.registerLicenseTerms(terms);
         vm.prank(ipId1);
         pilTemplate.setApproval(ipId1, socialRemixTermsId, ipId2, false);
         assertFalse(pilTemplate.isDerivativeApproved(ipId1, socialRemixTermsId, ipId2));
@@ -382,21 +382,21 @@ contract PILicenseTemplateTest is BaseTest {
 
     function test_PILicenseTemplate_verifyRegisterDerivative_derivativeNotAllowed() public {
         PILTerms memory terms = PILFlavors.defaultValuesLicenseTerms();
-        uint256 socialRemixTermsId = pilTemplate.registerLicenseTerms(terms);
+        uint32 socialRemixTermsId = pilTemplate.registerLicenseTerms(terms);
         bool result = pilTemplate.verifyRegisterDerivative(ipId2, ipId1, socialRemixTermsId, ipOwner2);
         assertFalse(result);
     }
 
     // test verifyCompatibleLicenses
     function test_PILicenseTemplate_verifyCompatibleLicenses() public {
-        uint256 commUseTermsId = pilTemplate.registerLicenseTerms(
+        uint32 commUseTermsId = pilTemplate.registerLicenseTerms(
             PILFlavors.commercialUse({
                 mintingFee: 100,
                 currencyToken: address(erc20),
                 royaltyPolicy: address(royaltyPolicyLAP)
             })
         );
-        uint256 commRemixTermsId = pilTemplate.registerLicenseTerms(
+        uint32 commRemixTermsId = pilTemplate.registerLicenseTerms(
             PILFlavors.commercialRemix({
                 mintingFee: 100,
                 commercialRevShare: 10,
@@ -404,13 +404,13 @@ contract PILicenseTemplateTest is BaseTest {
                 currencyToken: address(erc20)
             })
         );
-        uint256[] memory licenseTermsIds = new uint256[](2);
+        uint32[] memory licenseTermsIds = new uint32[](2);
         licenseTermsIds[0] = commUseTermsId;
         licenseTermsIds[1] = commRemixTermsId;
         assertFalse(pilTemplate.verifyCompatibleLicenses(licenseTermsIds));
 
-        uint256 defaultTermsId = pilTemplate.registerLicenseTerms(PILFlavors.defaultValuesLicenseTerms());
-        uint256 socialRemixTermsId = pilTemplate.registerLicenseTerms(PILFlavors.nonCommercialSocialRemixing());
+        uint32 defaultTermsId = pilTemplate.registerLicenseTerms(PILFlavors.defaultValuesLicenseTerms());
+        uint32 socialRemixTermsId = pilTemplate.registerLicenseTerms(PILFlavors.nonCommercialSocialRemixing());
         licenseTermsIds[0] = defaultTermsId;
         licenseTermsIds[1] = socialRemixTermsId;
         assertFalse(pilTemplate.verifyCompatibleLicenses(licenseTermsIds));
@@ -426,14 +426,14 @@ contract PILicenseTemplateTest is BaseTest {
 
     // test verifyRegisterDerivativeForAllParents
     function test_PILicenseTemplate_verifyRegisterDerivativeForAllParents() public {
-        uint256 commUseTermsId = pilTemplate.registerLicenseTerms(
+        uint32 commUseTermsId = pilTemplate.registerLicenseTerms(
             PILFlavors.commercialUse({
                 mintingFee: 100,
                 currencyToken: address(erc20),
                 royaltyPolicy: address(royaltyPolicyLAP)
             })
         );
-        uint256 commRemixTermsId = pilTemplate.registerLicenseTerms(
+        uint32 commRemixTermsId = pilTemplate.registerLicenseTerms(
             PILFlavors.commercialRemix({
                 mintingFee: 100,
                 commercialRevShare: 10,
@@ -441,7 +441,7 @@ contract PILicenseTemplateTest is BaseTest {
                 currencyToken: address(erc20)
             })
         );
-        uint256[] memory licenseTermsIds = new uint256[](2);
+        uint32[] memory licenseTermsIds = new uint32[](2);
         licenseTermsIds[0] = commUseTermsId;
         licenseTermsIds[1] = commRemixTermsId;
         address[] memory parentIpIds = new address[](2);
@@ -449,8 +449,8 @@ contract PILicenseTemplateTest is BaseTest {
         parentIpIds[1] = ipId3;
         assertFalse(pilTemplate.verifyRegisterDerivativeForAllParents(ipId2, parentIpIds, licenseTermsIds, ipOwner2));
 
-        uint256 defaultTermsId = pilTemplate.registerLicenseTerms(PILFlavors.defaultValuesLicenseTerms());
-        uint256 socialRemixTermsId = pilTemplate.registerLicenseTerms(PILFlavors.nonCommercialSocialRemixing());
+        uint32 defaultTermsId = pilTemplate.registerLicenseTerms(PILFlavors.defaultValuesLicenseTerms());
+        uint32 socialRemixTermsId = pilTemplate.registerLicenseTerms(PILFlavors.nonCommercialSocialRemixing());
         licenseTermsIds[0] = defaultTermsId;
         licenseTermsIds[1] = socialRemixTermsId;
         assertFalse(pilTemplate.verifyRegisterDerivativeForAllParents(ipId2, parentIpIds, licenseTermsIds, ipOwner2));
@@ -466,13 +466,13 @@ contract PILicenseTemplateTest is BaseTest {
 
     // test isLicenseTransferable
     function test_PILicenseTemplate_isLicenseTransferable() public {
-        uint256 defaultTermsId = pilTemplate.registerLicenseTerms(PILFlavors.defaultValuesLicenseTerms());
+        uint32 defaultTermsId = pilTemplate.registerLicenseTerms(PILFlavors.defaultValuesLicenseTerms());
         assertTrue(pilTemplate.isLicenseTransferable(defaultTermsId));
 
-        uint256 socialRemixTermsId = pilTemplate.registerLicenseTerms(PILFlavors.nonCommercialSocialRemixing());
+        uint32 socialRemixTermsId = pilTemplate.registerLicenseTerms(PILFlavors.nonCommercialSocialRemixing());
         assertTrue(pilTemplate.isLicenseTransferable(socialRemixTermsId));
 
-        uint256 commUseTermsId = pilTemplate.registerLicenseTerms(
+        uint32 commUseTermsId = pilTemplate.registerLicenseTerms(
             PILFlavors.commercialUse({
                 mintingFee: 100,
                 currencyToken: address(erc20),
@@ -481,7 +481,7 @@ contract PILicenseTemplateTest is BaseTest {
         );
         assertTrue(pilTemplate.isLicenseTransferable(commUseTermsId));
 
-        uint256 commRemixTermsId = pilTemplate.registerLicenseTerms(
+        uint32 commRemixTermsId = pilTemplate.registerLicenseTerms(
             PILFlavors.commercialRemix({
                 mintingFee: 100,
                 commercialRevShare: 10,
@@ -493,7 +493,7 @@ contract PILicenseTemplateTest is BaseTest {
 
         PILTerms memory terms = pilTemplate.getLicenseTerms(commRemixTermsId);
         terms.transferable = false;
-        uint256 nonTransferableTermsId = pilTemplate.registerLicenseTerms(terms);
+        uint32 nonTransferableTermsId = pilTemplate.registerLicenseTerms(terms);
         assertFalse(pilTemplate.isLicenseTransferable(nonTransferableTermsId));
     }
 
@@ -504,7 +504,7 @@ contract PILicenseTemplateTest is BaseTest {
             royaltyPolicy: address(royaltyPolicyLAP)
         });
         terms.uri = "license.url";
-        uint256 termsId = pilTemplate.registerLicenseTerms(terms);
+        uint32 termsId = pilTemplate.registerLicenseTerms(terms);
         assertEq(pilTemplate.getLicenseTermsURI(termsId), "license.url");
     }
 
@@ -515,7 +515,7 @@ contract PILicenseTemplateTest is BaseTest {
             royaltyPolicy: address(royaltyPolicyLAP)
         });
         terms.uri = "license.url";
-        uint256 termsId = pilTemplate.registerLicenseTerms(terms);
+        uint32 termsId = pilTemplate.registerLicenseTerms(terms);
         assertEq(pilTemplate.getLicenseTermsURI(termsId), "license.url");
 
         PILTerms memory terms1 = PILFlavors.commercialUse({
@@ -524,7 +524,7 @@ contract PILicenseTemplateTest is BaseTest {
             royaltyPolicy: address(royaltyPolicyLAP)
         });
         terms1.uri = "another.license.url";
-        uint256 termsId1 = pilTemplate.registerLicenseTerms(terms1);
+        uint32 termsId1 = pilTemplate.registerLicenseTerms(terms1);
 
         assertEq(pilTemplate.getLicenseTermsURI(termsId1), "another.license.url");
         assertEq(pilTemplate.getLicenseTermsURI(termsId), "license.url");
@@ -533,8 +533,8 @@ contract PILicenseTemplateTest is BaseTest {
     }
 
     function test_PILicenseTemplate_getEarlierExpiredTime_WithEmptyLicenseTerms() public {
-        uint256[] memory licenseTermsIds = new uint256[](0);
-        assertEq(pilTemplate.getEarlierExpireTime(licenseTermsIds, block.timestamp), 0);
+        uint32[] memory licenseTermsIds = new uint32[](0);
+        assertEq(pilTemplate.getEarlierExpireTime(licenseTermsIds, uint40(block.timestamp)), 0);
     }
 
     function test_PILicenseTemplate_name() public {

--- a/test/foundry/registries/LicenseRegistry.t.sol
+++ b/test/foundry/registries/LicenseRegistry.t.sol
@@ -85,7 +85,7 @@ contract LicenseRegistryTest is BaseTest {
     }
 
     function test_LicenseRegistry_setDefaultLicenseTerms() public {
-        uint256 socialRemixTermsId = pilTemplate.registerLicenseTerms(PILFlavors.nonCommercialSocialRemixing());
+        uint32 socialRemixTermsId = pilTemplate.registerLicenseTerms(PILFlavors.nonCommercialSocialRemixing());
         vm.prank(admin);
         licenseRegistry.setDefaultLicenseTerms(address(pilTemplate), socialRemixTermsId);
         (address defaultLicenseTemplate, uint256 defaultLicenseTermsId) = licenseRegistry.getDefaultLicenseTerms();
@@ -118,7 +118,7 @@ contract LicenseRegistryTest is BaseTest {
     }
 
     function test_LicenseRegistry_setMintingLicenseConfigForLicense() public {
-        uint256 defaultTermsId = pilTemplate.registerLicenseTerms(PILFlavors.defaultValuesLicenseTerms());
+        uint32 defaultTermsId = pilTemplate.registerLicenseTerms(PILFlavors.defaultValuesLicenseTerms());
         Licensing.MintingLicenseConfig memory mintingLicenseConfig = Licensing.MintingLicenseConfig({
             isSet: true,
             mintingFee: 100,
@@ -147,7 +147,7 @@ contract LicenseRegistryTest is BaseTest {
 
     function test_LicenseRegistry_setMintingLicenseConfigForLicense_revert_UnregisteredTemplate() public {
         MockLicenseTemplate pilTemplate2 = new MockLicenseTemplate();
-        uint256 termsId = pilTemplate2.registerLicenseTerms();
+        uint32 termsId = pilTemplate2.registerLicenseTerms();
         Licensing.MintingLicenseConfig memory mintingLicenseConfig = Licensing.MintingLicenseConfig({
             isSet: true,
             mintingFee: 100,
@@ -164,7 +164,7 @@ contract LicenseRegistryTest is BaseTest {
     }
 
     function test_LicenseRegistry_setMintingLicenseConfigForIp() public {
-        uint256 defaultTermsId = pilTemplate.registerLicenseTerms(PILFlavors.defaultValuesLicenseTerms());
+        uint32 defaultTermsId = pilTemplate.registerLicenseTerms(PILFlavors.defaultValuesLicenseTerms());
         Licensing.MintingLicenseConfig memory mintingLicenseConfig = Licensing.MintingLicenseConfig({
             isSet: true,
             mintingFee: 100,
@@ -189,30 +189,30 @@ contract LicenseRegistryTest is BaseTest {
 
     // test attachLicenseTermsToIp
     function test_LicenseRegistry_attachLicenseTermsToIp_revert_CannotAttachToDerivativeIP() public {
-        uint256 socialRemixTermsId = pilTemplate.registerLicenseTerms(PILFlavors.nonCommercialSocialRemixing());
+        uint32 socialRemixTermsId = pilTemplate.registerLicenseTerms(PILFlavors.nonCommercialSocialRemixing());
         vm.prank(admin);
         licenseRegistry.setDefaultLicenseTerms(address(pilTemplate), socialRemixTermsId);
 
         address[] memory parentIpIds = new address[](1);
         parentIpIds[0] = ipId1;
-        uint256[] memory licenseTermsIds = new uint256[](1);
+        uint32[] memory licenseTermsIds = new uint32[](1);
         licenseTermsIds[0] = socialRemixTermsId;
         vm.prank(ipOwner2);
         licensingModule.registerDerivative(ipId2, parentIpIds, licenseTermsIds, address(pilTemplate), "");
 
-        uint256 defaultTermsId = pilTemplate.registerLicenseTerms(PILFlavors.defaultValuesLicenseTerms());
+        uint32 defaultTermsId = pilTemplate.registerLicenseTerms(PILFlavors.defaultValuesLicenseTerms());
         vm.expectRevert(Errors.LicensingModule__DerivativesCannotAddLicenseTerms.selector);
         vm.prank(address(licensingModule));
         licenseRegistry.attachLicenseTermsToIp(ipId2, address(pilTemplate), defaultTermsId);
     }
 
     function test_LicenseRegistry_registerDerivativeIp_revert_parentsArrayEmpty() public {
-        uint256 socialRemixTermsId = pilTemplate.registerLicenseTerms(PILFlavors.nonCommercialSocialRemixing());
+        uint32 socialRemixTermsId = pilTemplate.registerLicenseTerms(PILFlavors.nonCommercialSocialRemixing());
         vm.prank(admin);
         licenseRegistry.setDefaultLicenseTerms(address(pilTemplate), socialRemixTermsId);
 
         address[] memory parentIpIds = new address[](0);
-        uint256[] memory licenseTermsIds = new uint256[](1);
+        uint32[] memory licenseTermsIds = new uint32[](1);
         licenseTermsIds[0] = socialRemixTermsId;
         vm.expectRevert(Errors.LicenseRegistry__NoParentIp.selector);
         vm.prank(address(licensingModule));
@@ -221,7 +221,7 @@ contract LicenseRegistryTest is BaseTest {
 
     // test getAttachedLicenseTerms
     function test_LicenseRegistry_getAttachedLicenseTerms_revert_OutOfIndex() public {
-        uint256 socialRemixTermsId = pilTemplate.registerLicenseTerms(PILFlavors.nonCommercialSocialRemixing());
+        uint32 socialRemixTermsId = pilTemplate.registerLicenseTerms(PILFlavors.nonCommercialSocialRemixing());
 
         vm.prank(ipOwner1);
         licensingModule.attachLicenseTerms(ipId1, address(pilTemplate), socialRemixTermsId);
@@ -231,13 +231,13 @@ contract LicenseRegistryTest is BaseTest {
 
     // test getDerivativeIp revert IndexOutOfBounds(
     function test_LicenseRegistry_getDerivativeIp_revert_IndexOutOfBounds() public {
-        uint256 socialRemixTermsId = pilTemplate.registerLicenseTerms(PILFlavors.nonCommercialSocialRemixing());
+        uint32 socialRemixTermsId = pilTemplate.registerLicenseTerms(PILFlavors.nonCommercialSocialRemixing());
         vm.prank(admin);
         licenseRegistry.setDefaultLicenseTerms(address(pilTemplate), socialRemixTermsId);
 
         address[] memory parentIpIds = new address[](1);
         parentIpIds[0] = ipId1;
-        uint256[] memory licenseTermsIds = new uint256[](1);
+        uint32[] memory licenseTermsIds = new uint32[](1);
         licenseTermsIds[0] = socialRemixTermsId;
         vm.prank(ipOwner2);
         licensingModule.registerDerivative(ipId2, parentIpIds, licenseTermsIds, address(pilTemplate), "");
@@ -247,13 +247,13 @@ contract LicenseRegistryTest is BaseTest {
     }
 
     function test_LicenseRegistry_getParentIp_revert_IndexOutOfBounds() public {
-        uint256 socialRemixTermsId = pilTemplate.registerLicenseTerms(PILFlavors.nonCommercialSocialRemixing());
+        uint32 socialRemixTermsId = pilTemplate.registerLicenseTerms(PILFlavors.nonCommercialSocialRemixing());
         vm.prank(admin);
         licenseRegistry.setDefaultLicenseTerms(address(pilTemplate), socialRemixTermsId);
 
         address[] memory parentIpIds = new address[](1);
         parentIpIds[0] = ipId1;
-        uint256[] memory licenseTermsIds = new uint256[](1);
+        uint32[] memory licenseTermsIds = new uint32[](1);
         licenseTermsIds[0] = socialRemixTermsId;
         vm.prank(ipOwner2);
         licensingModule.registerDerivative(ipId2, parentIpIds, licenseTermsIds, address(pilTemplate), "");
@@ -263,7 +263,7 @@ contract LicenseRegistryTest is BaseTest {
     }
 
     function test_LicenseRegistry_registerDerivativeIp() public {
-        uint256 socialRemixTermsId = pilTemplate.registerLicenseTerms(PILFlavors.nonCommercialSocialRemixing());
+        uint32 socialRemixTermsId = pilTemplate.registerLicenseTerms(PILFlavors.nonCommercialSocialRemixing());
         vm.prank(ipOwner1);
         licensingModule.attachLicenseTerms(ipId1, address(pilTemplate), socialRemixTermsId);
         vm.prank(ipOwner2);
@@ -272,7 +272,7 @@ contract LicenseRegistryTest is BaseTest {
         address[] memory parentIpIds = new address[](2);
         parentIpIds[0] = ipId1;
         parentIpIds[1] = ipId2;
-        uint256[] memory licenseTermsIds = new uint256[](2);
+        uint32[] memory licenseTermsIds = new uint32[](2);
         licenseTermsIds[0] = socialRemixTermsId;
         licenseTermsIds[1] = socialRemixTermsId;
         vm.prank(address(licensingModule));
@@ -280,14 +280,14 @@ contract LicenseRegistryTest is BaseTest {
     }
 
     function test_LicenseRegistry_registerDerivativeIp_revert_DuplicateLicense() public {
-        uint256 socialRemixTermsId = pilTemplate.registerLicenseTerms(PILFlavors.nonCommercialSocialRemixing());
+        uint32 socialRemixTermsId = pilTemplate.registerLicenseTerms(PILFlavors.nonCommercialSocialRemixing());
         vm.prank(ipOwner1);
         licensingModule.attachLicenseTerms(ipId1, address(pilTemplate), socialRemixTermsId);
 
         address[] memory parentIpIds = new address[](2);
         parentIpIds[0] = ipId1;
         parentIpIds[1] = ipId1;
-        uint256[] memory licenseTermsIds = new uint256[](2);
+        uint32[] memory licenseTermsIds = new uint32[](2);
         licenseTermsIds[0] = socialRemixTermsId;
         licenseTermsIds[1] = socialRemixTermsId;
         vm.expectRevert(

--- a/test/foundry/upgrades/Upgrades.t.sol
+++ b/test/foundry/upgrades/Upgrades.t.sol
@@ -12,7 +12,6 @@ import { MockIpRoyaltyVaultV2 } from "../mocks/module/MockIpRoyaltyVaultV2.sol";
 import { MockAccessControllerV2 } from "../mocks/module/MockAccessControllerV2.sol";
 
 contract UpgradesTest is BaseTest {
-
     uint32 execDelay = 600;
 
     function setUp() public override {
@@ -45,7 +44,6 @@ contract UpgradesTest is BaseTest {
     }
 
     function test_upgradeAccessController() public {
-        
         (bool immediate, uint32 delay) = protocolAccessManager.canCall(
             u.bob,
             address(accessController),
@@ -53,7 +51,6 @@ contract UpgradesTest is BaseTest {
         );
         assertFalse(immediate);
         assertEq(delay, execDelay);
-
 
         address newAccessController = address(new MockAccessControllerV2());
         vm.prank(u.bob);
@@ -75,7 +72,10 @@ contract UpgradesTest is BaseTest {
 
     function test_deploymentSetup() public {
         // Deployer doesn't have the roles
-        (bool isMember, uint32 executionDelay) = protocolAccessManager.hasRole(ProtocolAdmin.PROTOCOL_ADMIN_ROLE, deployer);
+        (bool isMember, uint32 executionDelay) = protocolAccessManager.hasRole(
+            ProtocolAdmin.PROTOCOL_ADMIN_ROLE,
+            deployer
+        );
         assertFalse(isMember);
         assertEq(executionDelay, 0);
         (isMember, executionDelay) = protocolAccessManager.hasRole(ProtocolAdmin.UPGRADER_ROLE, deployer);
@@ -84,14 +84,17 @@ contract UpgradesTest is BaseTest {
         (isMember, executionDelay) = protocolAccessManager.hasRole(ProtocolAdmin.PAUSE_ADMIN_ROLE, deployer);
         assertFalse(isMember);
         assertEq(executionDelay, 0);
-        
+
         (isMember, executionDelay) = protocolAccessManager.hasRole(ProtocolAdmin.PROTOCOL_ADMIN_ROLE, multisig);
         assertTrue(isMember);
         assertEq(executionDelay, 0);
         (isMember, executionDelay) = protocolAccessManager.hasRole(ProtocolAdmin.PAUSE_ADMIN_ROLE, multisig);
         assertTrue(isMember);
         assertEq(executionDelay, 0);
-        (isMember, executionDelay) = protocolAccessManager.hasRole(ProtocolAdmin.PAUSE_ADMIN_ROLE, address(protocolPauser));
+        (isMember, executionDelay) = protocolAccessManager.hasRole(
+            ProtocolAdmin.PAUSE_ADMIN_ROLE,
+            address(protocolPauser)
+        );
         assertTrue(isMember);
         assertEq(executionDelay, 0);
         (isMember, executionDelay) = protocolAccessManager.hasRole(ProtocolAdmin.UPGRADER_ROLE, multisig);
@@ -99,7 +102,7 @@ contract UpgradesTest is BaseTest {
         assertEq(executionDelay, execDelay);
 
         // Target function role wiring
-        
+
         (bool immediate, uint32 delay) = protocolAccessManager.canCall(
             multisig,
             address(royaltyPolicyLAP),
@@ -107,8 +110,14 @@ contract UpgradesTest is BaseTest {
         );
         assertFalse(immediate);
         assertEq(delay, 600);
-        assertEq(protocolAccessManager.getTargetFunctionRole(address(royaltyPolicyLAP), RoyaltyPolicyLAP.upgradeVaults.selector), ProtocolAdmin.UPGRADER_ROLE);
-        
+        assertEq(
+            protocolAccessManager.getTargetFunctionRole(
+                address(royaltyPolicyLAP),
+                RoyaltyPolicyLAP.upgradeVaults.selector
+            ),
+            ProtocolAdmin.UPGRADER_ROLE
+        );
+
         (immediate, delay) = protocolAccessManager.canCall(
             multisig,
             address(accessController),
@@ -116,7 +125,13 @@ contract UpgradesTest is BaseTest {
         );
         assertFalse(immediate);
         assertEq(delay, execDelay);
-        assertEq(protocolAccessManager.getTargetFunctionRole(address(accessController), UUPSUpgradeable.upgradeToAndCall.selector), ProtocolAdmin.UPGRADER_ROLE);
+        assertEq(
+            protocolAccessManager.getTargetFunctionRole(
+                address(accessController),
+                UUPSUpgradeable.upgradeToAndCall.selector
+            ),
+            ProtocolAdmin.UPGRADER_ROLE
+        );
 
         (immediate, delay) = protocolAccessManager.canCall(
             multisig,
@@ -125,7 +140,13 @@ contract UpgradesTest is BaseTest {
         );
         assertFalse(immediate);
         assertEq(delay, execDelay);
-        assertEq(protocolAccessManager.getTargetFunctionRole(address(licenseToken), UUPSUpgradeable.upgradeToAndCall.selector), ProtocolAdmin.UPGRADER_ROLE);
+        assertEq(
+            protocolAccessManager.getTargetFunctionRole(
+                address(licenseToken),
+                UUPSUpgradeable.upgradeToAndCall.selector
+            ),
+            ProtocolAdmin.UPGRADER_ROLE
+        );
 
         (immediate, delay) = protocolAccessManager.canCall(
             multisig,
@@ -134,7 +155,13 @@ contract UpgradesTest is BaseTest {
         );
         assertFalse(immediate);
         assertEq(delay, execDelay);
-        assertEq(protocolAccessManager.getTargetFunctionRole(address(disputeModule), UUPSUpgradeable.upgradeToAndCall.selector), ProtocolAdmin.UPGRADER_ROLE);
+        assertEq(
+            protocolAccessManager.getTargetFunctionRole(
+                address(disputeModule),
+                UUPSUpgradeable.upgradeToAndCall.selector
+            ),
+            ProtocolAdmin.UPGRADER_ROLE
+        );
 
         (immediate, delay) = protocolAccessManager.canCall(
             multisig,
@@ -143,7 +170,13 @@ contract UpgradesTest is BaseTest {
         );
         assertFalse(immediate);
         assertEq(delay, execDelay);
-        assertEq(protocolAccessManager.getTargetFunctionRole(address(arbitrationPolicySP), UUPSUpgradeable.upgradeToAndCall.selector), ProtocolAdmin.UPGRADER_ROLE);
+        assertEq(
+            protocolAccessManager.getTargetFunctionRole(
+                address(arbitrationPolicySP),
+                UUPSUpgradeable.upgradeToAndCall.selector
+            ),
+            ProtocolAdmin.UPGRADER_ROLE
+        );
 
         (immediate, delay) = protocolAccessManager.canCall(
             multisig,
@@ -152,7 +185,13 @@ contract UpgradesTest is BaseTest {
         );
         assertFalse(immediate);
         assertEq(delay, execDelay);
-        assertEq(protocolAccessManager.getTargetFunctionRole(address(licensingModule), UUPSUpgradeable.upgradeToAndCall.selector), ProtocolAdmin.UPGRADER_ROLE);
+        assertEq(
+            protocolAccessManager.getTargetFunctionRole(
+                address(licensingModule),
+                UUPSUpgradeable.upgradeToAndCall.selector
+            ),
+            ProtocolAdmin.UPGRADER_ROLE
+        );
 
         (immediate, delay) = protocolAccessManager.canCall(
             multisig,
@@ -161,7 +200,13 @@ contract UpgradesTest is BaseTest {
         );
         assertFalse(immediate);
         assertEq(delay, execDelay);
-        assertEq(protocolAccessManager.getTargetFunctionRole(address(royaltyModule), UUPSUpgradeable.upgradeToAndCall.selector), ProtocolAdmin.UPGRADER_ROLE);
+        assertEq(
+            protocolAccessManager.getTargetFunctionRole(
+                address(royaltyModule),
+                UUPSUpgradeable.upgradeToAndCall.selector
+            ),
+            ProtocolAdmin.UPGRADER_ROLE
+        );
 
         (immediate, delay) = protocolAccessManager.canCall(
             multisig,
@@ -170,7 +215,13 @@ contract UpgradesTest is BaseTest {
         );
         assertFalse(immediate);
         assertEq(delay, execDelay);
-        assertEq(protocolAccessManager.getTargetFunctionRole(address(licenseRegistry), UUPSUpgradeable.upgradeToAndCall.selector), ProtocolAdmin.UPGRADER_ROLE);
+        assertEq(
+            protocolAccessManager.getTargetFunctionRole(
+                address(licenseRegistry),
+                UUPSUpgradeable.upgradeToAndCall.selector
+            ),
+            ProtocolAdmin.UPGRADER_ROLE
+        );
 
         (immediate, delay) = protocolAccessManager.canCall(
             multisig,
@@ -179,7 +230,13 @@ contract UpgradesTest is BaseTest {
         );
         assertFalse(immediate);
         assertEq(delay, execDelay);
-        assertEq(protocolAccessManager.getTargetFunctionRole(address(moduleRegistry), UUPSUpgradeable.upgradeToAndCall.selector), ProtocolAdmin.UPGRADER_ROLE);
+        assertEq(
+            protocolAccessManager.getTargetFunctionRole(
+                address(moduleRegistry),
+                UUPSUpgradeable.upgradeToAndCall.selector
+            ),
+            ProtocolAdmin.UPGRADER_ROLE
+        );
 
         (immediate, delay) = protocolAccessManager.canCall(
             multisig,
@@ -188,7 +245,13 @@ contract UpgradesTest is BaseTest {
         );
         assertFalse(immediate);
         assertEq(delay, execDelay);
-        assertEq(protocolAccessManager.getTargetFunctionRole(address(ipAssetRegistry), UUPSUpgradeable.upgradeToAndCall.selector), ProtocolAdmin.UPGRADER_ROLE);
+        assertEq(
+            protocolAccessManager.getTargetFunctionRole(
+                address(ipAssetRegistry),
+                UUPSUpgradeable.upgradeToAndCall.selector
+            ),
+            ProtocolAdmin.UPGRADER_ROLE
+        );
 
         (immediate, delay) = protocolAccessManager.canCall(
             multisig,
@@ -197,6 +260,12 @@ contract UpgradesTest is BaseTest {
         );
         assertFalse(immediate);
         assertEq(delay, execDelay);
-        assertEq(protocolAccessManager.getTargetFunctionRole(address(royaltyPolicyLAP), UUPSUpgradeable.upgradeToAndCall.selector), ProtocolAdmin.UPGRADER_ROLE);
+        assertEq(
+            protocolAccessManager.getTargetFunctionRole(
+                address(royaltyPolicyLAP),
+                UUPSUpgradeable.upgradeToAndCall.selector
+            ),
+            ProtocolAdmin.UPGRADER_ROLE
+        );
     }
 }

--- a/test/foundry/utils/LicensingHelper.t.sol
+++ b/test/foundry/utils/LicensingHelper.t.sol
@@ -16,7 +16,7 @@ contract LicensingHelper {
     IERC20 private erc20; // keep private to avoid collision with `BaseIntegration`
 
     mapping(string selectionName => PILTerms) internal selectedPILicenseTerms;
-    mapping(string selectionName => uint256 licenseTermsId) internal selectedPILicenseTermsId;
+    mapping(string selectionName => uint32 licenseTermsId) internal selectedPILicenseTermsId;
 
     string[] internal emptyStringArray = new string[](0);
 
@@ -29,7 +29,7 @@ contract LicensingHelper {
     function registerSelectedPILicenseTerms(
         string memory selectionName,
         PILTerms memory selectedPILicenseTerms_
-    ) public returns (uint256 pilSelectedLicenseTermsId) {
+    ) public returns (uint32 pilSelectedLicenseTermsId) {
         string memory _selectionName = string(abi.encodePacked("PIL_", selectionName));
         pilSelectedLicenseTermsId = pilTemplate.registerLicenseTerms(selectedPILicenseTerms_);
         // pilSelectedLicenseTermsId = pilTemplate.getLicenseTermsId(selectedPILicenseTerms_);
@@ -45,7 +45,7 @@ contract LicensingHelper {
         bool reciprocal,
         uint32 commercialRevShare,
         uint256 mintingFee
-    ) public returns (uint256 pilSelectedLicenseTermsId) {
+    ) public returns (uint32 pilSelectedLicenseTermsId) {
         pilSelectedLicenseTermsId = registerSelectedPILicenseTerms(
             selectionName,
             mapSelectedPILicenseTerms_Commercial(transferable, derivatives, reciprocal, commercialRevShare, mintingFee)
@@ -57,7 +57,7 @@ contract LicensingHelper {
         bool transferable,
         bool derivatives,
         bool reciprocal
-    ) public returns (uint256 pilSelectedLicenseTermsId) {
+    ) public returns (uint32 pilSelectedLicenseTermsId) {
         pilSelectedLicenseTermsId = registerSelectedPILicenseTerms(
             selectionName,
             mapSelectedPILicenseTerms_NonCommercial(transferable, derivatives, reciprocal)
@@ -66,7 +66,7 @@ contract LicensingHelper {
 
     function registerSelectedPILicenseTerms_NonCommercialSocialRemixing()
         public
-        returns (uint256 pilSelectedLicenseTermsId)
+        returns (uint32 pilSelectedLicenseTermsId)
     {
         pilSelectedLicenseTermsId = registerSelectedPILicenseTerms(
             "nc_social_remix",
@@ -135,7 +135,7 @@ contract LicensingHelper {
         return selectedPILicenseTerms[selectionName];
     }
 
-    function getSelectedPILicenseTermsId(string memory selectionName) internal view returns (uint256) {
+    function getSelectedPILicenseTermsId(string memory selectionName) internal view returns (uint32) {
         string memory _selectionName = string(abi.encodePacked("PIL_", selectionName));
         return selectedPILicenseTermsId[selectionName];
     }


### PR DESCRIPTION
Optimizes LicenseTokenMetadata struct to use fewer storage slots.

Notes:
- EnumerableSet only supports uint256 for Uint, so while `licenseTermsId` is `uint32`, `attachedLicenseTerms` is `uint256`. This requires casting between the two.
- Casts `block.timestamp` to `uint40`.

Closes #93