### PR TITLE
Gas optimization in IpRoyaltyVault

### DIFF
--- a/contracts/modules/royalty/policies/IpRoyaltyVault.sol
+++ b/contracts/modules/royalty/policies/IpRoyaltyVault.sol
@@ -38,7 +38,7 @@ contract IpRoyaltyVault is IIpRoyaltyVault, ERC20SnapshotUpgradeable, Reentrancy
     struct IpRoyaltyVaultStorage {
         address ipId;
         uint32 unclaimedRoyaltyTokens;
-        uint256 lastSnapshotTimestamp;
+        uint40 lastSnapshotTimestamp;
         mapping(address token => uint256 amount) ancestorsVaultAmount;
         mapping(address ancestorIpId => bool) isCollectedByAncestor;
         mapping(address token => uint256 amount) claimVaultAmount;
@@ -96,7 +96,7 @@ contract IpRoyaltyVault is IIpRoyaltyVault, ERC20SnapshotUpgradeable, Reentrancy
         IpRoyaltyVaultStorage storage $ = _getIpRoyaltyVaultStorage();
 
         $.ipId = ipIdAddress;
-        $.lastSnapshotTimestamp = block.timestamp;
+        $.lastSnapshotTimestamp = uint40(block.timestamp);
         $.unclaimedRoyaltyTokens = unclaimedTokens;
 
         _mint(address(this), unclaimedTokens);
@@ -130,7 +130,7 @@ contract IpRoyaltyVault is IIpRoyaltyVault, ERC20SnapshotUpgradeable, Reentrancy
             revert Errors.IpRoyaltyVault__SnapshotIntervalTooShort();
 
         uint256 snapshotId = _snapshot();
-        $.lastSnapshotTimestamp = block.timestamp;
+        $.lastSnapshotTimestamp = uint40(block.timestamp);
 
         uint32 unclaimedTokens = $.unclaimedRoyaltyTokens;
         $.unclaimedAtSnapshot[snapshotId] = unclaimedTokens;

--- a/yarn.lock
+++ b/yarn.lock
@@ -4936,6 +4936,11 @@ slice-ansi@^4.0.0:
     astral-regex "^2.0.0"
     is-fullwidth-code-point "^3.0.0"
 
+solady@^0.0.191:
+  version "0.0.191"
+  resolved "https://registry.yarnpkg.com/solady/-/solady-0.0.191.tgz#a4a285ddbcc0d5a8860128ffdd6ea1564b673199"
+  integrity sha512-wiab1exBWHT7tLv8m+MnIppa0cn1PBhYskdYqe9/WYgL5Tn2cph5uZVLgy3H3fXXrya68Y5K5oe17hvOyrU87Q==
+
 solc@0.7.3:
   version "0.7.3"
   resolved "https://registry.yarnpkg.com/solc/-/solc-0.7.3.tgz#04646961bd867a744f63d2b4e3c0701ffdc7d78a"


### PR DESCRIPTION
Relates to issue https://github.com/storyprotocol/protocol-core-v1/issues/100

Makes timestamp a uint40.