### PR TITLE
Deploy with CREATE3 for Deterministic Addresses to Resolve Cyclical Dependencies in Contract Deployment

### DIFF
--- a/contracts/LicenseToken.sol
+++ b/contracts/LicenseToken.sol
@@ -19,6 +19,9 @@ import { ILicenseTemplate } from "./interfaces/modules/licensing/ILicenseTemplat
 contract LicenseToken is ILicenseToken, ERC721EnumerableUpgradeable, AccessManagedUpgradeable, UUPSUpgradeable {
     using Strings for *;
 
+    ILicensingModule public immutable LICENSING_MODULE;
+    IDisputeModule public immutable DISPUTE_MODULE;
+
     /// @notice Emitted for metadata updates, per EIP-4906
     event BatchMetadataUpdate(uint256 _fromTokenId, uint256 _toTokenId);
 
@@ -26,8 +29,6 @@ contract LicenseToken is ILicenseToken, ERC721EnumerableUpgradeable, AccessManag
     /// @custom:storage-location erc7201:story-protocol.LicenseToken
     struct LicenseTokenStorage {
         string imageUrl;
-        ILicensingModule licensingModule;
-        IDisputeModule disputeModule;
         uint256 totalMintedTokens;
         mapping(uint256 tokenId => LicenseTokenMetadata) licenseTokenMetadatas;
     }
@@ -37,14 +38,16 @@ contract LicenseToken is ILicenseToken, ERC721EnumerableUpgradeable, AccessManag
         0x62a0d75e37bea0c3e666dc72a74112fc6af15ce635719127e380d8ca1e555d00;
 
     modifier onlyLicensingModule() {
-        if (msg.sender != address(_getLicenseTokenStorage().licensingModule)) {
+        if (msg.sender != address(LICENSING_MODULE)) {
             revert Errors.LicenseToken__CallerNotLicensingModule();
         }
         _;
     }
 
     /// @custom:oz-upgrades-unsafe-allow constructor
-    constructor() {
+    constructor(address licensingModule, address disputeModule) {
+        LICENSING_MODULE = ILicensingModule(licensingModule);
+        DISPUTE_MODULE = IDisputeModule(disputeModule);
         _disableInitializers();
     }
 
@@ -57,28 +60,6 @@ contract LicenseToken is ILicenseToken, ERC721EnumerableUpgradeable, AccessManag
         __AccessManaged_init(accessManager);
         __UUPSUpgradeable_init();
         _getLicenseTokenStorage().imageUrl = imageUrl;
-    }
-
-    /// @notice Sets the LicensingModule address.
-    /// @dev Enforced to be only callable by the protocol admin
-    /// @param newLicensingModule The address of the LicensingModule
-    function setLicensingModule(address newLicensingModule) external restricted {
-        if (newLicensingModule == address(0)) {
-            revert Errors.LicenseToken__ZeroLicensingModule();
-        }
-        LicenseTokenStorage storage $ = _getLicenseTokenStorage();
-        $.licensingModule = ILicensingModule(newLicensingModule);
-    }
-
-    /// @notice Sets the DisputeModule address.
-    /// @dev Enforced to be only callable by the protocol admin
-    /// @param newDisputeModule The address of the DisputeModule
-    function setDisputeModule(address newDisputeModule) external restricted {
-        if (newDisputeModule == address(0)) {
-            revert Errors.LicenseToken__ZeroDisputeModule();
-        }
-        LicenseTokenStorage storage $ = _getLicenseTokenStorage();
-        $.disputeModule = IDisputeModule(newDisputeModule);
     }
 
     /// @dev Sets the Licensing Image URL.
@@ -207,16 +188,11 @@ contract LicenseToken is ILicenseToken, ERC721EnumerableUpgradeable, AccessManag
         return _getLicenseTokenStorage().licenseTokenMetadatas[tokenId].licenseTemplate;
     }
 
-    /// @notice Returns the canonical protocol-wide DisputeModule
-    /// @return The DisputeModule instance
-    function disputeModule() external view returns (IDisputeModule) {
-        return _getLicenseTokenStorage().disputeModule;
-    }
-
-    /// @notice Returns the canonical protocol-wide LicensingModule
-    /// @return The LicensingModule instance
-    function licensingModule() external view returns (ILicensingModule) {
-        return _getLicenseTokenStorage().licensingModule;
+    /// @notice Gets the expiration time of a License Token.
+    /// @param tokenId The ID of the License Token.
+    /// @return The expiration time of the License Token.
+    function getExpirationTime(uint256 tokenId) external view returns (uint256) {
+        return _getLicenseTokenStorage().licenseTokenMetadatas[tokenId].expiresAt;
     }
 
     /// @notice Returns true if the license has been revoked (licensor IP tagged after a dispute in
@@ -224,7 +200,7 @@ contract LicenseToken is ILicenseToken, ERC721EnumerableUpgradeable, AccessManag
     /// @return isRevoked True if the license is revoked
     function isLicenseTokenRevoked(uint256 tokenId) public view returns (bool) {
         LicenseTokenStorage storage $ = _getLicenseTokenStorage();
-        return $.disputeModule.isIpTagged($.licenseTokenMetadatas[tokenId].licensorIpId);
+        return DISPUTE_MODULE.isIpTagged($.licenseTokenMetadatas[tokenId].licensorIpId);
     }
 
     /// @notice ERC721 OpenSea metadata JSON representation of the LNFT parameters

--- a/contracts/LicenseToken.sol
+++ b/contracts/LicenseToken.sol
@@ -188,13 +188,6 @@ contract LicenseToken is ILicenseToken, ERC721EnumerableUpgradeable, AccessManag
         return _getLicenseTokenStorage().licenseTokenMetadatas[tokenId].licenseTemplate;
     }
 
-    /// @notice Gets the expiration time of a License Token.
-    /// @param tokenId The ID of the License Token.
-    /// @return The expiration time of the License Token.
-    function getExpirationTime(uint256 tokenId) external view returns (uint256) {
-        return _getLicenseTokenStorage().licenseTokenMetadatas[tokenId].expiresAt;
-    }
-
     /// @notice Returns true if the license has been revoked (licensor IP tagged after a dispute in
     /// the dispute module). If the tag is removed, the license is not revoked anymore.
     /// @return isRevoked True if the license is revoked

--- a/contracts/access/AccessController.sol
+++ b/contracts/access/AccessController.sol
@@ -52,6 +52,8 @@ contract AccessController is IAccessController, ProtocolPausableUpgradeable, UUP
     /// Constructor
     /// @custom:oz-upgrades-unsafe-allow constructor
     constructor(address ipAccountRegistry, address moduleRegistry) {
+        if (ipAccountRegistry == address(0)) revert Errors.AccessController__ZeroIPAccountRegistry();
+        if (moduleRegistry == address(0)) revert Errors.AccessController__ZeroModuleRegistry();
         IP_ACCOUNT_REGISTRY = IIPAccountRegistry(ipAccountRegistry);
         MODULE_REGISTRY = IModuleRegistry(moduleRegistry);
         _disableInitializers();

--- a/contracts/access/AccessController.sol
+++ b/contracts/access/AccessController.sol
@@ -153,11 +153,7 @@ contract AccessController is IAccessController, ProtocolPausableUpgradeable, UUP
         // If the caller (signer) is not the Owner, IPAccount is limited to interactions with only registered modules.
         // These interactions can be either initiating calls to these modules or receiving calls from them.
         // The IP account can also modify its own Permissions settings.
-        if (
-            to != address(this) &&
-            !MODULE_REGISTRY.isRegistered(to) &&
-            !MODULE_REGISTRY.isRegistered(signer)
-        ) {
+        if (to != address(this) && !MODULE_REGISTRY.isRegistered(to) && !MODULE_REGISTRY.isRegistered(signer)) {
             revert Errors.AccessController__BothCallerAndRecipientAreNotRegisteredModule(signer, to);
         }
 

--- a/contracts/access/AccessController.sol
+++ b/contracts/access/AccessController.sol
@@ -32,6 +32,9 @@ import { Errors } from "../lib/Errors.sol";
 contract AccessController is IAccessController, ProtocolPausableUpgradeable, UUPSUpgradeable {
     using IPAccountChecker for IIPAccountRegistry;
 
+    IIPAccountRegistry public immutable IP_ACCOUNT_REGISTRY;
+    IModuleRegistry public immutable MODULE_REGISTRY;
+
     /// @dev The storage struct of AccessController.
     /// @param encodedPermissions tracks the permission granted to an encoded permission path, where the
     /// encoded permission path = keccak256(abi.encodePacked(ipAccount, signer, to, func))
@@ -40,8 +43,6 @@ contract AccessController is IAccessController, ProtocolPausableUpgradeable, UUP
     /// @custom:storage-location erc7201:story-protocol.AccessController
     struct AccessControllerStorage {
         mapping(bytes32 => uint8) encodedPermissions;
-        address ipAccountRegistry;
-        address moduleRegistry;
     }
 
     // keccak256(abi.encode(uint256(keccak256("story-protocol.AccessController")) - 1)) & ~bytes32(uint256(0xff));
@@ -50,7 +51,9 @@ contract AccessController is IAccessController, ProtocolPausableUpgradeable, UUP
 
     /// Constructor
     /// @custom:oz-upgrades-unsafe-allow constructor
-    constructor() {
+    constructor(address ipAccountRegistry, address moduleRegistry) {
+        IP_ACCOUNT_REGISTRY = IIPAccountRegistry(ipAccountRegistry);
+        MODULE_REGISTRY = IModuleRegistry(moduleRegistry);
         _disableInitializers();
     }
 
@@ -62,16 +65,6 @@ contract AccessController is IAccessController, ProtocolPausableUpgradeable, UUP
         }
         __ProtocolPausable_init(accessManager);
         __UUPSUpgradeable_init();
-    }
-
-    /// @notice Sets the addresses of the IP account registry and the module registry
-    /// @dev TODO: Set these addresses in the constructor to make them immutable
-    /// @param ipAccountRegistry address of the IP account registry
-    /// @param moduleRegistry address of the module registry
-    function setAddresses(address ipAccountRegistry, address moduleRegistry) external restricted {
-        AccessControllerStorage storage $ = _getAccessControllerStorage();
-        $.ipAccountRegistry = ipAccountRegistry;
-        $.moduleRegistry = moduleRegistry;
     }
 
     /// @notice Sets a batch of permissions in a single transaction.
@@ -121,7 +114,7 @@ contract AccessController is IAccessController, ProtocolPausableUpgradeable, UUP
             revert Errors.AccessController__SignerIsZeroAddress();
         }
         AccessControllerStorage storage $ = _getAccessControllerStorage();
-        if (!IIPAccountRegistry($.ipAccountRegistry).isIpAccount(ipAccount)) {
+        if (!IP_ACCOUNT_REGISTRY.isIpAccount(ipAccount)) {
             revert Errors.AccessController__IPAccountIsNotValid(ipAccount);
         }
         // permission must be one of ABSTAIN, ALLOW, DENY
@@ -149,7 +142,7 @@ contract AccessController is IAccessController, ProtocolPausableUpgradeable, UUP
     function checkPermission(address ipAccount, address signer, address to, bytes4 func) external view {
         AccessControllerStorage storage $ = _getAccessControllerStorage();
         // Must be a valid IPAccount
-        if (!IIPAccountRegistry($.ipAccountRegistry).isIpAccount(ipAccount)) {
+        if (!IP_ACCOUNT_REGISTRY.isIpAccount(ipAccount)) {
             revert Errors.AccessController__IPAccountIsNotValid(ipAccount);
         }
         // Owner can call any contracts either registered module or unregistered/external contracts
@@ -162,8 +155,8 @@ contract AccessController is IAccessController, ProtocolPausableUpgradeable, UUP
         // The IP account can also modify its own Permissions settings.
         if (
             to != address(this) &&
-            !IModuleRegistry($.moduleRegistry).isRegistered(to) &&
-            !IModuleRegistry($.moduleRegistry).isRegistered(signer)
+            !MODULE_REGISTRY.isRegistered(to) &&
+            !MODULE_REGISTRY.isRegistered(signer)
         ) {
             revert Errors.AccessController__BothCallerAndRecipientAreNotRegisteredModule(signer, to);
         }

--- a/contracts/interfaces/ILicenseToken.sol
+++ b/contracts/interfaces/ILicenseToken.sol
@@ -86,14 +86,6 @@ interface ILicenseToken is IERC721Metadata, IERC721Enumerable {
     /// @return A `LicenseTokenMetadata` struct containing the metadata of the specified License Token.
     function getLicenseTokenMetadata(uint256 tokenId) external view returns (LicenseTokenMetadata memory);
 
-    /// @notice Returns the canonical protocol-wide DisputeModule
-    /// @return The DisputeModule instance
-    function disputeModule() external view returns (IDisputeModule);
-
-    /// @notice Returns the canonical protocol-wide LicensingModule
-    /// @return The LicensingModule instance
-    function licensingModule() external view returns (ILicensingModule);
-
     /// @notice Validates License Tokens for registering a derivative IP.
     /// @dev This function checks if the License Tokens are valid for the derivative IP registration process.
     /// The function will be called by LicensingModule when registering a derivative IP with license tokens.

--- a/contracts/interfaces/ILicenseToken.sol
+++ b/contracts/interfaces/ILicenseToken.sol
@@ -4,9 +4,6 @@ pragma solidity 0.8.23;
 import { IERC721Metadata } from "@openzeppelin/contracts/token/ERC721/extensions/IERC721Metadata.sol";
 import { IERC721Enumerable } from "@openzeppelin/contracts/token/ERC721/extensions/IERC721Enumerable.sol";
 
-import { IDisputeModule } from "./modules/dispute/IDisputeModule.sol";
-import { ILicensingModule } from "./modules/licensing/ILicensingModule.sol";
-
 /// @title ILicenseToken
 /// @notice Interface for the License Token (ERC721) NFT collection that manages License Tokens representing
 /// License Terms.

--- a/contracts/interfaces/modules/royalty/IRoyaltyModule.sol
+++ b/contracts/interfaces/modules/royalty/IRoyaltyModule.sol
@@ -30,14 +30,6 @@ interface IRoyaltyModule is IModule {
     /// @param amount The amount paid
     event LicenseMintingFeePaid(address receiverIpId, address payerAddress, address token, uint256 amount);
 
-    /// @notice Sets the licensing module
-    /// @dev Enforced to be only callable by the protocol admin
-    /// @param licensing The address of the license module
-    function setLicensingModule(address licensing) external;
-
-    /// @notice Returns the licensing module address
-    function licensingModule() external view returns (address);
-
     /// @notice Indicates if a royalty policy is whitelisted
     /// @param royaltyPolicy The address of the royalty policy
     /// @return isWhitelisted True if the royalty policy is whitelisted

--- a/contracts/lib/Errors.sol
+++ b/contracts/lib/Errors.sol
@@ -63,6 +63,18 @@ library Errors {
     /// @notice Zero address provided for Access Manager in initializer.
     error LicenseRegistry__ZeroAccessManager();
 
+    /// @notice Zero address provided for IP Asset Registry.
+    error LicensingModule__ZeroRoyaltyModule();
+
+    /// @notice Zero address provided for Licensing Module.
+    error LicensingModule__ZeroLicenseRegistry();
+
+    /// @notice Zero address provided for Dispute Module.
+    error LicensingModule__ZeroDisputeModule();
+
+    /// @notice Zero address provided for License Token.
+    error LicensingModule__ZeroLicenseToken();
+
     /// @notice Zero address provided for Licensing Module.
     error LicenseRegistry__ZeroLicensingModule();
 
@@ -447,6 +459,12 @@ library Errors {
 
     /// @notice Zero address provided for Access Manager in initializer.
     error AccessController__ZeroAccessManager();
+
+    /// @notice Zero address provided for IP Account Registry.
+    error AccessController__ZeroIPAccountRegistry();
+
+    /// @notice Zero address provided for Module Registry.
+    error AccessController__ZeroModuleRegistry();
 
     /// @notice IP Account is zero address.
     error AccessController__IPAccountIsZeroAddress();

--- a/contracts/lib/PILicenseTemplateErrors.sol
+++ b/contracts/lib/PILicenseTemplateErrors.sol
@@ -42,4 +42,10 @@ library PILicenseTemplateErrors {
 
     /// @notice Cannot add derivative reciprocal when derivative use is disabled.
     error PILicenseTemplate__DerivativesDisabled_CantAddReciprocal();
+
+    /// @notice Zero address provided for License Registry at initialization.
+    error PILicenseTemplate__ZeroLicenseRegistry();
+
+    /// @notice Zero address provided for Royalty Module at initialization.
+    error PILicenseTemplate__ZeroRoyaltyModule();
 }

--- a/contracts/modules/licensing/LicensingModule.sol
+++ b/contracts/modules/licensing/LicensingModule.sol
@@ -75,19 +75,23 @@ contract LicensingModule is
     /// @param accessController The address of the AccessController contract
     /// @param ipAccountRegistry The address of the IPAccountRegistry contract
     /// @param royaltyModule The address of the RoyaltyModule contract
-    /// @param registry The address of the LicenseRegistry contract
+    /// @param licenseRegistry The address of the LicenseRegistry contract
     /// @param disputeModule The address of the DisputeModule contract
     /// @custom:oz-upgrades-unsafe-allow constructor
     constructor(
         address accessController,
         address ipAccountRegistry,
         address royaltyModule,
-        address registry,
+        address licenseRegistry,
         address disputeModule,
         address licenseToken
     ) AccessControlled(accessController, ipAccountRegistry) {
+        if (royaltyModule == address(0))  revert Errors.LicensingModule__ZeroRoyaltyModule();
+        if (licenseRegistry == address(0)) revert Errors.LicensingModule__ZeroLicenseRegistry();
+        if (disputeModule == address(0)) revert Errors.LicensingModule__ZeroDisputeModule();
+        if (licenseToken == address(0)) revert Errors.LicensingModule__ZeroLicenseToken();
         ROYALTY_MODULE = RoyaltyModule(royaltyModule);
-        LICENSE_REGISTRY = ILicenseRegistry(registry);
+        LICENSE_REGISTRY = ILicenseRegistry(licenseRegistry);
         DISPUTE_MODULE = IDisputeModule(disputeModule);
         LICENSE_NFT = ILicenseToken(licenseToken);
         _disableInitializers();

--- a/contracts/modules/licensing/LicensingModule.sol
+++ b/contracts/modules/licensing/LicensingModule.sol
@@ -86,7 +86,7 @@ contract LicensingModule is
         address disputeModule,
         address licenseToken
     ) AccessControlled(accessController, ipAccountRegistry) {
-        if (royaltyModule == address(0))  revert Errors.LicensingModule__ZeroRoyaltyModule();
+        if (royaltyModule == address(0)) revert Errors.LicensingModule__ZeroRoyaltyModule();
         if (licenseRegistry == address(0)) revert Errors.LicensingModule__ZeroLicenseRegistry();
         if (disputeModule == address(0)) revert Errors.LicensingModule__ZeroDisputeModule();
         if (licenseToken == address(0)) revert Errors.LicensingModule__ZeroLicenseToken();

--- a/contracts/modules/licensing/PILicenseTemplate.sol
+++ b/contracts/modules/licensing/PILicenseTemplate.sol
@@ -56,6 +56,8 @@ contract PILicenseTemplate is
         address licenseRegistry,
         address royaltyModule
     ) LicensorApprovalChecker(accessController, ipAccountRegistry) {
+        if (licenseRegistry == address(0)) revert PILicenseTemplateErrors.PILicenseTemplate__ZeroLicenseRegistry();
+        if (royaltyModule == address(0)) revert PILicenseTemplateErrors.PILicenseTemplate__ZeroRoyaltyModule();
         LICENSE_REGISTRY = ILicenseRegistry(licenseRegistry);
         ROYALTY_MODULE = IRoyaltyModule(royaltyModule);
         _disableInitializers();

--- a/contracts/registries/LicenseRegistry.sol
+++ b/contracts/registries/LicenseRegistry.sol
@@ -73,6 +73,8 @@ contract LicenseRegistry is ILicenseRegistry, AccessManagedUpgradeable, UUPSUpgr
 
     /// @custom:oz-upgrades-unsafe-allow constructor
     constructor(address licensingModule, address disputeModule) {
+        if (licensingModule == address(0)) revert Errors.LicenseRegistry__ZeroLicensingModule();
+        if (disputeModule == address(0)) revert Errors.LicenseRegistry__ZeroDisputeModule();
         LICENSING_MODULE = ILicensingModule(licensingModule);
         DISPUTE_MODULE = IDisputeModule(disputeModule);
         _disableInitializers();

--- a/contracts/registries/LicenseRegistry.sol
+++ b/contracts/registries/LicenseRegistry.sol
@@ -27,9 +27,10 @@ contract LicenseRegistry is ILicenseRegistry, AccessManagedUpgradeable, UUPSUpgr
     using EnumerableSet for EnumerableSet.AddressSet;
     using IPAccountStorageOps for IIPAccount;
 
+    ILicensingModule public immutable LICENSING_MODULE;
+    IDisputeModule public immutable DISPUTE_MODULE;
+
     /// @dev Storage of the LicenseRegistry
-    /// @param licensingModule Returns the canonical protocol-wide LicensingModule
-    /// @param disputeModule Returns the canonical protocol-wide DisputeModule
     /// @param defaultLicenseTemplate The default license template address
     /// @param defaultLicenseTermsId The default license terms ID
     /// @param registeredLicenseTemplates Registered license templates
@@ -46,8 +47,6 @@ contract LicenseRegistry is ILicenseRegistry, AccessManagedUpgradeable, UUPSUpgr
     /// @dev Storage structure for the LicenseRegistry
     /// @custom:storage-location erc7201:story-protocol.LicenseRegistry
     struct LicenseRegistryStorage {
-        ILicensingModule licensingModule;
-        IDisputeModule disputeModule;
         address defaultLicenseTemplate;
         uint256 defaultLicenseTermsId;
         mapping(address licenseTemplate => bool isRegistered) registeredLicenseTemplates;
@@ -66,14 +65,16 @@ contract LicenseRegistry is ILicenseRegistry, AccessManagedUpgradeable, UUPSUpgr
     bytes32 public constant EXPIRATION_TIME = "EXPIRATION_TIME";
 
     modifier onlyLicensingModule() {
-        if (msg.sender != address(_getLicenseRegistryStorage().licensingModule)) {
+        if (msg.sender != address(LICENSING_MODULE)) {
             revert Errors.LicenseRegistry__CallerNotLicensingModule();
         }
         _;
     }
 
     /// @custom:oz-upgrades-unsafe-allow constructor
-    constructor() {
+    constructor(address licensingModule, address disputeModule) {
+        LICENSING_MODULE = ILicensingModule(licensingModule);
+        DISPUTE_MODULE = IDisputeModule(disputeModule);
         _disableInitializers();
     }
 
@@ -85,28 +86,6 @@ contract LicenseRegistry is ILicenseRegistry, AccessManagedUpgradeable, UUPSUpgr
         }
         __AccessManaged_init(accessManager);
         __UUPSUpgradeable_init();
-    }
-
-    /// @dev Sets the DisputeModule address.
-    /// @dev Enforced to be only callable by the protocol admin
-    /// @param newDisputeModule The address of the DisputeModule
-    function setDisputeModule(address newDisputeModule) external restricted {
-        if (newDisputeModule == address(0)) {
-            revert Errors.LicenseRegistry__ZeroDisputeModule();
-        }
-        LicenseRegistryStorage storage $ = _getLicenseRegistryStorage();
-        $.disputeModule = IDisputeModule(newDisputeModule);
-    }
-
-    /// @dev Sets the LicensingModule address.
-    /// @dev Enforced to be only callable by the protocol admin
-    /// @param newLicensingModule The address of the LicensingModule
-    function setLicensingModule(address newLicensingModule) external restricted {
-        if (newLicensingModule == address(0)) {
-            revert Errors.LicenseRegistry__ZeroLicensingModule();
-        }
-        LicenseRegistryStorage storage $ = _getLicenseRegistryStorage();
-        $.licensingModule = ILicensingModule(newLicensingModule);
     }
 
     /// @notice Sets the default license terms that are attached to all IPs by default.
@@ -405,16 +384,6 @@ contract LicenseRegistry is ILicenseRegistry, AccessManagedUpgradeable, UUPSUpgr
         return _getMintingLicenseConfig(ipId, licenseTemplate, licenseTermsId);
     }
 
-    /// @notice Returns the canonical protocol-wide LicensingModule
-    function licensingModule() external view returns (ILicensingModule) {
-        return _getLicenseRegistryStorage().licensingModule;
-    }
-
-    /// @notice Returns the canonical protocol-wide DisputeModule
-    function disputeModule() external view returns (IDisputeModule) {
-        return _getLicenseRegistryStorage().disputeModule;
-    }
-
     /// @notice Gets the expiration time for an IP.
     /// @param ipId The address of the IP.
     /// @return The expiration time, 0 means never expired.
@@ -447,7 +416,7 @@ contract LicenseRegistry is ILicenseRegistry, AccessManagedUpgradeable, UUPSUpgr
         uint256 licenseTermsId
     ) internal view {
         LicenseRegistryStorage storage $ = _getLicenseRegistryStorage();
-        if ($.disputeModule.isIpTagged(parentIpId)) {
+        if (DISPUTE_MODULE.isIpTagged(parentIpId)) {
             revert Errors.LicenseRegistry__ParentIpTagged(parentIpId);
         }
         if (childIpId == parentIpId) {

--- a/script/foundry/utils/DeployHelper.sol
+++ b/script/foundry/utils/DeployHelper.sol
@@ -284,7 +284,7 @@ contract DeployHelper is Script, BroadcastManager, JsonDeploymentHandler, Storag
 
         contractKey = "RoyaltyModule";
         _predeploy(contractKey);
-        impl = address(new RoyaltyModule(address(licensingModule), address(disputeModule), address(licenseRegistry)));
+        impl = address(new RoyaltyModule(licensingModuleAddr, address(disputeModule), address(licenseRegistry)));
         royaltyModule = RoyaltyModule(
             TestProxyHelper.deployUUPSProxy(
                 impl,

--- a/script/foundry/utils/DeployHelper.sol
+++ b/script/foundry/utils/DeployHelper.sol
@@ -11,7 +11,6 @@ import { stdJson } from "forge-std/StdJson.sol";
 import { ERC6551Registry } from "erc6551/ERC6551Registry.sol";
 import { AccessManager } from "@openzeppelin/contracts/access/manager/AccessManager.sol";
 import { UUPSUpgradeable } from "@openzeppelin/contracts-upgradeable/proxy/utils/UUPSUpgradeable.sol";
-import { CREATE3 } from "@solady/src/utils/CREATE3.sol";
 
 // contracts
 import { ProtocolPauseAdmin } from "contracts/pause/ProtocolPauseAdmin.sol";
@@ -53,6 +52,7 @@ import { JsonDeploymentHandler } from "./JsonDeploymentHandler.s.sol";
 
 // test
 import { TestProxyHelper } from "test/foundry/utils/TestProxyHelper.sol";
+import { Create3Deployer } from "test/foundry/utils/Create3Deployer.sol";
 
 contract DeployHelper is Script, BroadcastManager, JsonDeploymentHandler, StorageLayoutChecker {
     using StringUtil for uint256;
@@ -158,16 +158,32 @@ contract DeployHelper is Script, BroadcastManager, JsonDeploymentHandler, Storag
         _endBroadcast(); // BroadcastManager.s.sol
     }
 
-    function create3Deploy(bytes32 salt, bytes calldata creationCode, uint256 value) external returns (address) {
-        return CREATE3.deploy(salt, creationCode, value);
-    }
-
     function _deployProtocolContracts() private {
         require(address(erc20) != address(0), "Deploy: Asset Not Set");
         bytes32 ipAccountImplSalt = keccak256(
             abi.encode(type(IPAccountImpl).creationCode, address(this), block.timestamp)
         );
-        address ipAccountImplAddr = CREATE3.getDeployed(ipAccountImplSalt);
+        address ipAccountImplAddr = Create3Deployer.getDeployed(ipAccountImplSalt);
+
+        bytes32 licenseTokenSalt = keccak256(
+            abi.encode(type(LicenseToken).creationCode, address(this), block.timestamp)
+        );
+        address licenseTokenAddr = Create3Deployer.getDeployed(licenseTokenSalt);
+
+        bytes32 licensingModuleSalt = keccak256(
+            abi.encode(type(LicensingModule).creationCode, address(this), block.timestamp)
+        );
+        address licensingModuleAddr = Create3Deployer.getDeployed(licensingModuleSalt);
+
+        bytes32 disputeModuleSalt = keccak256(
+            abi.encode(type(DisputeModule).creationCode, address(this), block.timestamp)
+        );
+        address disputeModuleAddr = Create3Deployer.getDeployed(disputeModuleSalt);
+
+        bytes32 licenseRegistrySalt = keccak256(
+            abi.encode(type(LicenseRegistry).creationCode, address(this), block.timestamp)
+        );
+        address licenseRegistryAddr = Create3Deployer.getDeployed(licenseRegistrySalt);
 
         string memory contractKey;
 
@@ -183,22 +199,9 @@ contract DeployHelper is Script, BroadcastManager, JsonDeploymentHandler, Storag
         protocolPauser = new ProtocolPauseAdmin(address(protocolAccessManager));
         _postdeploy(contractKey, address(protocolPauser));
 
-        contractKey = "AccessController";
-        _predeploy(contractKey);
-
-        address impl = address(new AccessController());
-        accessController = AccessController(
-            TestProxyHelper.deployUUPSProxy(
-                impl,
-                abi.encodeCall(AccessController.initialize, address(protocolAccessManager))
-            )
-        );
-        impl = address(0); // Make sure we don't deploy wrong impl
-        _postdeploy(contractKey, address(accessController));
-
         contractKey = "ModuleRegistry";
         _predeploy(contractKey);
-        impl = address(new ModuleRegistry());
+        address impl = address(new ModuleRegistry());
         moduleRegistry = ModuleRegistry(
             TestProxyHelper.deployUUPSProxy(
                 impl,
@@ -222,17 +225,31 @@ contract DeployHelper is Script, BroadcastManager, JsonDeploymentHandler, Storag
 
         IPAccountRegistry ipAccountRegistry = IPAccountRegistry(address(ipAssetRegistry));
 
+        contractKey = "AccessController";
+        _predeploy(contractKey);
+        impl = address(new AccessController(address(ipAssetRegistry), address(moduleRegistry)));
+        accessController = AccessController(
+            TestProxyHelper.deployUUPSProxy(
+                impl,
+                abi.encodeCall(AccessController.initialize, address(protocolAccessManager))
+            )
+        );
+        impl = address(0); // Make sure we don't deploy wrong impl
+        _postdeploy(contractKey, address(accessController));
+
         contractKey = "LicenseRegistry";
         _predeploy(contractKey);
-        impl = address(new LicenseRegistry());
+        impl = address(new LicenseRegistry(licensingModuleAddr, disputeModuleAddr));
         licenseRegistry = LicenseRegistry(
             TestProxyHelper.deployUUPSProxy(
+                licenseRegistrySalt,
                 impl,
                 abi.encodeCall(LicenseRegistry.initialize, (address(protocolAccessManager)))
             )
         );
         impl = address(0); // Make sure we don't deploy wrong impl
         _postdeploy(contractKey, address(licenseRegistry));
+        require(licenseRegistryAddr == address(licenseRegistry), "Deploy: License Registry Address Mismatch");
 
         contractKey = "IPAccountImpl";
         bytes memory ipAccountImplCode = abi.encodePacked(
@@ -245,43 +262,29 @@ contract DeployHelper is Script, BroadcastManager, JsonDeploymentHandler, Storag
             )
         );
         _predeploy(contractKey);
-        this.create3Deploy(ipAccountImplSalt, ipAccountImplCode, 0);
-        ipAccountImpl = IPAccountImpl(payable(ipAccountImplAddr));
+        ipAccountImpl = IPAccountImpl(payable(Create3Deployer.deploy(ipAccountImplSalt, ipAccountImplCode)));
         _postdeploy(contractKey, address(ipAccountImpl));
+        require(ipAccountImplAddr == address(ipAccountImpl), "Deploy: IP Account Impl Address Mismatch");
 
         contractKey = "DisputeModule";
         _predeploy(contractKey);
-        impl = address(new DisputeModule(address(accessController), address(ipAssetRegistry), address(licenseRegistry)));
+        impl = address(
+            new DisputeModule(address(accessController), address(ipAssetRegistry), address(licenseRegistry))
+        );
         disputeModule = DisputeModule(
             TestProxyHelper.deployUUPSProxy(
+                disputeModuleSalt,
                 impl,
                 abi.encodeCall(DisputeModule.initialize, address(protocolAccessManager))
             )
         );
         impl = address(0);
         _postdeploy(contractKey, address(disputeModule));
-
-        contractKey = "LicenseToken";
-        _predeploy(contractKey);
-        impl = address(new LicenseToken());
-        licenseToken = LicenseToken(
-            TestProxyHelper.deployUUPSProxy(
-                impl,
-                abi.encodeCall(
-                    LicenseToken.initialize,
-                    (
-                        address(protocolAccessManager),
-                        "https://github.com/storyprotocol/protocol-core/blob/main/assets/license-image.gif"
-                    )
-                )
-            )
-        );
-        impl = address(0);
-        _postdeploy(contractKey, address(licenseToken));
+        require(disputeModuleAddr == address(disputeModule), "Deploy: Dispute Module Address Mismatch");
 
         contractKey = "RoyaltyModule";
         _predeploy(contractKey);
-        impl = address(new RoyaltyModule(address(disputeModule), address(licenseRegistry)));
+        impl = address(new RoyaltyModule(address(licensingModule), address(disputeModule), address(licenseRegistry)));
         royaltyModule = RoyaltyModule(
             TestProxyHelper.deployUUPSProxy(
                 impl,
@@ -300,17 +303,39 @@ contract DeployHelper is Script, BroadcastManager, JsonDeploymentHandler, Storag
                 address(royaltyModule),
                 address(licenseRegistry),
                 address(disputeModule),
-                address(licenseToken)
+                licenseTokenAddr
             )
         );
         licensingModule = LicensingModule(
             TestProxyHelper.deployUUPSProxy(
+                licensingModuleSalt,
                 impl,
                 abi.encodeCall(LicensingModule.initialize, address(protocolAccessManager))
             )
         );
         impl = address(0); // Make sure we don't deploy wrong impl
         _postdeploy(contractKey, address(licensingModule));
+        require(licensingModuleAddr == address(licensingModule), "Deploy: Licensing Module Address Mismatch");
+
+        contractKey = "LicenseToken";
+        _predeploy(contractKey);
+        impl = address(new LicenseToken(address(licensingModule), address(disputeModule)));
+        licenseToken = LicenseToken(
+            TestProxyHelper.deployUUPSProxy(
+                licenseTokenSalt,
+                impl,
+                abi.encodeCall(
+                    LicenseToken.initialize,
+                    (
+                        address(protocolAccessManager),
+                        "https://github.com/storyprotocol/protocol-core/blob/main/assets/license-image.gif"
+                    )
+                )
+            )
+        );
+        impl = address(0);
+        _postdeploy(contractKey, address(licenseToken));
+        require(licenseTokenAddr == address(licenseToken), "Deploy: License Token Address Mismatch");
 
         //
         // Story-specific Non-Core Contracts
@@ -406,7 +431,6 @@ contract DeployHelper is Script, BroadcastManager, JsonDeploymentHandler, Storag
         protocolPauser.addPausable(address(royaltyModule));
         protocolPauser.addPausable(address(royaltyPolicyLAP));
         protocolPauser.addPausable(address(ipAssetRegistry));
-        
 
         // Module Registry
         moduleRegistry.registerModule(DISPUTE_MODULE_KEY, address(disputeModule));
@@ -416,19 +440,7 @@ contract DeployHelper is Script, BroadcastManager, JsonDeploymentHandler, Storag
         moduleRegistry.registerModule(CORE_METADATA_VIEW_MODULE_KEY, address(coreMetadataViewModule));
         moduleRegistry.registerModule(TOKEN_WITHDRAWAL_MODULE_KEY, address(tokenWithdrawalModule));
 
-        // License Registry
-        licenseRegistry.setDisputeModule(address(disputeModule));
-        licenseRegistry.setLicensingModule(address(licensingModule));
-
-        // License Token
-        licenseToken.setDisputeModule(address(disputeModule));
-        licenseToken.setLicensingModule(address(licensingModule));
-
-        // Access Controller
-        accessController.setAddresses(address(ipAccountRegistry), address(moduleRegistry));
-
         // Royalty Module and SP Royalty Policy
-        royaltyModule.setLicensingModule(address(licensingModule));
         royaltyModule.whitelistRoyaltyPolicy(address(royaltyPolicyLAP), true);
         royaltyModule.whitelistRoyaltyToken(address(erc20), true);
         royaltyPolicyLAP.setSnapshotInterval(7 days);
@@ -484,13 +496,33 @@ contract DeployHelper is Script, BroadcastManager, JsonDeploymentHandler, Storag
         selectors[1] = ProtocolPausableUpgradeable.unpause.selector;
 
         protocolAccessManager.labelRole(ProtocolAdmin.PAUSE_ADMIN_ROLE, ProtocolAdmin.PAUSE_ADMIN_ROLE_LABEL);
-        protocolAccessManager.setTargetFunctionRole(address(accessController), selectors, ProtocolAdmin.PAUSE_ADMIN_ROLE);
+        protocolAccessManager.setTargetFunctionRole(
+            address(accessController),
+            selectors,
+            ProtocolAdmin.PAUSE_ADMIN_ROLE
+        );
         protocolAccessManager.setTargetFunctionRole(address(disputeModule), selectors, ProtocolAdmin.PAUSE_ADMIN_ROLE);
-        protocolAccessManager.setTargetFunctionRole(address(licensingModule), selectors, ProtocolAdmin.PAUSE_ADMIN_ROLE);
+        protocolAccessManager.setTargetFunctionRole(
+            address(licensingModule),
+            selectors,
+            ProtocolAdmin.PAUSE_ADMIN_ROLE
+        );
         protocolAccessManager.setTargetFunctionRole(address(royaltyModule), selectors, ProtocolAdmin.PAUSE_ADMIN_ROLE);
-        protocolAccessManager.setTargetFunctionRole(address(royaltyPolicyLAP), selectors, ProtocolAdmin.PAUSE_ADMIN_ROLE);
-        protocolAccessManager.setTargetFunctionRole(address(ipAssetRegistry), selectors, ProtocolAdmin.PAUSE_ADMIN_ROLE);
-        protocolAccessManager.setTargetFunctionRole(address(licenseRegistry), selectors, ProtocolAdmin.PAUSE_ADMIN_ROLE);
+        protocolAccessManager.setTargetFunctionRole(
+            address(royaltyPolicyLAP),
+            selectors,
+            ProtocolAdmin.PAUSE_ADMIN_ROLE
+        );
+        protocolAccessManager.setTargetFunctionRole(
+            address(ipAssetRegistry),
+            selectors,
+            ProtocolAdmin.PAUSE_ADMIN_ROLE
+        );
+        protocolAccessManager.setTargetFunctionRole(
+            address(licenseRegistry),
+            selectors,
+            ProtocolAdmin.PAUSE_ADMIN_ROLE
+        );
         protocolAccessManager.setTargetFunctionRole(address(protocolPauser), selectors, ProtocolAdmin.PAUSE_ADMIN_ROLE);
         ///////// Role Granting /////////
         protocolAccessManager.grantRole(ProtocolAdmin.UPGRADER_ROLE, multisig, upgraderExecDelay);

--- a/test/foundry/LicenseToken.t.sol
+++ b/test/foundry/LicenseToken.t.sol
@@ -44,26 +44,6 @@ contract LicenseTokenTest is BaseTest {
         _;
     }
 
-    function test_LicenseToken_setDisputeModule() public whenCallerIsProtocolManager {
-        licenseToken.setDisputeModule(address(1));
-        assertEq(address(licenseToken.disputeModule()), address(1));
-    }
-
-    function test_LicenseToken_revert_setDisputeModule_zeroDisputeModule() public whenCallerIsProtocolManager {
-        vm.expectRevert(Errors.LicenseToken__ZeroDisputeModule.selector);
-        licenseToken.setDisputeModule(address(0));
-    }
-
-    function test_LicenseToken_setLicensingModule() public whenCallerIsProtocolManager {
-        licenseToken.setLicensingModule(address(1));
-        assertEq(address(licenseToken.licensingModule()), address(1));
-    }
-
-    function test_LicenseToken_revert_setLicensingModule_zeroLicensingModule() public whenCallerIsProtocolManager {
-        vm.expectRevert(Errors.LicenseToken__ZeroLicensingModule.selector);
-        licenseToken.setLicensingModule(address(0));
-    }
-
     function test_LicenseToken_setLicensingImageUrl() public whenCallerIsProtocolManager {
         vm.expectEmit(address(licenseToken));
         emit LicenseToken.BatchMetadataUpdate(1, 0);

--- a/test/foundry/mocks/module/MockAccessControllerV2.sol
+++ b/test/foundry/mocks/module/MockAccessControllerV2.sol
@@ -14,6 +14,9 @@ contract MockAccessControllerV2 is AccessController {
     bytes32 private constant AccessControllerV2StorageLocation =
         0xf328f2cdee4ae4df23921504bfa43e3156fb4d18b23549ca0a43fd1e64947a00;
 
+    constructor(address ipAccountRegistry, address moduleRegistry) AccessController(ipAccountRegistry, moduleRegistry) {
+    }
+
     function initialize() public reinitializer(2) {
         _getAccessControllerV2Storage().newState = "initialized";
     }

--- a/test/foundry/mocks/module/MockAccessControllerV2.sol
+++ b/test/foundry/mocks/module/MockAccessControllerV2.sol
@@ -14,8 +14,10 @@ contract MockAccessControllerV2 is AccessController {
     bytes32 private constant AccessControllerV2StorageLocation =
         0xf328f2cdee4ae4df23921504bfa43e3156fb4d18b23549ca0a43fd1e64947a00;
 
-    constructor(address ipAccountRegistry, address moduleRegistry) AccessController(ipAccountRegistry, moduleRegistry) {
-    }
+    constructor(
+        address ipAccountRegistry,
+        address moduleRegistry
+    ) AccessController(ipAccountRegistry, moduleRegistry) {}
 
     function initialize() public reinitializer(2) {
         _getAccessControllerV2Storage().newState = "initialized";

--- a/test/foundry/modules/royalty/RoyaltyModule.t.sol
+++ b/test/foundry/modules/royalty/RoyaltyModule.t.sol
@@ -109,28 +109,11 @@ contract TestRoyaltyModule is BaseTest {
         royaltyModule.onLinkToParents(address(3), address(royaltyPolicyLAP), parents, encodedLicenseData, "");
     }
     function test_RoyaltyModule_initialize_revert_ZeroAccessManager() public {
-        address impl = address(new RoyaltyModule(address(disputeModule), address(licenseRegistry)));
+        address impl = address(
+            new RoyaltyModule(address(licensingModule), address(disputeModule), address(licenseRegistry))
+        );
         vm.expectRevert(Errors.RoyaltyModule__ZeroAccessManager.selector);
         RoyaltyModule(TestProxyHelper.deployUUPSProxy(impl, abi.encodeCall(RoyaltyModule.initialize, address(0))));
-    }
-
-    function test_RoyaltyModule_setLicensingModule_revert_ZeroLicensingModule() public {
-        vm.startPrank(u.admin);
-        vm.expectRevert(Errors.RoyaltyModule__ZeroLicensingModule.selector);
-        royaltyModule.setLicensingModule(address(0));
-    }
-
-    function test_RoyaltyModule_setLicensingModule() public {
-        vm.startPrank(u.admin);
-        address impl = address(new RoyaltyModule(address(disputeModule), address(licenseRegistry)));
-        RoyaltyModule testRoyaltyModule = RoyaltyModule(
-            TestProxyHelper.deployUUPSProxy(
-                impl,
-                abi.encodeCall(RoyaltyModule.initialize, address(protocolAccessManager))
-            )
-        );
-        testRoyaltyModule.setLicensingModule(address(licensingModule));
-        assertEq(testRoyaltyModule.licensingModule(), address(licensingModule));
     }
 
     function test_RoyaltyModule_whitelistRoyaltyPolicy_revert_ZeroRoyaltyToken() public {

--- a/test/foundry/registries/LicenseRegistry.t.sol
+++ b/test/foundry/registries/LicenseRegistry.t.sol
@@ -56,30 +56,6 @@ contract LicenseRegistryTest is BaseTest {
         vm.label(ipAcct[5], "IPAccount5");
     }
 
-    function test_LicenseRegistry_setDisputeModule() public {
-        vm.prank(admin);
-        licenseRegistry.setDisputeModule(address(123));
-        assertEq(address(licenseRegistry.disputeModule()), address(123));
-    }
-
-    function test_LicenseRegistry_setLicensingModule() public {
-        vm.prank(admin);
-        licenseRegistry.setLicensingModule(address(123));
-        assertEq(address(licenseRegistry.licensingModule()), address(123));
-    }
-
-    function test_LicenseRegistry_setDisputeModule_revert_ZeroAddress() public {
-        vm.expectRevert(Errors.LicenseRegistry__ZeroDisputeModule.selector);
-        vm.prank(admin);
-        licenseRegistry.setDisputeModule(address(0));
-    }
-
-    function test_LicenseRegistry_setLicensingModule_revert_ZeroAddress() public {
-        vm.expectRevert(Errors.LicenseRegistry__ZeroLicensingModule.selector);
-        vm.prank(admin);
-        licenseRegistry.setLicensingModule(address(0));
-    }
-
     function test_LicenseRegistry_setDefaultLicenseTerms() public {
         uint256 socialRemixTermsId = pilTemplate.registerLicenseTerms(PILFlavors.nonCommercialSocialRemixing());
         vm.prank(admin);

--- a/test/foundry/upgrades/Upgrades.t.sol
+++ b/test/foundry/upgrades/Upgrades.t.sol
@@ -52,7 +52,9 @@ contract UpgradesTest is BaseTest {
         assertFalse(immediate);
         assertEq(delay, execDelay);
 
-        address newAccessController = address(new MockAccessControllerV2());
+        address newAccessController = address(
+            new MockAccessControllerV2(address(ipAccountRegistry), address(moduleRegistry))
+        );
         vm.prank(u.bob);
         (bytes32 operationId, uint32 nonce) = protocolAccessManager.schedule(
             address(accessController),

--- a/test/foundry/utils/Create3Deployer.sol
+++ b/test/foundry/utils/Create3Deployer.sol
@@ -1,0 +1,14 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.23;
+
+import { CREATE3 } from "@solady/src/utils/CREATE3.sol";
+
+library Create3Deployer {
+    function deploy(bytes32 salt, bytes calldata creationCode) external returns (address) {
+        return CREATE3.deploy(salt, creationCode, 0);
+    }
+
+    function getDeployed(bytes32 salt) external view returns (address) {
+        return CREATE3.getDeployed(salt);
+    }
+}

--- a/test/foundry/utils/TestProxyHelper.sol
+++ b/test/foundry/utils/TestProxyHelper.sol
@@ -1,6 +1,7 @@
 // SPDX-License-Identifier: MIT
 pragma solidity ^0.8.23;
 import { ERC1967Proxy } from "@openzeppelin/contracts/proxy/ERC1967/ERC1967Proxy.sol";
+import { Create3Deployer } from "./Create3Deployer.sol";
 
 library TestProxyHelper {
     /// Deploys a new UUPS proxy with the provided implementation and data
@@ -10,5 +11,9 @@ library TestProxyHelper {
     function deployUUPSProxy(address impl, bytes memory data) internal returns (address) {
         ERC1967Proxy proxy = new ERC1967Proxy(impl, data);
         return address(proxy);
+    }
+
+    function deployUUPSProxy(bytes32 salt, address impl, bytes memory data) internal returns (address) {
+        return Create3Deployer.deploy(salt, abi.encodePacked(type(ERC1967Proxy).creationCode, abi.encode(impl, data)));
     }
 }


### PR DESCRIPTION
### Description:

This PR introduces the use of `CREATE3` for deploying our smart contracts, an update aimed at resolving the challenges posed by cyclical dependencies during the deployment phase. By leveraging CREATE3, we can deploy contracts to deterministic addresses using a predefined salt. This approach has several advantages and key implementations as detailed below:

1. **Deterministic Deployment:** Utilize CREATE3 to ensure all contracts with cyclical dependencies are deployed to known, deterministic addresses. This method uses only a salt for address derivation, making the process more predictable and secure.
2. **Immutable Storage:** By directly passing these deterministic addresses to the constructors of dependent contracts, we can store them as immutable variables within the contracts. This not only enhances security but also improves the efficiency of contract interactions.
3. **Simplification of Protocol:** With the addresses being hardcoded and immutable, the need for post-deployment governance functions to set these addresses is eliminated. This significantly simplifies our protocol by reducing the layers of interaction required and minimizing the potential for human error.

### Benefits:
- **Robust Contract Interaction:** Hardcoding addresses as immutable variables reduces the risk of address manipulation and ensures more robust interactions between interconnected contracts.
- **Protocol Streamlining:** Eliminates the need for manual interventions in the form of governance actions to set contract addresses after deployment, thereby streamlining operations and reducing the scope for errors.

### Tests Plane
All changes are covered by existing automation tests.

### Related Issues
Closes #106 
