### PR TITLE
Enhance Permission Management with Simplified `setAllPermissions` Method in AccessController

### DIFF
--- a/contracts/access/AccessController.sol
+++ b/contracts/access/AccessController.sol
@@ -87,10 +87,6 @@ contract AccessController is IAccessController, ProtocolPausableUpgradeable, UUP
         }
     }
 
-    function setAllPermissions(address ipAccount, address signer, uint8 permission) external whenNotPaused {
-        _setPermission(ipAccount, signer, address(0), bytes4(0), permission);
-    }
-
     /// @notice Sets the permission for a specific function call
     /// @dev Each policy is represented as a mapping from an IP account address to a signer address to a recipient
     /// address to a function selector to a permission level. The permission level can be 0 (ABSTAIN), 1 (ALLOW), or
@@ -116,7 +112,14 @@ contract AccessController is IAccessController, ProtocolPausableUpgradeable, UUP
             revert Errors.AccessController__ToAndFuncAreZeroAddressShouldCallSetAllPermissions();
         }
         _setPermission(ipAccount, signer, to, func, permission);
+    }
 
+    /// @notice Sets permission to a signer for all functions across all modules.
+    /// @param ipAccount The address of the IP account that grants the permission for `signer`.
+    /// @param signer The address of the signer receiving the permissions.
+    /// @param permission The new permission.
+    function setAllPermissions(address ipAccount, address signer, uint8 permission) external whenNotPaused {
+        _setPermission(ipAccount, signer, address(0), bytes4(0), permission);
     }
 
     /// @notice Checks the permission level for a specific function call. Reverts if permission is not granted.

--- a/contracts/interfaces/access/IAccessController.sol
+++ b/contracts/interfaces/access/IAccessController.sol
@@ -40,6 +40,12 @@ interface IAccessController {
     /// @param permission The new permission level
     function setPermission(address ipAccount, address signer, address to, bytes4 func, uint8 permission) external;
 
+    /// @notice Sets permission to a signer for all functions across all modules.
+    /// @param ipAccount The address of the IP account that grants the permission for `signer`.
+    /// @param signer The address of the signer receiving the permissions.
+    /// @param permission The new permission.
+    function setAllPermissions(address ipAccount, address signer, uint8 permission) external;
+
     /// @notice Checks the permission level for a specific function call. Reverts if permission is not granted.
     /// Otherwise, the function is a noop.
     /// @dev This function checks the permission level for a specific function call.

--- a/contracts/lib/Errors.sol
+++ b/contracts/lib/Errors.sol
@@ -487,6 +487,9 @@ library Errors {
     /// @notice Permission denied.
     error AccessController__PermissionDenied(address ipAccount, address signer, address to, bytes4 func);
 
+    /// @notice Both recipient (to) and function selectors are zero address means delegate all permissions to signer.
+    error AccessController__ToAndFuncAreZeroAddressShouldCallSetAllPermissions();
+
     ////////////////////////////////////////////////////////////////////////////
     //                            Access Controlled                           //
     ////////////////////////////////////////////////////////////////////////////

--- a/test/foundry/access/AccessController.t.sol
+++ b/test/foundry/access/AccessController.t.sol
@@ -287,11 +287,9 @@ contract AccessControllerTest is BaseTest {
             address(accessController),
             0,
             abi.encodeWithSignature(
-                "setPermission(address,address,address,bytes4,uint8)",
+                "setAllPermissions(address,address,uint8)",
                 address(ipAccount),
                 signer,
-                address(0),
-                bytes4(0),
                 AccessPermission.ALLOW
             )
         );
@@ -323,11 +321,9 @@ contract AccessControllerTest is BaseTest {
             address(accessController),
             0,
             abi.encodeWithSignature(
-                "setPermission(address,address,address,bytes4,uint8)",
+                "setAllPermissions(address,address,uint8)",
                 address(ipAccount),
                 signer,
-                address(0),
-                bytes4(0),
                 AccessPermission.DENY
             )
         );
@@ -478,11 +474,9 @@ contract AccessControllerTest is BaseTest {
             address(accessController),
             0,
             abi.encodeWithSignature(
-                "setPermission(address,address,address,bytes4,uint8)",
+                "setAllPermissions(address,address,uint8)",
                 address(ipAccount),
                 signer,
-                address(0),
-                bytes4(0),
                 AccessPermission.DENY
             )
         );
@@ -529,11 +523,9 @@ contract AccessControllerTest is BaseTest {
             address(accessController),
             0,
             abi.encodeWithSignature(
-                "setPermission(address,address,address,bytes4,uint8)",
+                "setAllPermissions(address,address,uint8)",
                 address(ipAccount),
                 signer,
-                address(0),
-                bytes4(0),
                 AccessPermission.ALLOW
             )
         );
@@ -588,11 +580,9 @@ contract AccessControllerTest is BaseTest {
             address(accessController),
             0,
             abi.encodeWithSignature(
-                "setPermission(address,address,address,bytes4,uint8)",
+                "setAllPermissions(address,address,uint8)",
                 address(ipAccount),
                 signer,
-                address(0),
-                bytes4(0),
                 AccessPermission.DENY
             )
         );
@@ -644,11 +634,9 @@ contract AccessControllerTest is BaseTest {
             address(accessController),
             0,
             abi.encodeWithSignature(
-                "setPermission(address,address,address,bytes4,uint8)",
+                "setAllPermissions(address,address,uint8)",
                 address(ipAccount),
                 signer,
-                address(0),
-                bytes4(0),
                 AccessPermission.ALLOW
             )
         );
@@ -779,11 +767,9 @@ contract AccessControllerTest is BaseTest {
             address(accessController),
             0,
             abi.encodeWithSignature(
-                "setPermission(address,address,address,bytes4,uint8)",
+                "setAllPermissions(address,address,uint8)",
                 address(ipAccount),
                 address(mockOrchestratorModule),
-                address(0),
-                bytes4(0),
                 AccessPermission.ALLOW
             )
         );
@@ -828,11 +814,9 @@ contract AccessControllerTest is BaseTest {
             address(accessController),
             0,
             abi.encodeWithSignature(
-                "setPermission(address,address,address,bytes4,uint8)",
+                "setAllPermissions(address,address,uint8)",
                 address(ipAccount),
                 address(mockOrchestratorModule),
-                address(0),
-                bytes4(0),
                 AccessPermission.ALLOW
             )
         );
@@ -1658,6 +1642,148 @@ contract AccessControllerTest is BaseTest {
                 address(ipAccount),
                 signer,
                 address(mockModule),
+                bytes4(0),
+                AccessPermission.ALLOW
+            )
+        );
+    }
+
+    function test_setAllPermissions() public {
+        address signer = vm.addr(2);
+
+        // setAllPermissions to ALLOW
+        vm.prank(owner);
+        accessController.setAllPermissions(address(ipAccount), signer, AccessPermission.ALLOW);
+        assertEq(
+            accessController.getPermission(
+                address(ipAccount),
+                signer,
+                address(0),
+                bytes4(0)
+            ),
+            AccessPermission.ALLOW,
+            "setAllPermissions to ALLOW failed"
+        );
+
+        assertEq(
+            accessController.getPermission(
+                address(ipAccount),
+                signer,
+                address(mockModule),
+                mockModule.executeNoReturn.selector
+            ),
+            AccessPermission.ABSTAIN,
+            "setAllPermissions to ABSTAIN failed for a specific module"
+        );
+
+        accessController.checkPermission(
+            address(ipAccount),
+            signer,
+            address(mockModule),
+            mockModule.executeSuccessfully.selector
+        );
+
+        // setAllPermissions to DENY
+        vm.prank(owner);
+        accessController.setAllPermissions(address(ipAccount), signer, AccessPermission.DENY);
+        assertEq(
+            accessController.getPermission(
+                address(ipAccount),
+                signer,
+                address(0),
+                bytes4(0)
+            ),
+            AccessPermission.DENY,
+            "setAllPermissions to DENY failed"
+        );
+
+        assertEq(
+            accessController.getPermission(
+                address(ipAccount),
+                signer,
+                address(mockModule),
+                mockModule.executeNoReturn.selector
+            ),
+            AccessPermission.ABSTAIN,
+            "setAllPermissions to ABSTAIN failed for a specific module"
+        );
+
+        vm.expectRevert(
+            abi.encodeWithSelector(
+                Errors.AccessController__PermissionDenied.selector,
+                address(ipAccount),
+                signer,
+                address(mockModule),
+                mockModule.executeSuccessfully.selector
+            )
+        );
+        accessController.checkPermission(
+            address(ipAccount),
+            signer,
+            address(mockModule),
+            mockModule.executeSuccessfully.selector
+        );
+
+        // setAllPermissions to ABSTAIN
+        vm.prank(owner);
+        accessController.setAllPermissions(address(ipAccount), signer, AccessPermission.ABSTAIN);
+        assertEq(
+            accessController.getPermission(
+                address(ipAccount),
+                signer,
+                address(0),
+                bytes4(0)
+            ),
+            AccessPermission.ABSTAIN,
+            "setAllPermissions to ABSTAIN failed"
+        );
+
+        assertEq(
+            accessController.getPermission(
+                address(ipAccount),
+                signer,
+                address(mockModule),
+                mockModule.executeNoReturn.selector
+            ),
+            AccessPermission.ABSTAIN,
+            "setAllPermissions to ABSTAIN failed for a specific module"
+        );
+
+        vm.expectRevert(
+            abi.encodeWithSelector(
+                Errors.AccessController__PermissionDenied.selector,
+                address(ipAccount),
+                signer,
+                address(mockModule),
+                mockModule.executeSuccessfully.selector
+            )
+        );
+        accessController.checkPermission(
+            address(ipAccount),
+            signer,
+            address(mockModule),
+            mockModule.executeSuccessfully.selector
+        );
+
+    }
+
+    function test_setPermission_revert_BothToAndSignerAreZero() public {
+        address signer = vm.addr(2);
+        // by owner
+        vm.expectRevert(Errors.AccessController__ToAndFuncAreZeroAddressShouldCallSetAllPermissions.selector);
+        vm.prank(owner);
+        accessController.setPermission(address(ipAccount), signer, address(0), bytes4(0), AccessPermission.ALLOW);
+        // by ipAccount
+        vm.expectRevert(Errors.AccessController__ToAndFuncAreZeroAddressShouldCallSetAllPermissions.selector);
+        vm.prank(owner);
+        ipAccount.execute(
+            address(accessController),
+            0,
+            abi.encodeWithSignature(
+                "setPermission(address,address,address,bytes4,uint8)",
+                address(ipAccount),
+                address(tokenWithdrawalModule),
+                address(0),
                 bytes4(0),
                 AccessPermission.ALLOW
             )

--- a/test/foundry/access/AccessController.t.sol
+++ b/test/foundry/access/AccessController.t.sol
@@ -1655,12 +1655,7 @@ contract AccessControllerTest is BaseTest {
         vm.prank(owner);
         accessController.setAllPermissions(address(ipAccount), signer, AccessPermission.ALLOW);
         assertEq(
-            accessController.getPermission(
-                address(ipAccount),
-                signer,
-                address(0),
-                bytes4(0)
-            ),
+            accessController.getPermission(address(ipAccount), signer, address(0), bytes4(0)),
             AccessPermission.ALLOW,
             "setAllPermissions to ALLOW failed"
         );
@@ -1687,12 +1682,7 @@ contract AccessControllerTest is BaseTest {
         vm.prank(owner);
         accessController.setAllPermissions(address(ipAccount), signer, AccessPermission.DENY);
         assertEq(
-            accessController.getPermission(
-                address(ipAccount),
-                signer,
-                address(0),
-                bytes4(0)
-            ),
+            accessController.getPermission(address(ipAccount), signer, address(0), bytes4(0)),
             AccessPermission.DENY,
             "setAllPermissions to DENY failed"
         );
@@ -1728,12 +1718,7 @@ contract AccessControllerTest is BaseTest {
         vm.prank(owner);
         accessController.setAllPermissions(address(ipAccount), signer, AccessPermission.ABSTAIN);
         assertEq(
-            accessController.getPermission(
-                address(ipAccount),
-                signer,
-                address(0),
-                bytes4(0)
-            ),
+            accessController.getPermission(address(ipAccount), signer, address(0), bytes4(0)),
             AccessPermission.ABSTAIN,
             "setAllPermissions to ABSTAIN failed"
         );
@@ -1764,7 +1749,6 @@ contract AccessControllerTest is BaseTest {
             address(mockModule),
             mockModule.executeSuccessfully.selector
         );
-
     }
 
     function test_setPermission_revert_BothToAndSignerAreZero() public {


### PR DESCRIPTION
## Description
This PR introduces a new method, `setAllPermissions`, to the AccessController. The existing setPermission function provides comprehensive functionality with the capability to set permissions at a granular level.

The new `setAllPermissions` function simplifies permission settings by reducing the parameters required, focusing solely on full permissions across all modules and functions. This method is designed to be user-friendly and reduces the risk of configuration errors, making it ideal for scenarios where complete delegation of control is necessary. 

1. **Introduction of `setAllPermissions` Function:** Allows users to grant all permissions associated with an `IPAccount` to another address (signer) through a straightforward interface, using only three parameters: the `IPAccount` address, the delegate `signer` address, and the `permission` level.

2. **Extended Test Coverage:** Added tests to validate the functionality of `setAllPermissions` in various scenarios, ensuring that it behaves as expected without affecting the granular control provided by setPermission.

## Test Plan 
1. Deploy the updated `AccessController` contract.
2. Use the `setAllPermissions` function to assign comprehensive permissions to a test address.
3. Confirm that the test address has appropriate access across all functions and modules.
4. Verify that no permissions can be set outside the intended scope, ensuring safety against misconfiguration.

## Related Issue
Closes #122 
