### PR TITLE
Optimize LicenseTokenMetadata Struct

### DIFF
--- a/contracts/LicenseToken.sol
+++ b/contracts/LicenseToken.sol
@@ -84,7 +84,7 @@ contract LicenseToken is ILicenseToken, ERC721EnumerableUpgradeable, AccessManag
     function mintLicenseTokens(
         address licensorIpId,
         address licenseTemplate,
-        uint256 licenseTermsId,
+        uint32 licenseTermsId,
         uint256 amount, // mint amount
         address minter,
         address receiver
@@ -129,15 +129,11 @@ contract LicenseToken is ILicenseToken, ERC721EnumerableUpgradeable, AccessManag
         address childIpId,
         address childIpOwner,
         uint256[] calldata tokenIds
-    )
-        external
-        view
-        returns (address licenseTemplate, address[] memory licensorIpIds, uint256[] memory licenseTermsIds)
-    {
+    ) external view returns (address licenseTemplate, address[] memory licensorIpIds, uint32[] memory licenseTermsIds) {
         LicenseTokenStorage storage $ = _getLicenseTokenStorage();
         licenseTemplate = $.licenseTokenMetadatas[tokenIds[0]].licenseTemplate;
         licensorIpIds = new address[](tokenIds.length);
-        licenseTermsIds = new uint256[](tokenIds.length);
+        licenseTermsIds = new uint32[](tokenIds.length);
 
         for (uint256 i = 0; i < tokenIds.length; i++) {
             LicenseTokenMetadata memory ltm = $.licenseTokenMetadatas[tokenIds[i]];
@@ -180,7 +176,7 @@ contract LicenseToken is ILicenseToken, ERC721EnumerableUpgradeable, AccessManag
 
     /// @notice Returns the ID of the license terms that are used for the given license ID
     /// @param tokenId The ID of the license token
-    function getLicenseTermsId(uint256 tokenId) external view returns (uint256) {
+    function getLicenseTermsId(uint256 tokenId) external view returns (uint32) {
         return _getLicenseTokenStorage().licenseTokenMetadatas[tokenId].licenseTermsId;
     }
 

--- a/contracts/interfaces/ILicenseToken.sol
+++ b/contracts/interfaces/ILicenseToken.sol
@@ -16,14 +16,14 @@ import { IERC721Enumerable } from "@openzeppelin/contracts/token/ERC721/extensio
 interface ILicenseToken is IERC721Metadata, IERC721Enumerable {
     /// @notice Metadata struct for License Tokens.
     /// @param licensorIpId The ID of the licensor IP for which the License Token was minted.
-    /// @param licenseTemplate The address of the License Template associated with the License Token.
     /// @param licenseTermsId The ID of the License Terms associated with the License Token.
     /// @param transferable Whether the License Token is transferable, determined by the License Terms.
+    /// @param licenseTemplate The address of the License Template associated with the License Token.
     struct LicenseTokenMetadata {
         address licensorIpId;
-        address licenseTemplate;
-        uint256 licenseTermsId;
+        uint32 licenseTermsId;
         bool transferable;
+        address licenseTemplate;
     }
 
     /// @notice Emitted when a License Token is minted.
@@ -44,7 +44,7 @@ interface ILicenseToken is IERC721Metadata, IERC721Enumerable {
     function mintLicenseTokens(
         address licensorIpId,
         address licenseTemplate,
-        uint256 licenseTermsId,
+        uint32 licenseTermsId,
         uint256 amount, // mint amount
         address minter,
         address receiver
@@ -67,7 +67,7 @@ interface ILicenseToken is IERC721Metadata, IERC721Enumerable {
 
     /// @notice Returns the ID of the license terms that are used for the given license ID
     /// @param tokenId The ID of the license token
-    function getLicenseTermsId(uint256 tokenId) external view returns (uint256);
+    function getLicenseTermsId(uint256 tokenId) external view returns (uint32);
 
     /// @notice Returns the address of the license template that is used for the given license ID
     /// @param tokenId The ID of the license token
@@ -97,5 +97,5 @@ interface ILicenseToken is IERC721Metadata, IERC721Enumerable {
         address childIpId,
         address childIpOwner,
         uint256[] calldata tokenIds
-    ) external view returns (address licenseTemplate, address[] memory licensorIpIds, uint256[] memory licenseTermsIds);
+    ) external view returns (address licenseTemplate, address[] memory licensorIpIds, uint32[] memory licenseTermsIds);
 }

--- a/contracts/interfaces/modules/licensing/ILicenseTemplate.sol
+++ b/contracts/interfaces/modules/licensing/ILicenseTemplate.sol
@@ -16,7 +16,7 @@ interface ILicenseTemplate is IERC165 {
     /// @param licenseTermsId The ID of the license terms.
     /// @param licenseTemplate The address of the license template.
     /// @param licenseTerms The data of the license.
-    event LicenseTermsRegistered(uint256 indexed licenseTermsId, address indexed licenseTemplate, bytes licenseTerms);
+    event LicenseTermsRegistered(uint32 indexed licenseTermsId, address indexed licenseTemplate, bytes licenseTerms);
 
     /// @notice Returns the name of the license template.
     /// @return The name of the license template.
@@ -27,7 +27,7 @@ interface ILicenseTemplate is IERC165 {
     /// hence the json format should follow the common NFT metadata standard.
     /// @param licenseTermsId The ID of the license terms.
     /// @return The JSON string of the license terms.
-    function toJson(uint256 licenseTermsId) external view returns (string memory);
+    function toJson(uint32 licenseTermsId) external view returns (string memory);
 
     /// @notice Returns the metadata URI of the license template.
     /// @return The metadata URI of the license template.
@@ -36,33 +36,33 @@ interface ILicenseTemplate is IERC165 {
     /// @notice Returns the URI of the license terms.
     /// @param licenseTermsId The ID of the license terms.
     /// @return The URI of the license terms.
-    function getLicenseTermsURI(uint256 licenseTermsId) external view returns (string memory);
+    function getLicenseTermsURI(uint32 licenseTermsId) external view returns (string memory);
 
     /// @notice Returns the total number of registered license terms.
     /// @return The total number of registered license terms.
-    function totalRegisteredLicenseTerms() external view returns (uint256);
+    function totalRegisteredLicenseTerms() external view returns (uint32);
 
     /// @notice Checks if a license terms exists.
     /// @param licenseTermsId The ID of the license terms.
     /// @return True if the license terms exists, false otherwise.
-    function exists(uint256 licenseTermsId) external view returns (bool);
+    function exists(uint32 licenseTermsId) external view returns (bool);
 
     /// @notice Checks if a license terms is transferable.
     /// @param licenseTermsId The ID of the license terms.
     /// @return True if the license terms is transferable, false otherwise.
-    function isLicenseTransferable(uint256 licenseTermsId) external view returns (bool);
+    function isLicenseTransferable(uint32 licenseTermsId) external view returns (bool);
 
     /// @notice Returns the earliest expiration time among the given license terms.
     /// @param start The start time to calculate the expiration time.
     /// @param licenseTermsIds The IDs of the license terms.
     /// @return The earliest expiration time.
-    function getEarlierExpireTime(uint256[] calldata licenseTermsIds, uint256 start) external view returns (uint256);
+    function getEarlierExpireTime(uint32[] calldata licenseTermsIds, uint256 start) external view returns (uint256);
 
     /// @notice Returns the expiration time of a license terms.
     /// @param start The start time.
     /// @param licenseTermsId The ID of the license terms.
     /// @return The expiration time.
-    function getExpireTime(uint256 licenseTermsId, uint256 start) external view returns (uint256);
+    function getExpireTime(uint32 licenseTermsId, uint256 start) external view returns (uint256);
 
     /// @notice Returns the royalty policy of a license terms.
     /// @dev All License Templates should implement this method.
@@ -76,7 +76,7 @@ interface ILicenseTemplate is IERC165 {
     /// @return currencyToken The address of the ERC20 token, used for minting license fee and royalties.
     /// the currency token will used for pay for license token minting fee and royalties.
     function getRoyaltyPolicy(
-        uint256 licenseTermsId
+        uint32 licenseTermsId
     )
         external
         view
@@ -91,7 +91,7 @@ interface ILicenseTemplate is IERC165 {
     /// @param amount The amount of licenses to mint.
     /// @return True if the minting is verified, false otherwise.
     function verifyMintLicenseToken(
-        uint256 licenseTermsId,
+        uint32 licenseTermsId,
         address licensee,
         address licensorIpId,
         uint256 amount
@@ -109,7 +109,7 @@ interface ILicenseTemplate is IERC165 {
     function verifyRegisterDerivative(
         address childIpId,
         address parentIpId,
-        uint256 licenseTermsId,
+        uint32 licenseTermsId,
         address licensee
     ) external returns (bool);
 
@@ -119,7 +119,7 @@ interface ILicenseTemplate is IERC165 {
     /// It ensures that the licenses of all parent IPs are compatible with each other during the registration process.
     /// @param licenseTermsIds The IDs of the license terms.
     /// @return True if the licenses are compatible, false otherwise.
-    function verifyCompatibleLicenses(uint256[] calldata licenseTermsIds) external view returns (bool);
+    function verifyCompatibleLicenses(uint32[] calldata licenseTermsIds) external view returns (bool);
 
     /// @notice Verifies the registration of a derivative for all parent IPs.
     /// @dev This function is called by the LicensingModule to verify licenses for registering a derivative IP
@@ -134,7 +134,7 @@ interface ILicenseTemplate is IERC165 {
     function verifyRegisterDerivativeForAllParents(
         address childIpId,
         address[] calldata parentIpId,
-        uint256[] calldata licenseTermsIds,
+        uint32[] calldata licenseTermsIds,
         address childIpOwner
     ) external returns (bool);
 }

--- a/contracts/interfaces/modules/licensing/ILicensingModule.sol
+++ b/contracts/interfaces/modules/licensing/ILicensingModule.sol
@@ -20,7 +20,7 @@ interface ILicensingModule is IModule {
         address indexed caller,
         address indexed ipId,
         address licenseTemplate,
-        uint256 licenseTermsId
+        uint32 licenseTermsId
     );
 
     /// @notice Emitted when license tokens are minted.
@@ -53,7 +53,7 @@ interface ILicensingModule is IModule {
         address indexed childIpId,
         uint256[] licenseTokenIds,
         address[] parentIpIds,
-        uint256[] licenseTermsIds,
+        uint32[] licenseTermsIds,
         address licenseTemplate
     );
 
@@ -62,7 +62,7 @@ interface ILicensingModule is IModule {
     /// @param ipId The IP ID.
     /// @param licenseTemplate The address of the license template.
     /// @param licenseTermsId The ID of the license terms.
-    function attachLicenseTerms(address ipId, address licenseTemplate, uint256 licenseTermsId) external;
+    function attachLicenseTerms(address ipId, address licenseTemplate, uint32 licenseTermsId) external;
 
     /// @notice Mints license tokens for the license terms attached to an IP.
     /// The license tokens are minted to the receiver.
@@ -86,7 +86,7 @@ interface ILicensingModule is IModule {
     function mintLicenseTokens(
         address licensorIpId,
         address licenseTemplate,
-        uint256 licenseTermsId,
+        uint32 licenseTermsId,
         uint256 amount,
         address receiver,
         bytes calldata royaltyContext
@@ -105,7 +105,7 @@ interface ILicensingModule is IModule {
     function registerDerivative(
         address childIpId,
         address[] calldata parentIpIds,
-        uint256[] calldata licenseTermsIds,
+        uint32[] calldata licenseTermsIds,
         address licenseTemplate,
         bytes calldata royaltyContext
     ) external;
@@ -135,7 +135,7 @@ interface ILicensingModule is IModule {
     function setLicensingConfig(
         address ipId,
         address licenseTemplate,
-        uint256 licenseTermsId,
+        uint32 licenseTermsId,
         Licensing.LicensingConfig memory licensingConfig
     ) external;
 }

--- a/contracts/interfaces/modules/licensing/IPILicenseTemplate.sol
+++ b/contracts/interfaces/modules/licensing/IPILicenseTemplate.sol
@@ -53,15 +53,15 @@ interface IPILicenseTemplate is ILicenseTemplate {
     /// @notice Registers new license terms.
     /// @param terms The PILTerms to register.
     /// @return selectedLicenseTermsId The ID of the newly registered license terms.
-    function registerLicenseTerms(PILTerms calldata terms) external returns (uint256 selectedLicenseTermsId);
+    function registerLicenseTerms(PILTerms calldata terms) external returns (uint32 selectedLicenseTermsId);
 
     /// @notice Gets the ID of the given license terms.
     /// @param terms The PILTerms to get the ID for.
     /// @return selectedLicenseTermsId The ID of the given license terms.
-    function getLicenseTermsId(PILTerms calldata terms) external view returns (uint256 selectedLicenseTermsId);
+    function getLicenseTermsId(PILTerms calldata terms) external view returns (uint32 selectedLicenseTermsId);
 
     /// @notice Gets license terms of the given ID.
     /// @param selectedLicenseTermsId The ID of the license terms.
     /// @return terms The PILTerms associate with the given ID.
-    function getLicenseTerms(uint256 selectedLicenseTermsId) external view returns (PILTerms memory terms);
+    function getLicenseTerms(uint32 selectedLicenseTermsId) external view returns (PILTerms memory terms);
 }

--- a/contracts/interfaces/registries/ILicenseRegistry.sol
+++ b/contracts/interfaces/registries/ILicenseRegistry.sol
@@ -16,7 +16,7 @@ interface ILicenseRegistry {
     event LicensingConfigSetForLicense(
         address indexed ipId,
         address indexed licenseTemplate,
-        uint256 indexed licenseTermsId
+        uint32 indexed licenseTermsId
     );
 
     /// @notice Emitted when a minting license configuration is set for all licenses of an IP.
@@ -28,10 +28,10 @@ interface ILicenseRegistry {
     /// @notice Sets the default license terms that are attached to all IPs by default.
     /// @param newLicenseTemplate The address of the new default license template.
     /// @param newLicenseTermsId The ID of the new default license terms.
-    function setDefaultLicenseTerms(address newLicenseTemplate, uint256 newLicenseTermsId) external;
+    function setDefaultLicenseTerms(address newLicenseTemplate, uint32 newLicenseTermsId) external;
 
     /// @notice Returns the default license terms.
-    function getDefaultLicenseTerms() external view returns (address licenseTemplate, uint256 licenseTermsId);
+    function getDefaultLicenseTerms() external view returns (address licenseTemplate, uint32 licenseTermsId);
 
     /// @notice Registers a new license template in the Story Protocol.
     /// @param licenseTemplate The address of the license template to register.
@@ -51,7 +51,7 @@ interface ILicenseRegistry {
         address ipId,
         address[] calldata parentIpIds,
         address licenseTemplate,
-        uint256[] calldata licenseTermsIds
+        uint32[] calldata licenseTermsIds
     ) external;
 
     /// @notice Checks if an IP is a derivative IP.
@@ -73,7 +73,7 @@ interface ILicenseRegistry {
     function verifyMintLicenseToken(
         address licensorIpId,
         address licenseTemplate,
-        uint256 licenseTermsId,
+        uint32 licenseTermsId,
         bool isMintedByIpOwner
     ) external view returns (Licensing.LicensingConfig memory);
 
@@ -81,13 +81,13 @@ interface ILicenseRegistry {
     /// @param ipId The address of the IP to which the license terms are attached.
     /// @param licenseTemplate The address of the license template.
     /// @param licenseTermsId The ID of the license terms.
-    function attachLicenseTermsToIp(address ipId, address licenseTemplate, uint256 licenseTermsId) external;
+    function attachLicenseTermsToIp(address ipId, address licenseTemplate, uint32 licenseTermsId) external;
 
     /// @notice Checks if license terms exist.
     /// @param licenseTemplate The address of the license template where the license terms are defined.
     /// @param licenseTermsId The ID of the license terms.
     /// @return Whether the license terms exist.
-    function exists(address licenseTemplate, uint256 licenseTermsId) external view returns (bool);
+    function exists(address licenseTemplate, uint32 licenseTermsId) external view returns (bool);
 
     /// @notice Checks if an IP has attached any license terms.
     /// @param ipId The address of the IP to check.
@@ -97,7 +97,7 @@ interface ILicenseRegistry {
     function hasIpAttachedLicenseTerms(
         address ipId,
         address licenseTemplate,
-        uint256 licenseTermsId
+        uint32 licenseTermsId
     ) external view returns (bool);
 
     /// @notice Gets the attached license terms of an IP by its index.
@@ -108,7 +108,7 @@ interface ILicenseRegistry {
     function getAttachedLicenseTerms(
         address ipId,
         uint256 index
-    ) external view returns (address licenseTemplate, uint256 licenseTermsId);
+    ) external view returns (address licenseTemplate, uint32 licenseTermsId);
 
     /// @notice Gets the count of attached license terms of an IP.
     /// @param ipId The address of the IP.
@@ -152,7 +152,7 @@ interface ILicenseRegistry {
     function getLicensingConfig(
         address ipId,
         address licenseTemplate,
-        uint256 licenseTermsId
+        uint32 licenseTermsId
     ) external view returns (Licensing.LicensingConfig memory);
 
     /// @notice Sets the minting license configuration for a specific license attached to a specific IP.
@@ -164,7 +164,7 @@ interface ILicenseRegistry {
     function setLicensingConfigForLicense(
         address ipId,
         address licenseTemplate,
-        uint256 licenseTermsId,
+        uint32 licenseTermsId,
         Licensing.LicensingConfig calldata licensingConfig
     ) external;
 

--- a/contracts/lib/Errors.sol
+++ b/contracts/lib/Errors.sol
@@ -100,10 +100,10 @@ library Errors {
     error LicenseRegistry__UnregisteredLicenseTemplate(address licenseTemplate);
 
     /// @notice License Terms or License Template not found.
-    error LicenseRegistry__LicenseTermsNotExists(address licenseTemplate, uint256 licenseTermsId);
+    error LicenseRegistry__LicenseTermsNotExists(address licenseTemplate, uint32 licenseTermsId);
 
     /// @notice Licensor IP does not have the provided license terms attached.
-    error LicenseRegistry__LicensorIpHasNoLicenseTerms(address ipId, address licenseTemplate, uint256 licenseTermsId);
+    error LicenseRegistry__LicensorIpHasNoLicenseTerms(address ipId, address licenseTemplate, uint32 licenseTermsId);
 
     /// @notice Invalid License Template address provided.
     error LicenseRegistry__NotLicenseTemplate(address licenseTemplate);
@@ -118,7 +118,7 @@ library Errors {
     error LicenseRegistry__ParentIpTagged(address ipId);
 
     /// @notice Parent IP does not have the provided license terms attached.
-    error LicenseRegistry__ParentIpHasNoLicenseTerms(address ipId, uint256 licenseTermsId);
+    error LicenseRegistry__ParentIpHasNoLicenseTerms(address ipId, uint32 licenseTermsId);
 
     /// @notice Empty Parent IP list provided.
     error LicenseRegistry__NoParentIp();
@@ -139,13 +139,13 @@ library Errors {
     error LicenseRegistry__IndexOutOfBounds(address ipId, uint256 index, uint256 length);
 
     /// @notice Provided license template and terms ID is already attached to IP.
-    error LicenseRegistry__LicenseTermsAlreadyAttached(address ipId, address licenseTemplate, uint256 licenseTermsId);
+    error LicenseRegistry__LicenseTermsAlreadyAttached(address ipId, address licenseTemplate, uint32 licenseTermsId);
 
     /// @notice Provided license template does not match the IP's current license template.
     error LicenseRegistry__UnmatchedLicenseTemplate(address ipId, address licenseTemplate, address newLicenseTemplate);
 
     /// @notice Provided license template and terms ID is a duplicate.
-    error LicenseRegistry__DuplicateLicense(address ipId, address licenseTemplate, uint256 licenseTermsId);
+    error LicenseRegistry__DuplicateLicense(address ipId, address licenseTemplate, uint32 licenseTermsId);
 
     ////////////////////////////////////////////////////////////////////////////
     //                             License Token                              //
@@ -195,7 +195,7 @@ library Errors {
     error LicensingModule__DisputedIpId();
 
     /// @notice License template and terms ID is not found.
-    error LicensingModule__LicenseTermsNotFound(address licenseTemplate, uint256 licenseTermsId);
+    error LicensingModule__LicenseTermsNotFound(address licenseTemplate, uint32 licenseTermsId);
 
     /// @notice Derivative IP cannot add license terms.
     error LicensingModule__DerivativesCannotAddLicenseTerms();
@@ -224,7 +224,7 @@ library Errors {
     /// @notice License template denied minting license token during the verification stage.
     error LicensingModule__LicenseDenyMintLicenseToken(
         address licenseTemplate,
-        uint256 licenseTermsId,
+        uint32 licenseTermsId,
         address licensorIpId
     );
 
@@ -232,7 +232,7 @@ library Errors {
     error LicensingModule__InvalidLicensingHook(address hook);
 
     /// @notice The license terms ID is invalid or license template doesn't exist.
-    error LicensingModule__InvalidLicenseTermsId(address licenseTemplate, uint256 licenseTermsId);
+    error LicensingModule__InvalidLicenseTermsId(address licenseTemplate, uint32 licenseTermsId);
 
     ////////////////////////////////////////////////////////////////////////////
     //                             Dispute Module                             //

--- a/contracts/modules/licensing/LicensingModule.sol
+++ b/contracts/modules/licensing/LicensingModule.sol
@@ -123,7 +123,7 @@ contract LicensingModule is
     function attachLicenseTerms(
         address ipId,
         address licenseTemplate,
-        uint256 licenseTermsId
+        uint32 licenseTermsId
     ) external verifyPermission(ipId) {
         _verifyIpNotDisputed(ipId);
         LICENSE_REGISTRY.attachLicenseTermsToIp(ipId, licenseTemplate, licenseTermsId);
@@ -152,7 +152,7 @@ contract LicensingModule is
     function mintLicenseTokens(
         address licensorIpId,
         address licenseTemplate,
-        uint256 licenseTermsId,
+        uint32 licenseTermsId,
         uint256 amount,
         address receiver,
         bytes calldata royaltyContext
@@ -224,7 +224,7 @@ contract LicensingModule is
     function registerDerivative(
         address childIpId,
         address[] calldata parentIpIds,
-        uint256[] calldata licenseTermsIds,
+        uint32[] calldata licenseTermsIds,
         address licenseTemplate,
         bytes calldata royaltyContext
     ) external whenNotPaused nonReentrant verifyPermission(childIpId) {
@@ -301,7 +301,7 @@ contract LicensingModule is
         // Confirm that the license token has not been revoked.
         // Validate that the owner of the derivative IP is also the owner of the license tokens.
         address childIpOwner = IIPAccount(payable(childIpId)).owner();
-        (address licenseTemplate, address[] memory parentIpIds, uint256[] memory licenseTermsIds) = LICENSE_NFT
+        (address licenseTemplate, address[] memory parentIpIds, uint32[] memory licenseTermsIds) = LICENSE_NFT
             .validateLicenseTokensForDerivative(childIpId, childIpOwner, licenseTokenIds);
 
         _verifyIpNotDisputed(childIpId);
@@ -366,7 +366,7 @@ contract LicensingModule is
     function setLicensingConfig(
         address ipId,
         address licenseTemplate,
-        uint256 licenseTermsId,
+        uint32 licenseTermsId,
         Licensing.LicensingConfig memory licensingConfig
     ) external verifyPermission(ipId) {
         if (
@@ -392,7 +392,7 @@ contract LicensingModule is
     function _payMintingFeeForAllParentIps(
         address childIpId,
         address[] calldata parentIpIds,
-        uint256[] calldata licenseTermsIds,
+        uint32[] calldata licenseTermsIds,
         address licenseTemplate,
         address childIpOwner,
         bytes calldata royaltyContext
@@ -425,7 +425,7 @@ contract LicensingModule is
         address childIpId,
         address parentIpId,
         address licenseTemplate,
-        uint256 licenseTermsId,
+        uint32 licenseTermsId,
         address childIpOwner,
         bytes calldata royaltyContext
     ) private returns (address royaltyPolicy, bytes memory royaltyData) {
@@ -472,7 +472,7 @@ contract LicensingModule is
     function _payMintingFee(
         address parentIpId,
         address licenseTemplate,
-        uint256 licenseTermsId,
+        uint32 licenseTermsId,
         uint256 amount,
         bytes calldata royaltyContext,
         Licensing.LicensingConfig memory licensingConfig,

--- a/contracts/modules/licensing/PILicenseTemplate.sol
+++ b/contracts/modules/licensing/PILicenseTemplate.sol
@@ -36,9 +36,9 @@ contract PILicenseTemplate is
     /// @dev Storage structure for the PILicenseTemplate
     /// @custom:storage-location erc7201:story-protocol.PILicenseTemplate
     struct PILicenseTemplateStorage {
-        mapping(uint256 licenseTermsId => PILTerms) licenseTerms;
-        mapping(bytes32 licenseTermsHash => uint256 licenseTermsId) hashedLicenseTerms;
-        uint256 licenseTermsCounter;
+        mapping(uint32 licenseTermsId => PILTerms) licenseTerms;
+        mapping(bytes32 licenseTermsHash => uint32 licenseTermsId) hashedLicenseTerms;
+        uint32 licenseTermsCounter;
     }
 
     /// @custom:oz-upgrades-unsafe-allow state-variable-immutable
@@ -83,7 +83,7 @@ contract PILicenseTemplate is
     /// It will return existing ID if the terms are already registered.
     /// @param terms The PILTerms to register.
     /// @return id The ID of the newly registered license terms.
-    function registerLicenseTerms(PILTerms calldata terms) external nonReentrant returns (uint256 id) {
+    function registerLicenseTerms(PILTerms calldata terms) external nonReentrant returns (uint32 id) {
         if (terms.royaltyPolicy != address(0) && !ROYALTY_MODULE.isWhitelistedRoyaltyPolicy(terms.royaltyPolicy)) {
             revert PILicenseTemplateErrors.PILicenseTemplate__RoyaltyPolicyNotWhitelisted();
         }
@@ -116,7 +116,7 @@ contract PILicenseTemplate is
     /// @notice Checks if a license terms exists.
     /// @param licenseTermsId The ID of the license terms.
     /// @return True if the license terms exists, false otherwise.
-    function exists(uint256 licenseTermsId) external view override returns (bool) {
+    function exists(uint32 licenseTermsId) external view override returns (bool) {
         return licenseTermsId <= _getPILicenseTemplateStorage().licenseTermsCounter;
     }
 
@@ -128,7 +128,7 @@ contract PILicenseTemplate is
     /// @param licensorIpId The IP ID of the licensor who attached the license terms minting the license token.
     /// @return True if the minting is verified, false otherwise.
     function verifyMintLicenseToken(
-        uint256 licenseTermsId,
+        uint32 licenseTermsId,
         address licensee,
         address licensorIpId,
         uint256
@@ -168,7 +168,7 @@ contract PILicenseTemplate is
     function verifyRegisterDerivative(
         address childIpId,
         address parentIpId,
-        uint256 licenseTermsId,
+        uint32 licenseTermsId,
         address licensee
     ) external override returns (bool) {
         return _verifyRegisterDerivative(childIpId, parentIpId, licenseTermsId, licensee);
@@ -180,7 +180,7 @@ contract PILicenseTemplate is
     /// It ensures that the licenses of all parent IPs are compatible with each other during the registration process.
     /// @param licenseTermsIds The IDs of the license terms.
     /// @return True if the licenses are compatible, false otherwise.
-    function verifyCompatibleLicenses(uint256[] calldata licenseTermsIds) external view override returns (bool) {
+    function verifyCompatibleLicenses(uint32[] calldata licenseTermsIds) external view override returns (bool) {
         return _verifyCompatibleLicenseTerms(licenseTermsIds);
     }
 
@@ -197,7 +197,7 @@ contract PILicenseTemplate is
     function verifyRegisterDerivativeForAllParents(
         address childIpId,
         address[] calldata parentIpIds,
-        uint256[] calldata licenseTermsIds,
+        uint32[] calldata licenseTermsIds,
         address childIpOwner
     ) external override returns (bool) {
         if (!_verifyCompatibleLicenseTerms(licenseTermsIds)) {
@@ -219,7 +219,7 @@ contract PILicenseTemplate is
     /// @return currency The address of the ERC20 token, used for minting license fee and royalties.
     /// the currency token will used for pay for license token minting fee and royalties.
     function getRoyaltyPolicy(
-        uint256 licenseTermsId
+        uint32 licenseTermsId
     ) external view returns (address royaltyPolicy, bytes memory royaltyData, uint256 mintingFee, address currency) {
         PILTerms memory terms = _getPILicenseTemplateStorage().licenseTerms[licenseTermsId];
         return (terms.royaltyPolicy, abi.encode(terms.commercialRevShare), terms.mintingFee, terms.currency);
@@ -228,7 +228,7 @@ contract PILicenseTemplate is
     /// @notice Checks if a license terms is transferable.
     /// @param licenseTermsId The ID of the license terms.
     /// @return True if the license terms is transferable, false otherwise.
-    function isLicenseTransferable(uint256 licenseTermsId) external view override returns (bool) {
+    function isLicenseTransferable(uint32 licenseTermsId) external view override returns (bool) {
         return _getPILicenseTemplateStorage().licenseTerms[licenseTermsId].transferable;
     }
 
@@ -237,7 +237,7 @@ contract PILicenseTemplate is
     /// @param licenseTermsIds The IDs of the license terms.
     /// @return The earliest expiration time.
     function getEarlierExpireTime(
-        uint256[] calldata licenseTermsIds,
+        uint32[] calldata licenseTermsIds,
         uint256 start
     ) external view override returns (uint256) {
         if (licenseTermsIds.length == 0) {
@@ -254,34 +254,34 @@ contract PILicenseTemplate is
     /// @param start The start time.
     /// @param licenseTermsId The ID of the license terms.
     /// @return The expiration time.
-    function getExpireTime(uint256 licenseTermsId, uint256 start) external view returns (uint256) {
+    function getExpireTime(uint32 licenseTermsId, uint256 start) external view returns (uint256) {
         return _getExpireTime(licenseTermsId, start);
     }
 
     /// @notice Gets the ID of the given license terms.
     /// @param terms The PILTerms to get the ID for.
     /// @return selectedLicenseTermsId The ID of the given license terms.
-    function getLicenseTermsId(PILTerms calldata terms) external view returns (uint256 selectedLicenseTermsId) {
+    function getLicenseTermsId(PILTerms calldata terms) external view returns (uint32 selectedLicenseTermsId) {
         return _getPILicenseTemplateStorage().hashedLicenseTerms[keccak256(abi.encode(terms))];
     }
 
     /// @notice Gets license terms of the given ID.
     /// @param selectedLicenseTermsId The ID of the license terms.
     /// @return terms The PILTerms associate with the given ID.
-    function getLicenseTerms(uint256 selectedLicenseTermsId) external view returns (PILTerms memory terms) {
+    function getLicenseTerms(uint32 selectedLicenseTermsId) external view returns (PILTerms memory terms) {
         return _getPILicenseTemplateStorage().licenseTerms[selectedLicenseTermsId];
     }
 
     /// @notice Returns the URI of the license terms.
     /// @param licenseTermsId The ID of the license terms.
     /// @return The URI of the license terms.
-    function getLicenseTermsURI(uint256 licenseTermsId) external view returns (string memory) {
+    function getLicenseTermsURI(uint32 licenseTermsId) external view returns (string memory) {
         return _getPILicenseTemplateStorage().licenseTerms[licenseTermsId].uri;
     }
 
     /// @notice Returns the total number of registered license terms.
     /// @return The total number of registered license terms.
-    function totalRegisteredLicenseTerms() external view returns (uint256) {
+    function totalRegisteredLicenseTerms() external view returns (uint32) {
         return _getPILicenseTemplateStorage().licenseTermsCounter;
     }
 
@@ -296,7 +296,7 @@ contract PILicenseTemplate is
     /// @dev Must return OpenSea standard compliant metadata.
     /// @param licenseTermsId The ID of the license terms.
     /// @return The JSON string of the license terms, follow the OpenSea metadata standard.
-    function toJson(uint256 licenseTermsId) public view returns (string memory) {
+    function toJson(uint32 licenseTermsId) public view returns (string memory) {
         PILTerms memory terms = _getPILicenseTemplateStorage().licenseTerms[licenseTermsId];
 
         /* solhint-disable */
@@ -429,7 +429,7 @@ contract PILicenseTemplate is
     function _verifyRegisterDerivative(
         address childIpId,
         address parentIpId,
-        uint256 licenseTermsId,
+        uint32 licenseTermsId,
         address licensee
     ) internal returns (bool) {
         PILTerms memory terms = _getPILicenseTemplateStorage().licenseTerms[licenseTermsId];
@@ -455,7 +455,7 @@ contract PILicenseTemplate is
     }
 
     /// @dev Verifies if the license terms are compatible.
-    function _verifyCompatibleLicenseTerms(uint256[] calldata licenseTermsIds) internal view returns (bool) {
+    function _verifyCompatibleLicenseTerms(uint32[] calldata licenseTermsIds) internal view returns (bool) {
         if (licenseTermsIds.length < 2) return true;
         PILicenseTemplateStorage storage $ = _getPILicenseTemplateStorage();
         bool commercial = $.licenseTerms[licenseTermsIds[0]].commercialUse;
@@ -468,7 +468,7 @@ contract PILicenseTemplate is
     }
 
     /// @dev Calculate and returns the expiration time based given start time and license terms.
-    function _getExpireTime(uint256 licenseTermsId, uint256 start) internal view returns (uint) {
+    function _getExpireTime(uint32 licenseTermsId, uint256 start) internal view returns (uint) {
         PILTerms memory terms = _getPILicenseTemplateStorage().licenseTerms[licenseTermsId];
         if (terms.expiration == 0) {
             return 0;

--- a/test/foundry/LicenseToken.t.sol
+++ b/test/foundry/LicenseToken.t.sol
@@ -20,7 +20,7 @@ contract LicenseTokenTest is BaseTest {
     mapping(uint256 => address) internal ipOwner;
     mapping(uint256 => uint256) internal tokenIds;
 
-    uint256 internal commTermsId;
+    uint32 internal commTermsId;
 
     function setUp() public override {
         super.setUp();
@@ -107,7 +107,7 @@ contract LicenseTokenTest is BaseTest {
     }
 
     function test_LicenseToken_revert_transfer_notTransferable() public {
-        uint256 licenseTermsId = pilTemplate.registerLicenseTerms(
+        uint32 licenseTermsId = pilTemplate.registerLicenseTerms(
             PILTerms({
                 transferable: false,
                 royaltyPolicy: address(0),
@@ -147,7 +147,7 @@ contract LicenseTokenTest is BaseTest {
     }
 
     function test_LicenseToken_TokenURI() public {
-        uint256 licenseTermsId = pilTemplate.registerLicenseTerms(PILFlavors.nonCommercialSocialRemixing());
+        uint32 licenseTermsId = pilTemplate.registerLicenseTerms(PILFlavors.nonCommercialSocialRemixing());
 
         vm.prank(address(licensingModule));
         uint256 licenseTokenId = licenseToken.mintLicenseTokens({
@@ -186,7 +186,7 @@ contract LicenseTokenTest is BaseTest {
     }
 
     function test_LicenseToken_getLicenseTokenMetadata() public {
-        uint256 licenseTermsId = pilTemplate.registerLicenseTerms(PILFlavors.nonCommercialSocialRemixing());
+        uint32 licenseTermsId = pilTemplate.registerLicenseTerms(PILFlavors.nonCommercialSocialRemixing());
 
         vm.prank(address(licensingModule));
         uint256 licenseTokenId = licenseToken.mintLicenseTokens({

--- a/test/foundry/integration/big-bang/SingleNftCollection.t.sol
+++ b/test/foundry/integration/big-bang/SingleNftCollection.t.sol
@@ -29,9 +29,9 @@ contract BigBang_Integration_SingleNftCollection is BaseIntegration {
 
     uint256 internal constant mintingFee = 100 ether;
 
-    uint256 internal ncSocialRemixTermsId;
+    uint32 internal ncSocialRemixTermsId;
 
-    uint256 internal commDerivTermsId;
+    uint32 internal commDerivTermsId;
 
     function setUp() public override {
         super.setUp();
@@ -106,7 +106,7 @@ contract BigBang_Integration_SingleNftCollection is BaseIntegration {
             address(licensingModule),
             0,
             abi.encodeWithSignature(
-                "attachLicenseTerms(address,address,uint256)",
+                "attachLicenseTerms(address,address,uint32)",
                 ipAcct[3],
                 address(pilTemplate),
                 ncSocialRemixTermsId

--- a/test/foundry/integration/flows/disputes/Disputes.t.sol
+++ b/test/foundry/integration/flows/disputes/Disputes.t.sol
@@ -16,7 +16,7 @@ contract Flows_Integration_Disputes is BaseIntegration {
     using Strings for *;
 
     mapping(uint256 tokenId => address ipAccount) internal ipAcct;
-    uint256 internal ncSocialRemixTermsId;
+    uint32 internal ncSocialRemixTermsId;
 
     function setUp() public override {
         super.setUp();
@@ -95,7 +95,7 @@ contract Flows_Integration_Disputes is BaseIntegration {
         address[] memory parentIpIds = new address[](1);
         parentIpIds[0] = ipAcct[1];
 
-        uint256[] memory licenseTermsIds = new uint256[](1);
+        uint32[] memory licenseTermsIds = new uint32[](1);
         licenseTermsIds[0] = ncSocialRemixTermsId;
 
         vm.prank(u.carl);

--- a/test/foundry/integration/flows/licensing/LicensingIntegration.t.sol
+++ b/test/foundry/integration/flows/licensing/LicensingIntegration.t.sol
@@ -65,10 +65,10 @@ contract LicensingIntegrationTest is BaseIntegration {
 
     function test_LicensingIntegration_Simple() public {
         // register license terms
-        uint256 lcId1 = pilTemplate.registerLicenseTerms(PILFlavors.nonCommercialSocialRemixing());
+        uint32 lcId1 = pilTemplate.registerLicenseTerms(PILFlavors.nonCommercialSocialRemixing());
         assertEq(lcId1, 1);
 
-        uint256 lcId2 = pilTemplate.registerLicenseTerms(
+        uint32 lcId2 = pilTemplate.registerLicenseTerms(
             PILFlavors.commercialRemix(100, 10, address(royaltyPolicyLAP), address(erc20))
         );
         assertEq(lcId2, 2);
@@ -89,7 +89,7 @@ contract LicensingIntegrationTest is BaseIntegration {
         assertEq(licenseRegistry.hasIpAttachedLicenseTerms(ipAcct[1], address(pilTemplate), 1), true);
         assertEq(licenseRegistry.getAttachedLicenseTermsCount(ipAcct[1]), 1);
 
-        (address attachedTemplate, uint256 attachedId) = licenseRegistry.getAttachedLicenseTerms(ipAcct[1], 0);
+        (address attachedTemplate, uint32 attachedId) = licenseRegistry.getAttachedLicenseTerms(ipAcct[1], 0);
         assertEq(attachedTemplate, address(pilTemplate));
         assertEq(attachedId, 1);
 
@@ -106,7 +106,7 @@ contract LicensingIntegrationTest is BaseIntegration {
         // register derivative directly
         vm.startPrank(u.bob);
         address[] memory parentIpIds = new address[](1);
-        uint256[] memory licenseTermsIds = new uint256[](1);
+        uint32[] memory licenseTermsIds = new uint32[](1);
         parentIpIds[0] = ipAcct[1];
         licenseTermsIds[0] = 1;
 
@@ -209,7 +209,7 @@ contract LicensingIntegrationTest is BaseIntegration {
         erc20.mint(u.eve, 1000);
         erc20.approve(address(royaltyPolicyLAP), 100);
         parentIpIds = new address[](1);
-        licenseTermsIds = new uint256[](1);
+        licenseTermsIds = new uint32[](1);
         parentIpIds[0] = ipAcct[1];
         licenseTermsIds[0] = 2;
 
@@ -232,7 +232,7 @@ contract LicensingIntegrationTest is BaseIntegration {
     }
 
     function test_LicensingIntegration_revert_registerDerivative_parentIpUnmatchedLicenseTemplate() public {
-        uint256 commRemixTermsId = anotherPILTemplate.registerLicenseTerms(
+        uint32 commRemixTermsId = anotherPILTemplate.registerLicenseTerms(
             PILFlavors.commercialRemix({
                 commercialRevShare: 100,
                 mintingFee: 1 ether,
@@ -244,7 +244,7 @@ contract LicensingIntegrationTest is BaseIntegration {
         address[] memory parentIpIds = new address[](1);
         parentIpIds[0] = ipAcct[1];
 
-        uint256[] memory licenseTermsIds = new uint256[](1);
+        uint32[] memory licenseTermsIds = new uint32[](1);
         licenseTermsIds[0] = commRemixTermsId;
 
         vm.prank(u.carl);
@@ -265,8 +265,8 @@ contract LicensingIntegrationTest is BaseIntegration {
     }
 
     function test_LicensingIntegration_revert_registerDerivative_parentIpNoLicenseTerms() public {
-        uint256 ncSocialRemixTermsId = registerSelectedPILicenseTerms_NonCommercialSocialRemixing();
-        uint256 commRemixTermsId = registerSelectedPILicenseTerms(
+        uint32 ncSocialRemixTermsId = registerSelectedPILicenseTerms_NonCommercialSocialRemixing();
+        uint32 commRemixTermsId = registerSelectedPILicenseTerms(
             "commercial_remix",
             PILFlavors.commercialRemix({
                 commercialRevShare: 100,
@@ -282,7 +282,7 @@ contract LicensingIntegrationTest is BaseIntegration {
         address[] memory parentIpIds = new address[](1);
         parentIpIds[0] = ipAcct[1];
 
-        uint256[] memory licenseTermsIds = new uint256[](1);
+        uint32[] memory licenseTermsIds = new uint32[](1);
         licenseTermsIds[0] = commRemixTermsId;
 
         vm.prank(u.carl);

--- a/test/foundry/integration/flows/licensing/LicensingScenarios.t.sol
+++ b/test/foundry/integration/flows/licensing/LicensingScenarios.t.sol
@@ -83,10 +83,10 @@ contract Licensing_Scenarios is BaseIntegration {
         uint256 mintingFee = 100;
 
         // Register non-commercial social remixing policy
-        uint256 ncSocialRemixTermsId = registerSelectedPILicenseTerms_NonCommercialSocialRemixing();
+        uint32 ncSocialRemixTermsId = registerSelectedPILicenseTerms_NonCommercialSocialRemixing();
 
         // Register commercial remixing policy
-        uint256 commRemixTermsId = registerSelectedPILicenseTerms(
+        uint32 commRemixTermsId = registerSelectedPILicenseTerms(
             "commercial_remix",
             PILFlavors.commercialRemix({
                 commercialRevShare: commercialRevShare,
@@ -97,7 +97,7 @@ contract Licensing_Scenarios is BaseIntegration {
         );
 
         // Register commercial use policy
-        uint256 commTermsId = registerSelectedPILicenseTerms(
+        uint32 commTermsId = registerSelectedPILicenseTerms(
             "commercial_use",
             PILFlavors.commercialUse({
                 mintingFee: mintingFee,

--- a/test/foundry/integration/flows/royalty/Royalty.t.sol
+++ b/test/foundry/integration/flows/royalty/Royalty.t.sol
@@ -24,7 +24,7 @@ contract Flows_Integration_Disputes is BaseIntegration {
 
     uint32 internal defaultCommRevShare = 10 * 10 ** 6; // 10%
     uint256 internal mintingFee = 7 ether;
-    uint256 internal commRemixTermsId;
+    uint32 internal commRemixTermsId;
 
     function setUp() public override {
         super.setUp();

--- a/test/foundry/mocks/module/MockLicenseTemplate.sol
+++ b/test/foundry/mocks/module/MockLicenseTemplate.sol
@@ -5,10 +5,10 @@ pragma solidity 0.8.23;
 import { BaseLicenseTemplateUpgradeable } from "contracts/modules/licensing/BaseLicenseTemplateUpgradeable.sol";
 
 contract MockLicenseTemplate is BaseLicenseTemplateUpgradeable {
-    uint256 public licenseTermsCounter;
-    mapping(uint256 => bool) public licenseTerms;
+    uint32 public licenseTermsCounter;
+    mapping(uint32 => bool) public licenseTerms;
 
-    function registerLicenseTerms() external returns (uint256 id) {
+    function registerLicenseTerms() external returns (uint32 id) {
         id = licenseTermsCounter++;
         licenseTerms[id] = true;
     }
@@ -16,7 +16,7 @@ contract MockLicenseTemplate is BaseLicenseTemplateUpgradeable {
     /// @notice Checks if a license terms exists.
     /// @param licenseTermsId The ID of the license terms.
     /// @return True if the license terms exists, false otherwise.
-    function exists(uint256 licenseTermsId) external view override returns (bool) {
+    function exists(uint32 licenseTermsId) external view override returns (bool) {
         return licenseTerms[licenseTermsId];
     }
 
@@ -28,7 +28,7 @@ contract MockLicenseTemplate is BaseLicenseTemplateUpgradeable {
     /// @param licensorIpId The IP ID of the licensor who attached the license terms minting the license token.
     /// @return True if the minting is verified, false otherwise.
     function verifyMintLicenseToken(
-        uint256 licenseTermsId,
+        uint32 licenseTermsId,
         address licensee,
         address licensorIpId,
         uint256 amount
@@ -48,7 +48,7 @@ contract MockLicenseTemplate is BaseLicenseTemplateUpgradeable {
     function verifyRegisterDerivative(
         address childIpId,
         address parentIpId,
-        uint256 licenseTermsId,
+        uint32 licenseTermsId,
         address licensee
     ) external override returns (bool) {
         return true;
@@ -60,7 +60,7 @@ contract MockLicenseTemplate is BaseLicenseTemplateUpgradeable {
     /// It ensures that the licenses of all parent IPs are compatible with each other during the registration process.
     /// @param licenseTermsIds The IDs of the license terms.
     /// @return True if the licenses are compatible, false otherwise.
-    function verifyCompatibleLicenses(uint256[] calldata licenseTermsIds) external view override returns (bool) {
+    function verifyCompatibleLicenses(uint32[] calldata licenseTermsIds) external view override returns (bool) {
         return true;
     }
 
@@ -77,7 +77,7 @@ contract MockLicenseTemplate is BaseLicenseTemplateUpgradeable {
     function verifyRegisterDerivativeForAllParents(
         address childIpId,
         address[] calldata parentIpIds,
-        uint256[] calldata licenseTermsIds,
+        uint32[] calldata licenseTermsIds,
         address childIpOwner
     ) external override returns (bool) {
         return true;
@@ -91,7 +91,7 @@ contract MockLicenseTemplate is BaseLicenseTemplateUpgradeable {
     /// @return currency The address of the ERC20 token, used for minting license fee and royalties.
     /// the currency token will used for pay for license token minting fee and royalties.
     function getRoyaltyPolicy(
-        uint256 licenseTermsId
+        uint32 licenseTermsId
     ) external view returns (address royaltyPolicy, bytes memory royaltyData, uint256 mintingFee, address currency) {
         return (address(0), "", 0, address(0));
     }
@@ -99,7 +99,7 @@ contract MockLicenseTemplate is BaseLicenseTemplateUpgradeable {
     /// @notice Checks if a license terms is transferable.
     /// @param licenseTermsId The ID of the license terms.
     /// @return True if the license terms is transferable, false otherwise.
-    function isLicenseTransferable(uint256 licenseTermsId) external view override returns (bool) {
+    function isLicenseTransferable(uint32 licenseTermsId) external view override returns (bool) {
         return true;
     }
 
@@ -108,7 +108,7 @@ contract MockLicenseTemplate is BaseLicenseTemplateUpgradeable {
     /// @param licenseTermsIds The IDs of the license terms.
     /// @return The earliest expiration time.
     function getEarlierExpireTime(
-        uint256[] calldata licenseTermsIds,
+        uint32[] calldata licenseTermsIds,
         uint256 start
     ) external view override returns (uint256) {
         return 0;
@@ -118,13 +118,13 @@ contract MockLicenseTemplate is BaseLicenseTemplateUpgradeable {
     /// @param start The start time.
     /// @param licenseTermsId The ID of the license terms.
     /// @return The expiration time.
-    function getExpireTime(uint256 licenseTermsId, uint256 start) external view returns (uint256) {
+    function getExpireTime(uint32 licenseTermsId, uint256 start) external view returns (uint256) {
         return 0;
     }
 
     /// @notice Returns the total number of registered license terms.
     /// @return The total number of registered license terms.
-    function totalRegisteredLicenseTerms() external view returns (uint256) {
+    function totalRegisteredLicenseTerms() external view returns (uint32) {
         return licenseTermsCounter;
     }
 
@@ -139,14 +139,14 @@ contract MockLicenseTemplate is BaseLicenseTemplateUpgradeable {
     /// @dev Must return OpenSea standard compliant metadata.
     /// @param licenseTermsId The ID of the license terms.
     /// @return The JSON string of the license terms, follow the OpenSea metadata standard.
-    function toJson(uint256 licenseTermsId) public view returns (string memory) {
+    function toJson(uint32 licenseTermsId) public view returns (string memory) {
         return "";
     }
 
     /// @notice Returns the URI of the license terms.
     /// @param licenseTermsId The ID of the license terms.
     /// @return The URI of the license terms.
-    function getLicenseTermsURI(uint256 licenseTermsId) external view returns (string memory) {
+    function getLicenseTermsURI(uint32 licenseTermsId) external view returns (string memory) {
         return "";
     }
 }

--- a/test/foundry/modules/licensing/LicensingModule.t.sol
+++ b/test/foundry/modules/licensing/LicensingModule.t.sol
@@ -63,12 +63,12 @@ contract LicensingModuleTest is BaseTest {
     }
 
     function test_LicensingModule_attachLicenseTerms_attachOneLicenseToOneIP() public {
-        uint256 termsId = pilTemplate.registerLicenseTerms(PILFlavors.defaultValuesLicenseTerms());
+        uint32 termsId = pilTemplate.registerLicenseTerms(PILFlavors.defaultValuesLicenseTerms());
         vm.expectEmit();
         emit ILicensingModule.LicenseTermsAttached(ipOwner1, ipId1, address(pilTemplate), termsId);
         vm.prank(ipOwner1);
         licensingModule.attachLicenseTerms(ipId1, address(pilTemplate), termsId);
-        (address licenseTemplate, uint256 licenseTermsId) = licenseRegistry.getAttachedLicenseTerms(ipId1, 0);
+        (address licenseTemplate, uint32 licenseTermsId) = licenseRegistry.getAttachedLicenseTerms(ipId1, 0);
         assertEq(licenseTemplate, address(pilTemplate));
         assertEq(licenseTermsId, termsId);
         assertTrue(licenseRegistry.hasIpAttachedLicenseTerms(ipId1, address(pilTemplate), termsId));
@@ -82,14 +82,14 @@ contract LicensingModuleTest is BaseTest {
     }
 
     function test_LicensingModule_attachLicenseTerms_sameLicenseAttachMultipleIP() public {
-        uint256 termsId = pilTemplate.registerLicenseTerms(PILFlavors.defaultValuesLicenseTerms());
+        uint32 termsId = pilTemplate.registerLicenseTerms(PILFlavors.defaultValuesLicenseTerms());
 
         vm.expectEmit();
         emit ILicensingModule.LicenseTermsAttached(ipOwner1, ipId1, address(pilTemplate), termsId);
         vm.prank(ipOwner1);
         licensingModule.attachLicenseTerms(ipId1, address(pilTemplate), termsId);
 
-        (address licenseTemplate, uint256 licenseTermsId) = licenseRegistry.getAttachedLicenseTerms(ipId1, 0);
+        (address licenseTemplate, uint32 licenseTermsId) = licenseRegistry.getAttachedLicenseTerms(ipId1, 0);
         assertEq(licenseTemplate, address(pilTemplate));
         assertEq(licenseTermsId, termsId);
         assertTrue(licenseRegistry.hasIpAttachedLicenseTerms(ipId1, address(pilTemplate), termsId));
@@ -119,12 +119,12 @@ contract LicensingModuleTest is BaseTest {
     }
 
     function test_LicensingModule_attachLicenseTerms_DifferentLicensesAttachToSameIP() public {
-        uint256 termsId1 = pilTemplate.registerLicenseTerms(PILFlavors.defaultValuesLicenseTerms());
+        uint32 termsId1 = pilTemplate.registerLicenseTerms(PILFlavors.defaultValuesLicenseTerms());
         vm.expectEmit();
         emit ILicensingModule.LicenseTermsAttached(ipOwner1, ipId1, address(pilTemplate), termsId1);
         vm.prank(ipOwner1);
         licensingModule.attachLicenseTerms(ipId1, address(pilTemplate), termsId1);
-        (address licenseTemplate1, uint256 licenseTermsId1) = licenseRegistry.getAttachedLicenseTerms(ipId1, 0);
+        (address licenseTemplate1, uint32 licenseTermsId1) = licenseRegistry.getAttachedLicenseTerms(ipId1, 0);
         assertEq(licenseTemplate1, address(pilTemplate));
         assertEq(licenseTermsId1, termsId1);
         assertTrue(licenseRegistry.hasIpAttachedLicenseTerms(ipId1, address(pilTemplate), termsId1));
@@ -136,12 +136,12 @@ contract LicensingModuleTest is BaseTest {
         assertFalse(licenseRegistry.isDerivativeIp(ipId1));
         assertTrue(licenseRegistry.exists(address(pilTemplate), termsId1));
 
-        uint256 termsId2 = pilTemplate.registerLicenseTerms(PILFlavors.nonCommercialSocialRemixing());
+        uint32 termsId2 = pilTemplate.registerLicenseTerms(PILFlavors.nonCommercialSocialRemixing());
         vm.expectEmit();
         emit ILicensingModule.LicenseTermsAttached(ipOwner1, ipId1, address(pilTemplate), termsId2);
         vm.prank(ipOwner1);
         licensingModule.attachLicenseTerms(ipId1, address(pilTemplate), termsId2);
-        (address licenseTemplate2, uint256 licenseTermsId2) = licenseRegistry.getAttachedLicenseTerms(ipId1, 1);
+        (address licenseTemplate2, uint32 licenseTermsId2) = licenseRegistry.getAttachedLicenseTerms(ipId1, 1);
         assertEq(licenseTemplate2, address(pilTemplate));
         assertEq(licenseTermsId2, termsId2);
         assertTrue(licenseRegistry.hasIpAttachedLicenseTerms(ipId1, address(pilTemplate), termsId2));
@@ -155,7 +155,7 @@ contract LicensingModuleTest is BaseTest {
     }
 
     function test_LicensingModule_attachLicenseTerms_revert_licenseNotExist() public {
-        uint256 nonExistTermsId = 9999;
+        uint32 nonExistTermsId = 9999;
         assertFalse(licenseRegistry.exists(address(pilTemplate), nonExistTermsId));
 
         vm.expectRevert(
@@ -192,7 +192,7 @@ contract LicensingModuleTest is BaseTest {
             uri: ""
         });
 
-        uint256 termsId = pilTemplate.registerLicenseTerms(terms);
+        uint32 termsId = pilTemplate.registerLicenseTerms(terms);
         vm.prank(ipOwner1);
         licensingModule.attachLicenseTerms(ipId1, address(pilTemplate), termsId);
 
@@ -233,7 +233,7 @@ contract LicensingModuleTest is BaseTest {
         vm.expectRevert(abi.encodeWithSelector(ERC721NonexistentToken.selector, lcTokenId));
         licenseToken.ownerOf(lcTokenId);
 
-        (address licenseTemplate, uint256 licenseTermsId) = licenseRegistry.getAttachedLicenseTerms(ipId2, 0);
+        (address licenseTemplate, uint32 licenseTermsId) = licenseRegistry.getAttachedLicenseTerms(ipId2, 0);
         assertEq(licenseTemplate, address(pilTemplate));
         assertEq(licenseTermsId, termsId);
 
@@ -247,14 +247,14 @@ contract LicensingModuleTest is BaseTest {
         });
 
         vm.warp(11 days);
-        uint256 anotherTermsId = pilTemplate.registerLicenseTerms(PILFlavors.defaultValuesLicenseTerms());
+        uint32 anotherTermsId = pilTemplate.registerLicenseTerms(PILFlavors.defaultValuesLicenseTerms());
         vm.expectRevert(abi.encodeWithSelector(Errors.LicenseRegistry__IpExpired.selector, ipId2));
         vm.prank(ipOwner2);
         licensingModule.attachLicenseTerms(ipId2, address(pilTemplate), anotherTermsId);
     }
 
     function test_LicensingModule_attachLicenseTerms_revert_attachSameLicenseToIpTwice() public {
-        uint256 termsId = pilTemplate.registerLicenseTerms(PILFlavors.defaultValuesLicenseTerms());
+        uint32 termsId = pilTemplate.registerLicenseTerms(PILFlavors.defaultValuesLicenseTerms());
         vm.prank(ipOwner1);
         licensingModule.attachLicenseTerms(ipId1, address(pilTemplate), termsId);
         vm.expectRevert(
@@ -270,14 +270,14 @@ contract LicensingModuleTest is BaseTest {
     }
 
     function test_LicensingModule_attachLicenseTerms_revert_attachLicenseDifferentTemplate() public {
-        uint256 termsId = pilTemplate.registerLicenseTerms(PILFlavors.defaultValuesLicenseTerms());
+        uint32 termsId = pilTemplate.registerLicenseTerms(PILFlavors.defaultValuesLicenseTerms());
         vm.prank(ipOwner1);
         licensingModule.attachLicenseTerms(ipId1, address(pilTemplate), termsId);
 
         MockLicenseTemplate mockLicenseTemplate = new MockLicenseTemplate();
         vm.prank(admin);
         licenseRegistry.registerLicenseTemplate(address(mockLicenseTemplate));
-        uint256 mockTermsId = mockLicenseTemplate.registerLicenseTerms();
+        uint32 mockTermsId = mockLicenseTemplate.registerLicenseTerms();
         vm.expectRevert(
             abi.encodeWithSelector(
                 Errors.LicenseRegistry__UnmatchedLicenseTemplate.selector,
@@ -292,7 +292,7 @@ contract LicensingModuleTest is BaseTest {
 
     function test_LicensingModule_attachLicenseTerms_revert_Unregistered_LicenseTemplate() public {
         MockLicenseTemplate mockLicenseTemplate = new MockLicenseTemplate();
-        uint256 mockTermsId = mockLicenseTemplate.registerLicenseTerms();
+        uint32 mockTermsId = mockLicenseTemplate.registerLicenseTerms();
         vm.expectRevert(
             abi.encodeWithSelector(
                 Errors.LicensingModule__LicenseTermsNotFound.selector,
@@ -305,7 +305,7 @@ contract LicensingModuleTest is BaseTest {
     }
 
     function test_LicensingModule_attachLicenseTerms_revert_NonExists_LicenseTerms() public {
-        uint256 nonExistsTermsId = 9999;
+        uint32 nonExistsTermsId = 9999;
         vm.expectRevert(
             abi.encodeWithSelector(
                 Errors.LicensingModule__LicenseTermsNotFound.selector,
@@ -318,7 +318,7 @@ contract LicensingModuleTest is BaseTest {
     }
 
     function test_LicensingModule_mintLicenseTokens_singleToken() public {
-        uint256 termsId = pilTemplate.registerLicenseTerms(PILFlavors.defaultValuesLicenseTerms());
+        uint32 termsId = pilTemplate.registerLicenseTerms(PILFlavors.defaultValuesLicenseTerms());
         vm.prank(ipOwner1);
         licensingModule.attachLicenseTerms(ipId1, address(pilTemplate), termsId);
 
@@ -344,7 +344,7 @@ contract LicensingModuleTest is BaseTest {
     }
 
     function test_LicensingModule_mintLicenseTokens_mintMultipleTokens() public {
-        uint256 termsId = pilTemplate.registerLicenseTerms(PILFlavors.defaultValuesLicenseTerms());
+        uint32 termsId = pilTemplate.registerLicenseTerms(PILFlavors.defaultValuesLicenseTerms());
         vm.prank(ipOwner1);
         licensingModule.attachLicenseTerms(ipId1, address(pilTemplate), termsId);
 
@@ -378,7 +378,7 @@ contract LicensingModuleTest is BaseTest {
     }
 
     function test_LicensingModule_mintLicenseTokens_mintMultipleTimes() public {
-        uint256 termsId = pilTemplate.registerLicenseTerms(PILFlavors.defaultValuesLicenseTerms());
+        uint32 termsId = pilTemplate.registerLicenseTerms(PILFlavors.defaultValuesLicenseTerms());
         vm.prank(ipOwner1);
         licensingModule.attachLicenseTerms(ipId1, address(pilTemplate), termsId);
 
@@ -436,7 +436,7 @@ contract LicensingModuleTest is BaseTest {
             uri: ""
         });
 
-        uint256 termsId = pilTemplate.registerLicenseTerms(terms);
+        uint32 termsId = pilTemplate.registerLicenseTerms(terms);
         vm.prank(ipOwner1);
         licensingModule.attachLicenseTerms(ipId1, address(pilTemplate), termsId);
 
@@ -458,7 +458,7 @@ contract LicensingModuleTest is BaseTest {
     }
 
     function test_LicensingModule_mintLicenseTokens_revert_invalidInputs() public {
-        uint256 termsId = pilTemplate.registerLicenseTerms(PILFlavors.defaultValuesLicenseTerms());
+        uint32 termsId = pilTemplate.registerLicenseTerms(PILFlavors.defaultValuesLicenseTerms());
         vm.prank(ipOwner1);
         licensingModule.attachLicenseTerms(ipId1, address(pilTemplate), termsId);
 
@@ -485,7 +485,7 @@ contract LicensingModuleTest is BaseTest {
     }
 
     function test_LicensingModule_mintLicenseTokens_revert_NonIpOwnerMintNotAttachedLicense() public {
-        uint256 termsId = pilTemplate.registerLicenseTerms(PILFlavors.defaultValuesLicenseTerms());
+        uint32 termsId = pilTemplate.registerLicenseTerms(PILFlavors.defaultValuesLicenseTerms());
         address receiver = address(0x111);
         vm.expectRevert(
             abi.encodeWithSelector(
@@ -522,7 +522,7 @@ contract LicensingModuleTest is BaseTest {
     }
 
     function test_LicensingModule_mintLicenseTokens_revert_paused() public {
-        uint256 termsId = pilTemplate.registerLicenseTerms(PILFlavors.defaultValuesLicenseTerms());
+        uint32 termsId = pilTemplate.registerLicenseTerms(PILFlavors.defaultValuesLicenseTerms());
         vm.prank(ipOwner1);
         licensingModule.attachLicenseTerms(ipId1, address(pilTemplate), termsId);
 
@@ -543,7 +543,7 @@ contract LicensingModuleTest is BaseTest {
     }
 
     function test_LicensingModule_mintLicenseTokens_IpOwnerMintNotAttachedLicense() public {
-        uint256 termsId = pilTemplate.registerLicenseTerms(PILFlavors.defaultValuesLicenseTerms());
+        uint32 termsId = pilTemplate.registerLicenseTerms(PILFlavors.defaultValuesLicenseTerms());
         address receiver = address(0x111);
         vm.prank(ipOwner1);
         uint256 lcTokenId = licensingModule.mintLicenseTokens({
@@ -565,7 +565,7 @@ contract LicensingModuleTest is BaseTest {
     }
 
     function test_LicensingModule_registerDerivativeWithLicenseTokens_singleParent() public {
-        uint256 termsId = pilTemplate.registerLicenseTerms(PILFlavors.nonCommercialSocialRemixing());
+        uint32 termsId = pilTemplate.registerLicenseTerms(PILFlavors.nonCommercialSocialRemixing());
         vm.prank(ipOwner1);
         licensingModule.attachLicenseTerms(ipId1, address(pilTemplate), termsId);
 
@@ -606,13 +606,13 @@ contract LicensingModuleTest is BaseTest {
         vm.expectRevert(abi.encodeWithSelector(ERC721NonexistentToken.selector, lcTokenId));
         licenseToken.ownerOf(lcTokenId);
 
-        (address licenseTemplate, uint256 licenseTermsId) = licenseRegistry.getAttachedLicenseTerms(ipId2, 0);
+        (address licenseTemplate, uint32 licenseTermsId) = licenseRegistry.getAttachedLicenseTerms(ipId2, 0);
         assertEq(licenseTemplate, address(pilTemplate));
         assertEq(licenseTermsId, termsId);
     }
 
     function test_LicensingModule_registerDerivativeWithLicenseTokens_revert_pause() public {
-        uint256 termsId = pilTemplate.registerLicenseTerms(PILFlavors.nonCommercialSocialRemixing());
+        uint32 termsId = pilTemplate.registerLicenseTerms(PILFlavors.nonCommercialSocialRemixing());
         vm.prank(ipOwner1);
         licensingModule.attachLicenseTerms(ipId1, address(pilTemplate), termsId);
 
@@ -636,7 +636,7 @@ contract LicensingModuleTest is BaseTest {
     }
 
     function test_LicensingModule_registerDerivativeWithLicenseTokens_twoParents() public {
-        uint256 termsId = pilTemplate.registerLicenseTerms(PILFlavors.nonCommercialSocialRemixing());
+        uint32 termsId = pilTemplate.registerLicenseTerms(PILFlavors.nonCommercialSocialRemixing());
         vm.prank(ipOwner1);
         licensingModule.attachLicenseTerms(ipId1, address(pilTemplate), termsId);
         vm.prank(ipOwner2);
@@ -708,12 +708,12 @@ contract LicensingModuleTest is BaseTest {
         vm.expectRevert(abi.encodeWithSelector(ERC721NonexistentToken.selector, lcTokenId2));
         licenseToken.ownerOf(lcTokenId2);
 
-        (address licenseTemplate, uint256 licenseTermsId) = licenseRegistry.getAttachedLicenseTerms(ipId3, 0);
+        (address licenseTemplate, uint32 licenseTermsId) = licenseRegistry.getAttachedLicenseTerms(ipId3, 0);
         assertEq(licenseTemplate, address(pilTemplate));
     }
 
     function test_LicensingModule_registerDerivativeWithLicenseTokens_revert_parentIsChild() public {
-        uint256 termsId = pilTemplate.registerLicenseTerms(PILFlavors.nonCommercialSocialRemixing());
+        uint32 termsId = pilTemplate.registerLicenseTerms(PILFlavors.nonCommercialSocialRemixing());
         vm.prank(ipOwner1);
 
         uint256 lcTokenId = licensingModule.mintLicenseTokens({
@@ -734,10 +734,10 @@ contract LicensingModuleTest is BaseTest {
     }
 
     function test_LicensingModule_registerDerivativeWithLicenseTokens_revert_ParentExpired() public {
-        uint256 termsId = pilTemplate.registerLicenseTerms(PILFlavors.nonCommercialSocialRemixing());
+        uint32 termsId = pilTemplate.registerLicenseTerms(PILFlavors.nonCommercialSocialRemixing());
         PILTerms memory expiredTerms = PILFlavors.nonCommercialSocialRemixing();
         expiredTerms.expiration = 10 days;
-        uint256 expiredTermsId = pilTemplate.registerLicenseTerms(expiredTerms);
+        uint32 expiredTermsId = pilTemplate.registerLicenseTerms(expiredTerms);
 
         vm.prank(ipOwner1);
         licensingModule.attachLicenseTerms(ipId1, address(pilTemplate), termsId);
@@ -803,7 +803,7 @@ contract LicensingModuleTest is BaseTest {
         assertEq(licenseRegistry.getParentIp(ipId3, 0), ipId1);
         assertEq(licenseRegistry.getParentIp(ipId3, 1), ipId2);
 
-        (address licenseTemplate, uint256 licenseTermsId) = licenseRegistry.getAttachedLicenseTerms(ipId3, 0);
+        (address licenseTemplate, uint32 licenseTermsId) = licenseRegistry.getAttachedLicenseTerms(ipId3, 0);
         assertEq(licenseTemplate, address(pilTemplate));
         assertEq(licenseTermsId, termsId);
         (address anotherLicenseTemplate, uint256 anotherLicenseTermsId) = licenseRegistry.getAttachedLicenseTerms(
@@ -839,7 +839,7 @@ contract LicensingModuleTest is BaseTest {
     }
 
     function test_LicensingModule_registerDerivativeWithLicenseTokens_revert_childAlreadyAttachedLicense() public {
-        uint256 termsId = pilTemplate.registerLicenseTerms(PILFlavors.nonCommercialSocialRemixing());
+        uint32 termsId = pilTemplate.registerLicenseTerms(PILFlavors.nonCommercialSocialRemixing());
         vm.prank(ipOwner1);
         licensingModule.attachLicenseTerms(ipId1, address(pilTemplate), termsId);
 
@@ -861,7 +861,7 @@ contract LicensingModuleTest is BaseTest {
     }
 
     function test_LicensingModule_registerDerivativeWithLicenseTokens_revert_AlreadyRegisteredAsDerivative() public {
-        uint256 termsId = pilTemplate.registerLicenseTerms(PILFlavors.nonCommercialSocialRemixing());
+        uint32 termsId = pilTemplate.registerLicenseTerms(PILFlavors.nonCommercialSocialRemixing());
         vm.prank(ipOwner1);
         licensingModule.attachLicenseTerms(ipId1, address(pilTemplate), termsId);
         vm.prank(ipOwner2);
@@ -898,7 +898,7 @@ contract LicensingModuleTest is BaseTest {
     }
 
     function test_LicensingModule_registerDerivativeWithLicenseTokens_revert_notLicensee() public {
-        uint256 termsId = pilTemplate.registerLicenseTerms(PILFlavors.nonCommercialSocialRemixing());
+        uint32 termsId = pilTemplate.registerLicenseTerms(PILFlavors.nonCommercialSocialRemixing());
         vm.prank(ipOwner1);
         licensingModule.attachLicenseTerms(ipId1, address(pilTemplate), termsId);
 
@@ -922,7 +922,7 @@ contract LicensingModuleTest is BaseTest {
     }
 
     function test_LicensingModule_singleTransfer_verifyOk() public {
-        uint256 termsId = pilTemplate.registerLicenseTerms(PILFlavors.nonCommercialSocialRemixing());
+        uint32 termsId = pilTemplate.registerLicenseTerms(PILFlavors.nonCommercialSocialRemixing());
         vm.prank(ipOwner1);
         licensingModule.attachLicenseTerms(ipId1, address(pilTemplate), termsId);
 
@@ -959,7 +959,7 @@ contract LicensingModuleTest is BaseTest {
         vm.expectRevert(abi.encodeWithSelector(ERC721NonexistentToken.selector, lcTokenId));
         licenseToken.ownerOf(lcTokenId);
 
-        (address licenseTemplate, uint256 licenseTermsId) = licenseRegistry.getAttachedLicenseTerms(ipId3, 0);
+        (address licenseTemplate, uint32 licenseTermsId) = licenseRegistry.getAttachedLicenseTerms(ipId3, 0);
         assertEq(licenseTemplate, address(pilTemplate));
         assertEq(licenseTermsId, termsId);
     }
@@ -989,7 +989,7 @@ contract LicensingModuleTest is BaseTest {
             uri: ""
         });
 
-        uint256 termsId = pilTemplate.registerLicenseTerms(terms);
+        uint32 termsId = pilTemplate.registerLicenseTerms(terms);
         vm.prank(ipOwner1);
         licensingModule.attachLicenseTerms(ipId1, address(pilTemplate), termsId);
 
@@ -1038,7 +1038,7 @@ contract LicensingModuleTest is BaseTest {
             uri: ""
         });
 
-        uint256 termsId = pilTemplate.registerLicenseTerms(terms);
+        uint32 termsId = pilTemplate.registerLicenseTerms(terms);
         vm.prank(ipOwner1);
         licensingModule.attachLicenseTerms(ipId1, address(pilTemplate), termsId);
 
@@ -1085,7 +1085,7 @@ contract LicensingModuleTest is BaseTest {
             uri: ""
         });
 
-        uint256 termsId = pilTemplate.registerLicenseTerms(terms);
+        uint32 termsId = pilTemplate.registerLicenseTerms(terms);
         vm.prank(ipOwner1);
         licensingModule.attachLicenseTerms(ipId1, address(pilTemplate), termsId);
 
@@ -1134,7 +1134,7 @@ contract LicensingModuleTest is BaseTest {
     function test_LicensingModule_registerDerivative_revert_emptyParentIpIds() public {
         vm.expectRevert(Errors.LicensingModule__NoParentIp.selector);
         vm.prank(ipOwner2);
-        licensingModule.registerDerivative(ipId2, new address[](0), new uint256[](0), address(0), "");
+        licensingModule.registerDerivative(ipId2, new address[](0), new uint32[](0), address(0), "");
     }
 
     function test_LicensingModule_registerDerivative_revert_parentIdsLengthMismatchWithLicenseIds() public {
@@ -1142,12 +1142,12 @@ contract LicensingModuleTest is BaseTest {
         parentIpIds[0] = ipId1;
         vm.expectRevert(abi.encodeWithSelector(Errors.LicensingModule__LicenseTermsLengthMismatch.selector, 1, 0));
         vm.prank(ipOwner2);
-        licensingModule.registerDerivative(ipId2, parentIpIds, new uint256[](0), address(0), "");
+        licensingModule.registerDerivative(ipId2, parentIpIds, new uint32[](0), address(0), "");
     }
 
     function test_LicensingModule_registerDerivative_revert_IncompatibleLicenses() public {
-        uint256 socialRemixTermsId = pilTemplate.registerLicenseTerms(PILFlavors.nonCommercialSocialRemixing());
-        uint256 commUseTermsId = pilTemplate.registerLicenseTerms(
+        uint32 socialRemixTermsId = pilTemplate.registerLicenseTerms(PILFlavors.nonCommercialSocialRemixing());
+        uint32 commUseTermsId = pilTemplate.registerLicenseTerms(
             PILFlavors.commercialUse({
                 mintingFee: 0,
                 currencyToken: address(erc20),
@@ -1164,7 +1164,7 @@ contract LicensingModuleTest is BaseTest {
         parentIpIds[0] = ipId1;
         parentIpIds[1] = ipId2;
 
-        uint256[] memory licenseTermsIds = new uint256[](2);
+        uint32[] memory licenseTermsIds = new uint32[](2);
         licenseTermsIds[0] = socialRemixTermsId;
         licenseTermsIds[1] = commUseTermsId;
 
@@ -1176,7 +1176,7 @@ contract LicensingModuleTest is BaseTest {
     }
 
     function test_LicensingModule_setLicensingConfig() public {
-        uint256 socialRemixTermsId = pilTemplate.registerLicenseTerms(PILFlavors.nonCommercialSocialRemixing());
+        uint32 socialRemixTermsId = pilTemplate.registerLicenseTerms(PILFlavors.nonCommercialSocialRemixing());
         MockLicensingHook licensingHook = new MockLicensingHook();
         vm.prank(admin);
         moduleRegistry.registerModule("MockLicensingHook", address(licensingHook));
@@ -1214,7 +1214,7 @@ contract LicensingModuleTest is BaseTest {
     }
 
     function test_LicensingModule_setLicensingConfig_revert_invalidTermsId() public {
-        uint256 socialRemixTermsId = pilTemplate.registerLicenseTerms(PILFlavors.nonCommercialSocialRemixing());
+        uint32 socialRemixTermsId = pilTemplate.registerLicenseTerms(PILFlavors.nonCommercialSocialRemixing());
         MockLicensingHook licensingHook = new MockLicensingHook();
         vm.prank(admin);
         moduleRegistry.registerModule("MockLicensingHook", address(licensingHook));
@@ -1242,7 +1242,7 @@ contract LicensingModuleTest is BaseTest {
     }
 
     function test_LicensingModule_setLicensingConfig_revert_invalidLicensingHook() public {
-        uint256 socialRemixTermsId = pilTemplate.registerLicenseTerms(PILFlavors.nonCommercialSocialRemixing());
+        uint32 socialRemixTermsId = pilTemplate.registerLicenseTerms(PILFlavors.nonCommercialSocialRemixing());
         // unregistered the licensing hook
         MockLicensingHook licensingHook = new MockLicensingHook();
         Licensing.LicensingConfig memory licensingConfig = Licensing.LicensingConfig({
@@ -1276,7 +1276,7 @@ contract LicensingModuleTest is BaseTest {
     }
 
     function test_LicensingModule_mintLicenseTokens_revert_licensingHookRevert() public {
-        uint256 termsId = pilTemplate.registerLicenseTerms(PILFlavors.defaultValuesLicenseTerms());
+        uint32 termsId = pilTemplate.registerLicenseTerms(PILFlavors.defaultValuesLicenseTerms());
         MockLicensingHook licensingHook = new MockLicensingHook();
         vm.prank(admin);
         moduleRegistry.registerModule("MockLicensingHook", address(licensingHook));
@@ -1304,7 +1304,7 @@ contract LicensingModuleTest is BaseTest {
     }
 
     function test_LicensingModule_mintLicenseTokens_withMintingFeeFromHook() public {
-        uint256 termsId = pilTemplate.registerLicenseTerms(
+        uint32 termsId = pilTemplate.registerLicenseTerms(
             PILFlavors.commercialRemix({
                 mintingFee: 999,
                 commercialRevShare: 10,
@@ -1354,7 +1354,7 @@ contract LicensingModuleTest is BaseTest {
     }
 
     function test_LicensingModule_registerDerivative_withMintingFeeFromHook() public {
-        uint256 termsId = pilTemplate.registerLicenseTerms(
+        uint32 termsId = pilTemplate.registerLicenseTerms(
             PILFlavors.commercialRemix({
                 mintingFee: 999,
                 commercialRevShare: 10,
@@ -1383,7 +1383,7 @@ contract LicensingModuleTest is BaseTest {
         erc20.approve(address(royaltyPolicyLAP), 100);
 
         address[] memory parentIpIds = new address[](1);
-        uint256[] memory licenseTermsIds = new uint256[](1);
+        uint32[] memory licenseTermsIds = new uint32[](1);
         parentIpIds[0] = ipId1;
         licenseTermsIds[0] = termsId;
 
@@ -1406,7 +1406,7 @@ contract LicensingModuleTest is BaseTest {
     }
 
     function test_LicensingModule_registerDerivative_revert_licensingHookRevert() public {
-        uint256 termsId = pilTemplate.registerLicenseTerms(PILFlavors.nonCommercialSocialRemixing());
+        uint32 termsId = pilTemplate.registerLicenseTerms(PILFlavors.nonCommercialSocialRemixing());
         MockLicensingHook licensingHook = new MockLicensingHook();
         vm.prank(admin);
         moduleRegistry.registerModule("MockLicensingHook", address(licensingHook));
@@ -1422,7 +1422,7 @@ contract LicensingModuleTest is BaseTest {
         licensingModule.attachLicenseTerms(ipId1, address(pilTemplate), termsId);
 
         address[] memory parentIpIds = new address[](1);
-        uint256[] memory licenseTermsIds = new uint256[](1);
+        uint32[] memory licenseTermsIds = new uint32[](1);
         parentIpIds[0] = ipId1;
         licenseTermsIds[0] = termsId;
         vm.prank(ipOwner2);

--- a/test/foundry/modules/licensing/PILicenseTemplate.t.sol
+++ b/test/foundry/modules/licensing/PILicenseTemplate.t.sol
@@ -52,7 +52,7 @@ contract PILicenseTemplateTest is BaseTest {
     // this contract is for testing for each PILicenseTemplate's functions
     // register license terms with PILTerms struct
     function test_PILicenseTemplate_registerLicenseTerms() public {
-        uint256 defaultTermsId = pilTemplate.registerLicenseTerms(PILFlavors.defaultValuesLicenseTerms());
+        uint32 defaultTermsId = pilTemplate.registerLicenseTerms(PILFlavors.defaultValuesLicenseTerms());
         assertEq(defaultTermsId, 1);
         (address royaltyPolicy, bytes memory royaltyData, uint256 mintingFee, address currency) = pilTemplate
             .getRoyaltyPolicy(defaultTermsId);
@@ -65,7 +65,7 @@ contract PILicenseTemplateTest is BaseTest {
         assertEq(pilTemplate.getExpireTime(defaultTermsId, block.timestamp), 0, "expire time should be 0");
         assertTrue(pilTemplate.exists(defaultTermsId), "license terms should exist");
 
-        uint256 socialRemixTermsId = pilTemplate.registerLicenseTerms(PILFlavors.nonCommercialSocialRemixing());
+        uint32 socialRemixTermsId = pilTemplate.registerLicenseTerms(PILFlavors.nonCommercialSocialRemixing());
         assertEq(socialRemixTermsId, 2);
         (royaltyPolicy, royaltyData, mintingFee, currency) = pilTemplate.getRoyaltyPolicy(socialRemixTermsId);
         assertEq(royaltyPolicy, address(0));
@@ -77,7 +77,7 @@ contract PILicenseTemplateTest is BaseTest {
         assertEq(pilTemplate.getExpireTime(socialRemixTermsId, block.timestamp), 0, "expire time should be 0");
         assertTrue(pilTemplate.exists(socialRemixTermsId), "license terms should exist");
 
-        uint256 commUseTermsId = pilTemplate.registerLicenseTerms(
+        uint32 commUseTermsId = pilTemplate.registerLicenseTerms(
             PILFlavors.commercialUse({
                 mintingFee: 100,
                 currencyToken: address(erc20),
@@ -98,7 +98,7 @@ contract PILicenseTemplateTest is BaseTest {
         assertEq(pilTemplate.getExpireTime(commUseTermsId, block.timestamp), 0, "expire time should be 0");
         assertEq(pilTemplate.totalRegisteredLicenseTerms(), 3);
 
-        uint256 commRemixTermsId = pilTemplate.registerLicenseTerms(
+        uint32 commRemixTermsId = pilTemplate.registerLicenseTerms(
             PILFlavors.commercialRemix({
                 mintingFee: 100,
                 commercialRevShare: 10,
@@ -124,7 +124,7 @@ contract PILicenseTemplateTest is BaseTest {
 
         assertEq(pilTemplate.totalRegisteredLicenseTerms(), 4);
 
-        uint256[] memory licenseTermsIds = new uint256[](4);
+        uint32[] memory licenseTermsIds = new uint32[](4);
         licenseTermsIds[0] = defaultTermsId;
         licenseTermsIds[1] = socialRemixTermsId;
         licenseTermsIds[2] = commUseTermsId;
@@ -135,8 +135,8 @@ contract PILicenseTemplateTest is BaseTest {
     }
     // register license terms twice
     function test_PILicenseTemplate_registerLicenseTerms_twice() public {
-        uint256 defaultTermsId = pilTemplate.registerLicenseTerms(PILFlavors.defaultValuesLicenseTerms());
-        uint256 defaultTermsId1 = pilTemplate.registerLicenseTerms(PILFlavors.defaultValuesLicenseTerms());
+        uint32 defaultTermsId = pilTemplate.registerLicenseTerms(PILFlavors.defaultValuesLicenseTerms());
+        uint32 defaultTermsId1 = pilTemplate.registerLicenseTerms(PILFlavors.defaultValuesLicenseTerms());
         assertEq(defaultTermsId, defaultTermsId1);
     }
 
@@ -233,7 +233,7 @@ contract PILicenseTemplateTest is BaseTest {
 
     // get license terms ID by PILTerms struct
     function test_PILicenseTemplate_getLicenseTermsId() public {
-        uint256 commUseTermsId = pilTemplate.registerLicenseTerms(
+        uint32 commUseTermsId = pilTemplate.registerLicenseTerms(
             PILFlavors.commercialUse({
                 mintingFee: 100,
                 currencyToken: address(erc20),
@@ -253,7 +253,7 @@ contract PILicenseTemplateTest is BaseTest {
 
     // get license terms struct by ID
     function test_PILicenseTemplate_getLicenseTerms() public {
-        uint256 commUseTermsId = pilTemplate.registerLicenseTerms(
+        uint32 commUseTermsId = pilTemplate.registerLicenseTerms(
             PILFlavors.commercialUse({
                 mintingFee: 100,
                 currencyToken: address(erc20),
@@ -268,7 +268,7 @@ contract PILicenseTemplateTest is BaseTest {
 
     // test license terms exists
     function test_PILicenseTemplate_exists() public {
-        uint256 commUseTermsId = pilTemplate.registerLicenseTerms(
+        uint32 commUseTermsId = pilTemplate.registerLicenseTerms(
             PILFlavors.commercialUse({
                 mintingFee: 100,
                 currencyToken: address(erc20),
@@ -281,7 +281,7 @@ contract PILicenseTemplateTest is BaseTest {
 
     // test verifyMintLicenseToken
     function test_PILicenseTemplate_verifyMintLicenseToken() public {
-        uint256 commUseTermsId = pilTemplate.registerLicenseTerms(
+        uint32 commUseTermsId = pilTemplate.registerLicenseTerms(
             PILFlavors.commercialUse({
                 mintingFee: 100,
                 currencyToken: address(erc20),
@@ -293,7 +293,7 @@ contract PILicenseTemplateTest is BaseTest {
     }
 
     function test_PILicenseTemplate_verifyMintLicenseToken_FromDerivativeIp_ButNotAttachedLicense() public {
-        uint256 commUseTermsId = pilTemplate.registerLicenseTerms(
+        uint32 commUseTermsId = pilTemplate.registerLicenseTerms(
             PILFlavors.commercialUse({
                 mintingFee: 0,
                 currencyToken: address(erc20),
@@ -305,19 +305,19 @@ contract PILicenseTemplateTest is BaseTest {
 
         address[] memory parentIpIds = new address[](1);
         parentIpIds[0] = ipAcct[1];
-        uint256[] memory licenseTermsIds = new uint256[](1);
+        uint32[] memory licenseTermsIds = new uint32[](1);
         licenseTermsIds[0] = commUseTermsId;
         vm.prank(ipOwner[2]);
         licensingModule.registerDerivative(ipAcct[2], parentIpIds, licenseTermsIds, address(pilTemplate), "");
 
-        uint256 anotherTermsId = pilTemplate.registerLicenseTerms(PILFlavors.nonCommercialSocialRemixing());
+        uint32 anotherTermsId = pilTemplate.registerLicenseTerms(PILFlavors.nonCommercialSocialRemixing());
 
         bool result = pilTemplate.verifyMintLicenseToken(anotherTermsId, ipOwner[3], ipAcct[2], 1);
         assertFalse(result);
     }
 
     function test_PILicenseTemplate_verifyMintLicenseToken_FromDerivativeIp_NotReciprocal() public {
-        uint256 commUseTermsId = pilTemplate.registerLicenseTerms(
+        uint32 commUseTermsId = pilTemplate.registerLicenseTerms(
             PILFlavors.commercialUse({
                 mintingFee: 0,
                 currencyToken: address(erc20),
@@ -329,7 +329,7 @@ contract PILicenseTemplateTest is BaseTest {
 
         address[] memory parentIpIds = new address[](1);
         parentIpIds[0] = ipAcct[1];
-        uint256[] memory licenseTermsIds = new uint256[](1);
+        uint32[] memory licenseTermsIds = new uint32[](1);
         licenseTermsIds[0] = commUseTermsId;
         vm.prank(ipOwner[2]);
         licensingModule.registerDerivative(ipAcct[2], parentIpIds, licenseTermsIds, address(pilTemplate), "");
@@ -340,7 +340,7 @@ contract PILicenseTemplateTest is BaseTest {
 
     // test verifyRegisterDerivative
     function test_PILicenseTemplate_verifyRegisterDerivative() public {
-        uint256 commUseTermsId = pilTemplate.registerLicenseTerms(
+        uint32 commUseTermsId = pilTemplate.registerLicenseTerms(
             PILFlavors.commercialUse({
                 mintingFee: 100,
                 currencyToken: address(erc20),
@@ -355,7 +355,7 @@ contract PILicenseTemplateTest is BaseTest {
     function test_PILicenseTemplate_verifyRegisterDerivative_WithApproval() public {
         PILTerms memory terms = PILFlavors.nonCommercialSocialRemixing();
         terms.derivativesApproval = true;
-        uint256 socialRemixTermsId = pilTemplate.registerLicenseTerms(terms);
+        uint32 socialRemixTermsId = pilTemplate.registerLicenseTerms(terms);
         vm.prank(ipAcct[1]);
         pilTemplate.setApproval(ipAcct[1], socialRemixTermsId, ipAcct[2], true);
         assertTrue(pilTemplate.isDerivativeApproved(ipAcct[1], socialRemixTermsId, ipAcct[2]));
@@ -367,7 +367,7 @@ contract PILicenseTemplateTest is BaseTest {
     function test_PILicenseTemplate_verifyRegisterDerivative_WithoutApproval() public {
         PILTerms memory terms = PILFlavors.nonCommercialSocialRemixing();
         terms.derivativesApproval = true;
-        uint256 socialRemixTermsId = pilTemplate.registerLicenseTerms(terms);
+        uint32 socialRemixTermsId = pilTemplate.registerLicenseTerms(terms);
         vm.prank(ipAcct[1]);
         pilTemplate.setApproval(ipAcct[1], socialRemixTermsId, ipAcct[2], false);
         assertFalse(pilTemplate.isDerivativeApproved(ipAcct[1], socialRemixTermsId, ipAcct[2]));
@@ -378,21 +378,21 @@ contract PILicenseTemplateTest is BaseTest {
 
     function test_PILicenseTemplate_verifyRegisterDerivative_derivativeNotAllowed() public {
         PILTerms memory terms = PILFlavors.defaultValuesLicenseTerms();
-        uint256 socialRemixTermsId = pilTemplate.registerLicenseTerms(terms);
+        uint32 socialRemixTermsId = pilTemplate.registerLicenseTerms(terms);
         bool result = pilTemplate.verifyRegisterDerivative(ipAcct[2], ipAcct[1], socialRemixTermsId, ipOwner[2]);
         assertFalse(result);
     }
 
     // test verifyCompatibleLicenses
     function test_PILicenseTemplate_verifyCompatibleLicenses() public {
-        uint256 commUseTermsId = pilTemplate.registerLicenseTerms(
+        uint32 commUseTermsId = pilTemplate.registerLicenseTerms(
             PILFlavors.commercialUse({
                 mintingFee: 100,
                 currencyToken: address(erc20),
                 royaltyPolicy: address(royaltyPolicyLAP)
             })
         );
-        uint256 commRemixTermsId = pilTemplate.registerLicenseTerms(
+        uint32 commRemixTermsId = pilTemplate.registerLicenseTerms(
             PILFlavors.commercialRemix({
                 mintingFee: 100,
                 commercialRevShare: 10,
@@ -400,13 +400,13 @@ contract PILicenseTemplateTest is BaseTest {
                 currencyToken: address(erc20)
             })
         );
-        uint256[] memory licenseTermsIds = new uint256[](2);
+        uint32[] memory licenseTermsIds = new uint32[](2);
         licenseTermsIds[0] = commUseTermsId;
         licenseTermsIds[1] = commRemixTermsId;
         assertFalse(pilTemplate.verifyCompatibleLicenses(licenseTermsIds));
 
-        uint256 defaultTermsId = pilTemplate.registerLicenseTerms(PILFlavors.defaultValuesLicenseTerms());
-        uint256 socialRemixTermsId = pilTemplate.registerLicenseTerms(PILFlavors.nonCommercialSocialRemixing());
+        uint32 defaultTermsId = pilTemplate.registerLicenseTerms(PILFlavors.defaultValuesLicenseTerms());
+        uint32 socialRemixTermsId = pilTemplate.registerLicenseTerms(PILFlavors.nonCommercialSocialRemixing());
         licenseTermsIds[0] = defaultTermsId;
         licenseTermsIds[1] = socialRemixTermsId;
         assertFalse(pilTemplate.verifyCompatibleLicenses(licenseTermsIds));
@@ -422,14 +422,14 @@ contract PILicenseTemplateTest is BaseTest {
 
     // test verifyRegisterDerivativeForAllParents
     function test_PILicenseTemplate_verifyRegisterDerivativeForAllParents() public {
-        uint256 commUseTermsId = pilTemplate.registerLicenseTerms(
+        uint32 commUseTermsId = pilTemplate.registerLicenseTerms(
             PILFlavors.commercialUse({
                 mintingFee: 100,
                 currencyToken: address(erc20),
                 royaltyPolicy: address(royaltyPolicyLAP)
             })
         );
-        uint256 commRemixTermsId = pilTemplate.registerLicenseTerms(
+        uint32 commRemixTermsId = pilTemplate.registerLicenseTerms(
             PILFlavors.commercialRemix({
                 mintingFee: 100,
                 commercialRevShare: 10,
@@ -437,7 +437,7 @@ contract PILicenseTemplateTest is BaseTest {
                 currencyToken: address(erc20)
             })
         );
-        uint256[] memory licenseTermsIds = new uint256[](2);
+        uint32[] memory licenseTermsIds = new uint32[](2);
         licenseTermsIds[0] = commUseTermsId;
         licenseTermsIds[1] = commRemixTermsId;
         address[] memory parentIpIds = new address[](2);
@@ -447,8 +447,8 @@ contract PILicenseTemplateTest is BaseTest {
             pilTemplate.verifyRegisterDerivativeForAllParents(ipAcct[2], parentIpIds, licenseTermsIds, ipOwner[2])
         );
 
-        uint256 defaultTermsId = pilTemplate.registerLicenseTerms(PILFlavors.defaultValuesLicenseTerms());
-        uint256 socialRemixTermsId = pilTemplate.registerLicenseTerms(PILFlavors.nonCommercialSocialRemixing());
+        uint32 defaultTermsId = pilTemplate.registerLicenseTerms(PILFlavors.defaultValuesLicenseTerms());
+        uint32 socialRemixTermsId = pilTemplate.registerLicenseTerms(PILFlavors.nonCommercialSocialRemixing());
         licenseTermsIds[0] = defaultTermsId;
         licenseTermsIds[1] = socialRemixTermsId;
         assertFalse(
@@ -470,13 +470,13 @@ contract PILicenseTemplateTest is BaseTest {
 
     // test isLicenseTransferable
     function test_PILicenseTemplate_isLicenseTransferable() public {
-        uint256 defaultTermsId = pilTemplate.registerLicenseTerms(PILFlavors.defaultValuesLicenseTerms());
+        uint32 defaultTermsId = pilTemplate.registerLicenseTerms(PILFlavors.defaultValuesLicenseTerms());
         assertTrue(pilTemplate.isLicenseTransferable(defaultTermsId));
 
-        uint256 socialRemixTermsId = pilTemplate.registerLicenseTerms(PILFlavors.nonCommercialSocialRemixing());
+        uint32 socialRemixTermsId = pilTemplate.registerLicenseTerms(PILFlavors.nonCommercialSocialRemixing());
         assertTrue(pilTemplate.isLicenseTransferable(socialRemixTermsId));
 
-        uint256 commUseTermsId = pilTemplate.registerLicenseTerms(
+        uint32 commUseTermsId = pilTemplate.registerLicenseTerms(
             PILFlavors.commercialUse({
                 mintingFee: 100,
                 currencyToken: address(erc20),
@@ -485,7 +485,7 @@ contract PILicenseTemplateTest is BaseTest {
         );
         assertTrue(pilTemplate.isLicenseTransferable(commUseTermsId));
 
-        uint256 commRemixTermsId = pilTemplate.registerLicenseTerms(
+        uint32 commRemixTermsId = pilTemplate.registerLicenseTerms(
             PILFlavors.commercialRemix({
                 mintingFee: 100,
                 commercialRevShare: 10,
@@ -497,7 +497,7 @@ contract PILicenseTemplateTest is BaseTest {
 
         PILTerms memory terms = pilTemplate.getLicenseTerms(commRemixTermsId);
         terms.transferable = false;
-        uint256 nonTransferableTermsId = pilTemplate.registerLicenseTerms(terms);
+        uint32 nonTransferableTermsId = pilTemplate.registerLicenseTerms(terms);
         assertFalse(pilTemplate.isLicenseTransferable(nonTransferableTermsId));
     }
 
@@ -508,7 +508,7 @@ contract PILicenseTemplateTest is BaseTest {
             royaltyPolicy: address(royaltyPolicyLAP)
         });
         terms.uri = "license.url";
-        uint256 termsId = pilTemplate.registerLicenseTerms(terms);
+        uint32 termsId = pilTemplate.registerLicenseTerms(terms);
         assertEq(pilTemplate.getLicenseTermsURI(termsId), "license.url");
     }
 
@@ -519,7 +519,7 @@ contract PILicenseTemplateTest is BaseTest {
             royaltyPolicy: address(royaltyPolicyLAP)
         });
         terms.uri = "license.url";
-        uint256 termsId = pilTemplate.registerLicenseTerms(terms);
+        uint32 termsId = pilTemplate.registerLicenseTerms(terms);
         assertEq(pilTemplate.getLicenseTermsURI(termsId), "license.url");
 
         PILTerms memory terms1 = PILFlavors.commercialUse({
@@ -528,7 +528,7 @@ contract PILicenseTemplateTest is BaseTest {
             royaltyPolicy: address(royaltyPolicyLAP)
         });
         terms1.uri = "another.license.url";
-        uint256 termsId1 = pilTemplate.registerLicenseTerms(terms1);
+        uint32 termsId1 = pilTemplate.registerLicenseTerms(terms1);
 
         assertEq(pilTemplate.getLicenseTermsURI(termsId1), "another.license.url");
         assertEq(pilTemplate.getLicenseTermsURI(termsId), "license.url");
@@ -537,7 +537,7 @@ contract PILicenseTemplateTest is BaseTest {
     }
 
     function test_PILicenseTemplate_getEarlierExpiredTime_WithEmptyLicenseTerms() public {
-        uint256[] memory licenseTermsIds = new uint256[](0);
+        uint32[] memory licenseTermsIds = new uint32[](0);
         assertEq(pilTemplate.getEarlierExpireTime(licenseTermsIds, block.timestamp), 0);
     }
 

--- a/test/foundry/registries/LicenseRegistry.t.sol
+++ b/test/foundry/registries/LicenseRegistry.t.sol
@@ -58,10 +58,10 @@ contract LicenseRegistryTest is BaseTest {
     }
 
     function test_LicenseRegistry_setDefaultLicenseTerms() public {
-        uint256 socialRemixTermsId = pilTemplate.registerLicenseTerms(PILFlavors.nonCommercialSocialRemixing());
+        uint32 socialRemixTermsId = pilTemplate.registerLicenseTerms(PILFlavors.nonCommercialSocialRemixing());
         vm.prank(admin);
         licenseRegistry.setDefaultLicenseTerms(address(pilTemplate), socialRemixTermsId);
-        (address defaultLicenseTemplate, uint256 defaultLicenseTermsId) = licenseRegistry.getDefaultLicenseTerms();
+        (address defaultLicenseTemplate, uint32 defaultLicenseTermsId) = licenseRegistry.getDefaultLicenseTerms();
         assertEq(defaultLicenseTemplate, address(pilTemplate));
         assertEq(defaultLicenseTermsId, socialRemixTermsId);
     }
@@ -91,7 +91,7 @@ contract LicenseRegistryTest is BaseTest {
     }
 
     function test_LicenseRegistry_setLicensingConfigForLicense() public {
-        uint256 defaultTermsId = pilTemplate.registerLicenseTerms(PILFlavors.defaultValuesLicenseTerms());
+        uint32 defaultTermsId = pilTemplate.registerLicenseTerms(PILFlavors.defaultValuesLicenseTerms());
         Licensing.LicensingConfig memory mintingLicenseConfig = Licensing.LicensingConfig({
             isSet: true,
             mintingFee: 100,
@@ -118,7 +118,7 @@ contract LicenseRegistryTest is BaseTest {
 
     function test_LicenseRegistry_setLicensingConfigForLicense_revert_UnregisteredTemplate() public {
         MockLicenseTemplate pilTemplate2 = new MockLicenseTemplate();
-        uint256 termsId = pilTemplate2.registerLicenseTerms();
+        uint32 termsId = pilTemplate2.registerLicenseTerms();
         Licensing.LicensingConfig memory mintingLicenseConfig = Licensing.LicensingConfig({
             isSet: true,
             mintingFee: 100,
@@ -134,7 +134,7 @@ contract LicenseRegistryTest is BaseTest {
     }
 
     function test_LicenseRegistry_setLicensingConfigForIp() public {
-        uint256 defaultTermsId = pilTemplate.registerLicenseTerms(PILFlavors.defaultValuesLicenseTerms());
+        uint32 defaultTermsId = pilTemplate.registerLicenseTerms(PILFlavors.defaultValuesLicenseTerms());
         Licensing.LicensingConfig memory mintingLicenseConfig = Licensing.LicensingConfig({
             isSet: true,
             mintingFee: 100,
@@ -157,30 +157,30 @@ contract LicenseRegistryTest is BaseTest {
 
     // test attachLicenseTermsToIp
     function test_LicenseRegistry_attachLicenseTermsToIp_revert_CannotAttachToDerivativeIP() public {
-        uint256 socialRemixTermsId = pilTemplate.registerLicenseTerms(PILFlavors.nonCommercialSocialRemixing());
+        uint32 socialRemixTermsId = pilTemplate.registerLicenseTerms(PILFlavors.nonCommercialSocialRemixing());
         vm.prank(admin);
         licenseRegistry.setDefaultLicenseTerms(address(pilTemplate), socialRemixTermsId);
 
         address[] memory parentIpIds = new address[](1);
         parentIpIds[0] = ipAcct[1];
-        uint256[] memory licenseTermsIds = new uint256[](1);
+        uint32[] memory licenseTermsIds = new uint32[](1);
         licenseTermsIds[0] = socialRemixTermsId;
         vm.prank(ipOwner[2]);
         licensingModule.registerDerivative(ipAcct[2], parentIpIds, licenseTermsIds, address(pilTemplate), "");
 
-        uint256 defaultTermsId = pilTemplate.registerLicenseTerms(PILFlavors.defaultValuesLicenseTerms());
+        uint32 defaultTermsId = pilTemplate.registerLicenseTerms(PILFlavors.defaultValuesLicenseTerms());
         vm.expectRevert(Errors.LicensingModule__DerivativesCannotAddLicenseTerms.selector);
         vm.prank(address(licensingModule));
         licenseRegistry.attachLicenseTermsToIp(ipAcct[2], address(pilTemplate), defaultTermsId);
     }
 
     function test_LicenseRegistry_registerDerivativeIp_revert_parentsArrayEmpty() public {
-        uint256 socialRemixTermsId = pilTemplate.registerLicenseTerms(PILFlavors.nonCommercialSocialRemixing());
+        uint32 socialRemixTermsId = pilTemplate.registerLicenseTerms(PILFlavors.nonCommercialSocialRemixing());
         vm.prank(admin);
         licenseRegistry.setDefaultLicenseTerms(address(pilTemplate), socialRemixTermsId);
 
         address[] memory parentIpIds = new address[](0);
-        uint256[] memory licenseTermsIds = new uint256[](1);
+        uint32[] memory licenseTermsIds = new uint32[](1);
         licenseTermsIds[0] = socialRemixTermsId;
         vm.expectRevert(Errors.LicenseRegistry__NoParentIp.selector);
         vm.prank(address(licensingModule));
@@ -189,7 +189,7 @@ contract LicenseRegistryTest is BaseTest {
 
     // test getAttachedLicenseTerms
     function test_LicenseRegistry_getAttachedLicenseTerms_revert_OutOfIndex() public {
-        uint256 socialRemixTermsId = pilTemplate.registerLicenseTerms(PILFlavors.nonCommercialSocialRemixing());
+        uint32 socialRemixTermsId = pilTemplate.registerLicenseTerms(PILFlavors.nonCommercialSocialRemixing());
 
         vm.prank(ipOwner[1]);
         licensingModule.attachLicenseTerms(ipAcct[1], address(pilTemplate), socialRemixTermsId);
@@ -199,13 +199,13 @@ contract LicenseRegistryTest is BaseTest {
 
     // test getDerivativeIp revert IndexOutOfBounds(
     function test_LicenseRegistry_getDerivativeIp_revert_IndexOutOfBounds() public {
-        uint256 socialRemixTermsId = pilTemplate.registerLicenseTerms(PILFlavors.nonCommercialSocialRemixing());
+        uint32 socialRemixTermsId = pilTemplate.registerLicenseTerms(PILFlavors.nonCommercialSocialRemixing());
         vm.prank(admin);
         licenseRegistry.setDefaultLicenseTerms(address(pilTemplate), socialRemixTermsId);
 
         address[] memory parentIpIds = new address[](1);
         parentIpIds[0] = ipAcct[1];
-        uint256[] memory licenseTermsIds = new uint256[](1);
+        uint32[] memory licenseTermsIds = new uint32[](1);
         licenseTermsIds[0] = socialRemixTermsId;
         vm.prank(ipOwner[2]);
         licensingModule.registerDerivative(ipAcct[2], parentIpIds, licenseTermsIds, address(pilTemplate), "");
@@ -215,13 +215,13 @@ contract LicenseRegistryTest is BaseTest {
     }
 
     function test_LicenseRegistry_getParentIp_revert_IndexOutOfBounds() public {
-        uint256 socialRemixTermsId = pilTemplate.registerLicenseTerms(PILFlavors.nonCommercialSocialRemixing());
+        uint32 socialRemixTermsId = pilTemplate.registerLicenseTerms(PILFlavors.nonCommercialSocialRemixing());
         vm.prank(admin);
         licenseRegistry.setDefaultLicenseTerms(address(pilTemplate), socialRemixTermsId);
 
         address[] memory parentIpIds = new address[](1);
         parentIpIds[0] = ipAcct[1];
-        uint256[] memory licenseTermsIds = new uint256[](1);
+        uint32[] memory licenseTermsIds = new uint32[](1);
         licenseTermsIds[0] = socialRemixTermsId;
         vm.prank(ipOwner[2]);
         licensingModule.registerDerivative(ipAcct[2], parentIpIds, licenseTermsIds, address(pilTemplate), "");
@@ -231,7 +231,7 @@ contract LicenseRegistryTest is BaseTest {
     }
 
     function test_LicenseRegistry_registerDerivativeIp() public {
-        uint256 socialRemixTermsId = pilTemplate.registerLicenseTerms(PILFlavors.nonCommercialSocialRemixing());
+        uint32 socialRemixTermsId = pilTemplate.registerLicenseTerms(PILFlavors.nonCommercialSocialRemixing());
         vm.prank(ipOwner[1]);
         licensingModule.attachLicenseTerms(ipAcct[1], address(pilTemplate), socialRemixTermsId);
         vm.prank(ipOwner[2]);
@@ -240,7 +240,7 @@ contract LicenseRegistryTest is BaseTest {
         address[] memory parentIpIds = new address[](2);
         parentIpIds[0] = ipAcct[1];
         parentIpIds[1] = ipAcct[2];
-        uint256[] memory licenseTermsIds = new uint256[](2);
+        uint32[] memory licenseTermsIds = new uint32[](2);
         licenseTermsIds[0] = socialRemixTermsId;
         licenseTermsIds[1] = socialRemixTermsId;
         vm.prank(address(licensingModule));
@@ -248,14 +248,14 @@ contract LicenseRegistryTest is BaseTest {
     }
 
     function test_LicenseRegistry_registerDerivativeIp_revert_DuplicateLicense() public {
-        uint256 socialRemixTermsId = pilTemplate.registerLicenseTerms(PILFlavors.nonCommercialSocialRemixing());
+        uint32 socialRemixTermsId = pilTemplate.registerLicenseTerms(PILFlavors.nonCommercialSocialRemixing());
         vm.prank(ipOwner[1]);
         licensingModule.attachLicenseTerms(ipAcct[1], address(pilTemplate), socialRemixTermsId);
 
         address[] memory parentIpIds = new address[](2);
         parentIpIds[0] = ipAcct[1];
         parentIpIds[1] = ipAcct[1];
-        uint256[] memory licenseTermsIds = new uint256[](2);
+        uint32[] memory licenseTermsIds = new uint32[](2);
         licenseTermsIds[0] = socialRemixTermsId;
         licenseTermsIds[1] = socialRemixTermsId;
         vm.expectRevert(
@@ -306,18 +306,18 @@ contract LicenseRegistryTest is BaseTest {
         licenseRegistry.setExpireTime(ipAcct[1], block.timestamp + 100);
         PILTerms memory terms1 = PILFlavors.nonCommercialSocialRemixing();
         terms1.expiration = 200;
-        uint256 termsId1 = pilTemplate.registerLicenseTerms(terms1);
+        uint32 termsId1 = pilTemplate.registerLicenseTerms(terms1);
         vm.prank(ipOwner[1]);
         licensingModule.attachLicenseTerms(ipAcct[1], address(pilTemplate), termsId1);
 
         PILTerms memory terms2 = PILFlavors.nonCommercialSocialRemixing();
         terms2.expiration = 400;
-        uint256 termsId2 = pilTemplate.registerLicenseTerms(terms2);
+        uint32 termsId2 = pilTemplate.registerLicenseTerms(terms2);
         vm.prank(ipOwner[2]);
         licensingModule.attachLicenseTerms(ipAcct[2], address(pilTemplate), termsId2);
 
         address[] memory parentIpIds = new address[](2);
-        uint256[] memory licenseTermsIds = new uint256[](2);
+        uint32[] memory licenseTermsIds = new uint32[](2);
         parentIpIds[0] = ipAcct[1];
         parentIpIds[1] = ipAcct[2];
         licenseTermsIds[0] = termsId1;
@@ -330,10 +330,10 @@ contract LicenseRegistryTest is BaseTest {
         assertEq(licenseRegistry.getExpireTime(ipAcct[3]), block.timestamp + 100, "ipAcct[3] expire time is incorrect");
         assertEq(licenseRegistry.getParentIp(ipAcct[3], 0), ipAcct[1]);
         assertEq(licenseRegistry.getParentIp(ipAcct[3], 1), ipAcct[2]);
-        (address attachedTemplate1, uint256 attachedTermsId1) = licenseRegistry.getAttachedLicenseTerms(ipAcct[3], 0);
+        (address attachedTemplate1, uint32 attachedTermsId1) = licenseRegistry.getAttachedLicenseTerms(ipAcct[3], 0);
         assertEq(attachedTemplate1, address(pilTemplate));
         assertEq(attachedTermsId1, termsId1);
-        (address attachedTemplate2, uint256 attachedTermsId2) = licenseRegistry.getAttachedLicenseTerms(ipAcct[3], 1);
+        (address attachedTemplate2, uint32 attachedTermsId2) = licenseRegistry.getAttachedLicenseTerms(ipAcct[3], 1);
         assertEq(attachedTemplate2, address(pilTemplate));
         assertEq(attachedTermsId2, termsId2);
     }
@@ -343,18 +343,18 @@ contract LicenseRegistryTest is BaseTest {
         licenseRegistry.setExpireTime(ipAcct[1], block.timestamp + 500);
         PILTerms memory terms1 = PILFlavors.nonCommercialSocialRemixing();
         terms1.expiration = 0;
-        uint256 termsId1 = pilTemplate.registerLicenseTerms(terms1);
+        uint32 termsId1 = pilTemplate.registerLicenseTerms(terms1);
         vm.prank(ipOwner[1]);
         licensingModule.attachLicenseTerms(ipAcct[1], address(pilTemplate), termsId1);
 
         PILTerms memory terms2 = PILFlavors.nonCommercialSocialRemixing();
         terms2.expiration = 400;
-        uint256 termsId2 = pilTemplate.registerLicenseTerms(terms2);
+        uint32 termsId2 = pilTemplate.registerLicenseTerms(terms2);
         vm.prank(ipOwner[2]);
         licensingModule.attachLicenseTerms(ipAcct[2], address(pilTemplate), termsId2);
 
         address[] memory parentIpIds = new address[](2);
-        uint256[] memory licenseTermsIds = new uint256[](2);
+        uint32[] memory licenseTermsIds = new uint32[](2);
         parentIpIds[0] = ipAcct[1];
         parentIpIds[1] = ipAcct[2];
         licenseTermsIds[0] = termsId1;
@@ -367,10 +367,10 @@ contract LicenseRegistryTest is BaseTest {
         assertEq(licenseRegistry.getExpireTime(ipAcct[3]), block.timestamp + 400, "ipAcct[3] expire time is incorrect");
         assertEq(licenseRegistry.getParentIp(ipAcct[3], 0), ipAcct[1]);
         assertEq(licenseRegistry.getParentIp(ipAcct[3], 1), ipAcct[2]);
-        (address attachedTemplate1, uint256 attachedTermsId1) = licenseRegistry.getAttachedLicenseTerms(ipAcct[3], 0);
+        (address attachedTemplate1, uint32 attachedTermsId1) = licenseRegistry.getAttachedLicenseTerms(ipAcct[3], 0);
         assertEq(attachedTemplate1, address(pilTemplate));
         assertEq(attachedTermsId1, termsId1);
-        (address attachedTemplate2, uint256 attachedTermsId2) = licenseRegistry.getAttachedLicenseTerms(ipAcct[3], 1);
+        (address attachedTemplate2, uint32 attachedTermsId2) = licenseRegistry.getAttachedLicenseTerms(ipAcct[3], 1);
         assertEq(attachedTemplate2, address(pilTemplate));
         assertEq(attachedTermsId2, termsId2);
     }

--- a/test/foundry/utils/LicensingHelper.t.sol
+++ b/test/foundry/utils/LicensingHelper.t.sol
@@ -16,7 +16,7 @@ contract LicensingHelper {
     IERC20 private erc20; // keep private to avoid collision with `BaseIntegration`
 
     mapping(string selectionName => PILTerms) internal selectedPILicenseTerms;
-    mapping(string selectionName => uint256 licenseTermsId) internal selectedPILicenseTermsId;
+    mapping(string selectionName => uint32 licenseTermsId) internal selectedPILicenseTermsId;
 
     string[] internal emptyStringArray = new string[](0);
 
@@ -29,7 +29,7 @@ contract LicensingHelper {
     function registerSelectedPILicenseTerms(
         string memory selectionName,
         PILTerms memory selectedPILicenseTerms_
-    ) public returns (uint256 pilSelectedLicenseTermsId) {
+    ) public returns (uint32 pilSelectedLicenseTermsId) {
         string memory _selectionName = string(abi.encodePacked("PIL_", selectionName));
         pilSelectedLicenseTermsId = pilTemplate.registerLicenseTerms(selectedPILicenseTerms_);
         // pilSelectedLicenseTermsId = pilTemplate.getLicenseTermsId(selectedPILicenseTerms_);
@@ -45,7 +45,7 @@ contract LicensingHelper {
         bool reciprocal,
         uint32 commercialRevShare,
         uint256 mintingFee
-    ) public returns (uint256 pilSelectedLicenseTermsId) {
+    ) public returns (uint32 pilSelectedLicenseTermsId) {
         pilSelectedLicenseTermsId = registerSelectedPILicenseTerms(
             selectionName,
             mapSelectedPILicenseTerms_Commercial(transferable, derivatives, reciprocal, commercialRevShare, mintingFee)
@@ -57,7 +57,7 @@ contract LicensingHelper {
         bool transferable,
         bool derivatives,
         bool reciprocal
-    ) public returns (uint256 pilSelectedLicenseTermsId) {
+    ) public returns (uint32 pilSelectedLicenseTermsId) {
         pilSelectedLicenseTermsId = registerSelectedPILicenseTerms(
             selectionName,
             mapSelectedPILicenseTerms_NonCommercial(transferable, derivatives, reciprocal)
@@ -66,7 +66,7 @@ contract LicensingHelper {
 
     function registerSelectedPILicenseTerms_NonCommercialSocialRemixing()
         public
-        returns (uint256 pilSelectedLicenseTermsId)
+        returns (uint32 pilSelectedLicenseTermsId)
     {
         pilSelectedLicenseTermsId = registerSelectedPILicenseTerms(
             "nc_social_remix",
@@ -135,7 +135,7 @@ contract LicensingHelper {
         return selectedPILicenseTerms[selectionName];
     }
 
-    function getSelectedPILicenseTermsId(string memory selectionName) internal view returns (uint256) {
+    function getSelectedPILicenseTermsId(string memory selectionName) internal view returns (uint32) {
         string memory _selectionName = string(abi.encodePacked("PIL_", selectionName));
         return selectedPILicenseTermsId[selectionName];
     }


### PR DESCRIPTION
## Description
Optimizes LicenseTokenMetadata struct to use 2 less storage slots (4 -> 2).

Original (4 slots):
```solidity
struct LicenseTokenMetadata {
    address licensorIpId;
    address licenseTemplate;
    uint256 licenseTermsId;
    bool transferable;
}
```

New (2 slots):
```solidity
struct LicenseTokenMetadata {
    address licensorIpId;
    uint32 licenseTermsId;
    bool transferable;
    address licenseTemplate;
}
```

## Related Issue

Closes https://github.com/storyprotocol/protocol-core-v1/issues/93

## Notes

- EnumerableSet only supports uint256 for Uint, so while licenseTermsId is uint32, attachedLicenseTerms is uint256. This requires casting between the two.
- If there’s 100k License Tokens minted, we’re saving 200k SSTORE, or 22,100 * 200k = ~4.5 billion gas units. 
  - 22,100 gas for a cold access SSTORE (see [here](https://hackmd.io/@fvictorio/gas-costs-after-berlin#Putting-it-all-together))
  - 4.5 billion * 20 gwei = 90 ETH -> $270k on gas saved for 100k LTs minted