### PR TITLE
 isAllProtocolPaused returns true even when there are not pausables configured

### DIFF
--- a/contracts/pause/ProtocolPauseAdmin.sol
+++ b/contracts/pause/ProtocolPauseAdmin.sol
@@ -74,6 +74,9 @@ contract ProtocolPauseAdmin is IProtocolPauseAdmin, AccessManaged {
     /// @notice Checks if all pausable contracts are paused.
     function isAllProtocolPaused() external view returns (bool) {
         uint256 length = _pausables.length();
+        if (length == 0) {
+            return false;
+        }
         for (uint256 i = 0; i < length; i++) {
             if (!ProtocolPausableUpgradeable(_pausables.at(i)).paused()) {
                 return false;

--- a/test/foundry/pause/ProtocolPauseAdmin.t.sol
+++ b/test/foundry/pause/ProtocolPauseAdmin.t.sol
@@ -116,4 +116,16 @@ contract ProtocolPauseAdminTest is BaseTest {
         protocolPauser.unpause();
         assertFalse(protocolPauser.isAllProtocolPaused());
     }
+
+    function test_ProtocolPauseAdmin_notPaused_ifNoPausables() public {
+        vm.startPrank(u.admin);
+        protocolPauser.removePausable(address(accessController));
+        protocolPauser.removePausable(address(disputeModule));
+        protocolPauser.removePausable(address(licensingModule));
+        protocolPauser.removePausable(address(royaltyModule));
+        protocolPauser.removePausable(address(royaltyPolicyLAP));
+        protocolPauser.removePausable(address(ipAssetRegistry));
+        vm.stopPrank();
+        assertFalse(protocolPauser.isAllProtocolPaused());
+    }
 }


### PR DESCRIPTION
## Description
Return false in `ProtocolPauseAdmin.isAllProtocolPaused()` when there is no pausable contracts added.

## Test Plan 
```test_ProtocolPauseAdmin_notPaused_ifNoPausables```
