### PR TITLE
Prevent Recursive Derivatives in IP Registration

### DIFF
--- a/contracts/lib/Errors.sol
+++ b/contracts/lib/Errors.sol
@@ -131,6 +131,9 @@ library Errors {
     /// @notice Provided derivative IP already has license terms attached.
     error LicenseRegistry__DerivativeIpAlreadyHasLicense(address childIpId);
 
+    /// @notice Provided derivative IP has already had child IP.
+    error LicenseRegistry__DerivativeIpAlreadyHasChild(address childIpId);
+
     /// @notice Provided derivative IP is already registered.
     error LicenseRegistry__DerivativeAlreadyRegistered(address childIpId);
 

--- a/contracts/registries/LicenseRegistry.sol
+++ b/contracts/registries/LicenseRegistry.sol
@@ -216,6 +216,9 @@ contract LicenseRegistry is ILicenseRegistry, AccessManagedUpgradeable, UUPSUpgr
         if ($.parentIps[childIpId].length() > 0) {
             revert Errors.LicenseRegistry__DerivativeAlreadyRegistered(childIpId);
         }
+        if ($.childIps[childIpId].length() > 0) {
+            revert Errors.LicenseRegistry__DerivativeIpAlreadyHasChild(childIpId);
+        }
         if ($.attachedLicenseTerms[childIpId].length() > 0) {
             revert Errors.LicenseRegistry__DerivativeIpAlreadyHasLicense(childIpId);
         }

--- a/test/foundry/modules/licensing/LicensingModule.t.sol
+++ b/test/foundry/modules/licensing/LicensingModule.t.sol
@@ -860,6 +860,43 @@ contract LicensingModuleTest is BaseTest {
         licensingModule.registerDerivativeWithLicenseTokens(ipId1, licenseTokens, "");
     }
 
+    function test_LicensingModule_registerDerivativeWithLicenseTokens_revert_DerivativeIpAlreadyHasChildIp() public {
+        uint256 termsId = pilTemplate.registerLicenseTerms(PILFlavors.nonCommercialSocialRemixing());
+        vm.prank(ipOwner1);
+        licensingModule.attachLicenseTerms(ipId1, address(pilTemplate), termsId);
+        vm.prank(ipOwner2);
+        licensingModule.attachLicenseTerms(ipId2, address(pilTemplate), termsId);
+
+        uint256 lcTokenId1 = licensingModule.mintLicenseTokens({
+            licensorIpId: ipId1,
+            licenseTemplate: address(pilTemplate),
+            licenseTermsId: termsId,
+            amount: 1,
+            receiver: ipOwner2,
+            royaltyContext: ""
+        });
+
+        uint256 lcTokenId2 = licensingModule.mintLicenseTokens({
+            licensorIpId: ipId2,
+            licenseTemplate: address(pilTemplate),
+            licenseTermsId: termsId,
+            amount: 1,
+            receiver: ipOwner3,
+            royaltyContext: ""
+        });
+
+        uint256[] memory licenseTokens = new uint256[](1);
+        licenseTokens[0] = lcTokenId2;
+        vm.prank(ipOwner3);
+        licensingModule.registerDerivativeWithLicenseTokens(ipId3, licenseTokens, "");
+
+        licenseTokens = new uint256[](1);
+        licenseTokens[0] = lcTokenId1;
+        vm.expectRevert(abi.encodeWithSelector(Errors.LicenseRegistry__DerivativeIpAlreadyHasChild.selector, ipId2));
+        vm.prank(ipOwner2);
+        licensingModule.registerDerivativeWithLicenseTokens(ipId2, licenseTokens, "");
+    }
+
     function test_LicensingModule_registerDerivativeWithLicenseTokens_revert_AlreadyRegisteredAsDerivative() public {
         uint256 termsId = pilTemplate.registerLicenseTerms(PILFlavors.nonCommercialSocialRemixing());
         vm.prank(ipOwner1);


### PR DESCRIPTION
## Description
This PR includes changes that enhance the `registerDerivativeIp` function in the `LicenseRegistry` contract. The function now checks whether the child IP already has a child IP before registering it as a derivative. This change is aimed at preventing recursive derivatives in our IP registration process.

## Changes:

1. Modified the `registerDerivativeIp` function to include a check for existing child IPs. If the child IP already has a child IP, the function will revert and prevent the registration.

2. Updated the unit tests to reflect these changes. 

## Test Plan 
Add unit tests to cover to new code changes

