### PR TITLE
v1.1 TRST-L-1 User can set undesired module as hook when contract is paused for maintenance

### DIFF
--- a/contracts/modules/licensing/LicensingModule.sol
+++ b/contracts/modules/licensing/LicensingModule.sol
@@ -368,7 +368,7 @@ contract LicensingModule is
         address licenseTemplate,
         uint256 licenseTermsId,
         Licensing.LicensingConfig memory licensingConfig
-    ) external verifyPermission(ipId) {
+    ) external verifyPermission(ipId) whenNotPaused {
         if (
             licensingConfig.licensingHook != address(0) &&
             (!licensingConfig.licensingHook.supportsInterface(type(ILicensingHook).interfaceId) ||


### PR DESCRIPTION
Added `whenNotPaused` modifier to `setLicensingConfig` method