### PR TITLE
Fix governance withdraw

### DIFF
--- a/contracts/interfaces/modules/dispute/policies/IArbitrationPolicy.sol
+++ b/contracts/interfaces/modules/dispute/policies/IArbitrationPolicy.sol
@@ -3,10 +3,6 @@ pragma solidity 0.8.23;
 
 /// @title Arbitration Policy Interface
 interface IArbitrationPolicy {
-    /// @notice Event emitted when governance withdraws
-    /// @param amount The amount withdrawn
-    event GovernanceWithdrew(uint256 amount);
-
     /// @notice Returns the protocol-wide dispute module address
     function DISPUTE_MODULE() external view returns (address);
 
@@ -15,6 +11,14 @@ interface IArbitrationPolicy {
 
     /// @notice Returns the arbitration price
     function ARBITRATION_PRICE() external view returns (uint256);
+
+    /// @notice Returns the treasury address
+    function treasury() external view returns (address);
+
+    /// @notice Allows governance set the treasury address
+    /// @dev Enforced to be only callable by the governance protocol admin
+    /// @param newTreasury The new address of the treasury
+    function setTreasury(address newTreasury) external;
 
     /// @notice Executes custom logic on raising dispute.
     /// @dev Enforced to be only callable by the DisputeModule.
@@ -42,8 +46,4 @@ interface IArbitrationPolicy {
     /// @param disputeId The dispute id
     /// @param data The arbitrary data used to resolve the dispute
     function onResolveDispute(address caller, uint256 disputeId, bytes calldata data) external;
-
-    /// @notice Allows governance address to withdraw
-    /// @dev Enforced to be only callable by the governance protocol admin.
-    function governanceWithdraw() external;
 }

--- a/contracts/lib/Errors.sol
+++ b/contracts/lib/Errors.sol
@@ -310,6 +310,9 @@ library Errors {
     /// @notice Zero address provided for Dispute Module.
     error ArbitrationPolicySP__ZeroDisputeModule();
 
+    /// @notice Zero address provided for Treasury.
+    error ArbitrationPolicySP__ZeroTreasury();
+
     /// @notice Zero address provided for Payment Token.
     error ArbitrationPolicySP__ZeroPaymentToken();
 

--- a/script/foundry/deployment/Main.s.sol
+++ b/script/foundry/deployment/Main.s.sol
@@ -13,6 +13,7 @@ contract Main is DeployHelper {
     uint256 internal CREATE3_DEFAULT_SEED = 0;
     // For arbitration policy
     uint256 internal constant ARBITRATION_PRICE = 1000 * 10 ** 6; // 1000 USDC
+    address internal constant TREASURY_ADDRESS = address(200);
     // For royalty policy
     uint256 internal constant MAX_ROYALTY_APPROVAL = 10000 ether;
 
@@ -22,7 +23,8 @@ contract Main is DeployHelper {
             CREATE3_DEPLOYER,
             address(0), // replaced with USDC in DeployHelper.sol
             ARBITRATION_PRICE,
-            MAX_ROYALTY_APPROVAL
+            MAX_ROYALTY_APPROVAL,
+            TREASURY_ADDRESS
         )
     {}
 

--- a/script/foundry/utils/DeployHelper.sol
+++ b/script/foundry/utils/DeployHelper.sol
@@ -107,6 +107,7 @@ contract DeployHelper is Script, BroadcastManager, JsonDeploymentHandler, Storag
     // keep private to avoid conflict with inheriting contracts
     uint256 private immutable ARBITRATION_PRICE;
     uint256 private immutable MAX_ROYALTY_APPROVAL;
+    address private immutable TREASURY_ADDRESS;
 
     // DeployHelper variable
     bool private writeDeploys;
@@ -116,13 +117,15 @@ contract DeployHelper is Script, BroadcastManager, JsonDeploymentHandler, Storag
         address create3Deployer_,
         address erc20_,
         uint256 arbitrationPrice_,
-        uint256 maxRoyaltyApproval_
+        uint256 maxRoyaltyApproval_,
+        address treasury_
     ) JsonDeploymentHandler("main") {
         erc6551Registry = ERC6551Registry(erc6551Registry_);
         create3Deployer = ICreate3Deployer(create3Deployer_);
         erc20 = ERC20(erc20_);
         ARBITRATION_PRICE = arbitrationPrice_;
         MAX_ROYALTY_APPROVAL = maxRoyaltyApproval_;
+        TREASURY_ADDRESS = treasury_;
 
         /// @dev USDC addresses are fetched from
         /// (mainnet) https://developers.circle.com/stablecoins/docs/usdc-on-main-networks
@@ -413,7 +416,7 @@ contract DeployHelper is Script, BroadcastManager, JsonDeploymentHandler, Storag
                 create3Deployer,
                 _getSalt(type(ArbitrationPolicySP).name),
                 impl,
-                abi.encodeCall(ArbitrationPolicySP.initialize, address(protocolAccessManager))
+                abi.encodeCall(ArbitrationPolicySP.initialize, (address(protocolAccessManager), TREASURY_ADDRESS))
             )
         );
         require(

--- a/script/foundry/utils/upgrades/ERC7201Helper.s.sol
+++ b/script/foundry/utils/upgrades/ERC7201Helper.s.sol
@@ -12,7 +12,7 @@ import { console2 } from "forge-std/console2.sol";
 contract ERC7201HelperScript is Script {
     
     string constant NAMESPACE = "story-protocol";
-    string constant CONTRACT_NAME = "AccessControllerV2";
+    string constant CONTRACT_NAME = "ArbitrationPolicySP";
 
     function run() external {
         bytes memory erc7201Key = abi.encodePacked(NAMESPACE, ".", CONTRACT_NAME);

--- a/test/foundry/modules/dispute/DisputeModule.t.sol
+++ b/test/foundry/modules/dispute/DisputeModule.t.sol
@@ -55,7 +55,7 @@ contract DisputeModuleTest is BaseTest {
         arbitrationPolicySP2 = ArbitrationPolicySP(
             TestProxyHelper.deployUUPSProxy(
                 impl,
-                abi.encodeCall(ArbitrationPolicySP.initialize, address(protocolAccessManager))
+                abi.encodeCall(ArbitrationPolicySP.initialize, (address(protocolAccessManager), TREASURY_ADDRESS))
             )
         );
 
@@ -424,7 +424,7 @@ contract DisputeModuleTest is BaseTest {
         uint256 arbitrationPolicySPUSDCBalanceAfter = USDC.balanceOf(address(arbitrationPolicySP));
 
         assertEq(ipAccount1USDCBalanceAfter - ipAccount1USDCBalanceBefore, 0);
-        assertEq(arbitrationPolicySPUSDCBalanceBefore - arbitrationPolicySPUSDCBalanceAfter, 0);
+        assertEq(arbitrationPolicySPUSDCBalanceBefore - arbitrationPolicySPUSDCBalanceAfter, ARBITRATION_PRICE);
         assertEq(currentTagBefore, bytes32("IN_DISPUTE"));
         assertEq(currentTagAfter, bytes32(0));
         assertFalse(disputeModule.isIpTagged(ipAddr));

--- a/test/foundry/utils/BaseTest.t.sol
+++ b/test/foundry/utils/BaseTest.t.sol
@@ -48,6 +48,7 @@ contract BaseTest is Test, DeployHelper, LicensingHelper {
 
     uint256 internal constant ARBITRATION_PRICE = 1000 * 10 ** 6; // 1000 MockToken (6 decimals)
     uint256 internal constant MAX_ROYALTY_APPROVAL = 10000 ether;
+    address internal constant TREASURY_ADDRESS = address(200);
 
     constructor()
         DeployHelper(
@@ -55,7 +56,8 @@ contract BaseTest is Test, DeployHelper, LicensingHelper {
             address(CREATE3_DEPLOYER),
             address(erc20),
             ARBITRATION_PRICE,
-            MAX_ROYALTY_APPROVAL
+            MAX_ROYALTY_APPROVAL,
+            TREASURY_ADDRESS
         )
     {}
 


### PR DESCRIPTION
## Description
Removes the `governanceWithdraw` function and replaces its functionality with a transfer directly to a treasury address whenever a dispute judgement tags an IP as infringing.
