### PR TITLE
Add Existence Check for `licenseTermsId` when verifyMintLicenseToken in PILicenseTemplate

### DIFF
--- a/contracts/modules/licensing/PILicenseTemplate.sol
+++ b/contracts/modules/licensing/PILicenseTemplate.sol
@@ -117,7 +117,7 @@ contract PILicenseTemplate is
     /// @param licenseTermsId The ID of the license terms.
     /// @return True if the license terms exists, false otherwise.
     function exists(uint256 licenseTermsId) external view override returns (bool) {
-        return licenseTermsId <= _getPILicenseTemplateStorage().licenseTermsCounter;
+        return _exists(licenseTermsId);
     }
 
     /// @notice Verifies the minting of a license token.
@@ -133,6 +133,7 @@ contract PILicenseTemplate is
         address licensorIpId,
         uint256
     ) external override nonReentrant returns (bool) {
+        if (!_exists(licenseTermsId)) return false;
         PILTerms memory terms = _getPILicenseTemplateStorage().licenseTerms[licenseTermsId];
         // If the policy defines no reciprocal derivatives are allowed (no derivatives of derivatives),
         // and we are mintingFromADerivative we don't allow minting
@@ -476,6 +477,10 @@ contract PILicenseTemplate is
         return start + terms.expiration;
     }
 
+    /// @dev Checks if a license terms exists.
+    function _exists(uint256 licenseTermsId) internal view returns (bool) {
+        return licenseTermsId <= _getPILicenseTemplateStorage().licenseTermsCounter;
+    }
     ////////////////////////////////////////////////////////////////////////////
     //                         Upgrades related                               //
     ////////////////////////////////////////////////////////////////////////////

--- a/test/foundry/modules/licensing/PILicenseTemplate.t.sol
+++ b/test/foundry/modules/licensing/PILicenseTemplate.t.sol
@@ -338,6 +338,18 @@ contract PILicenseTemplateTest is BaseTest {
         assertFalse(result);
     }
 
+    function test_PILicenseTemplate_verifyMintLicenseToken_LicenseTermsIdNonExist() public {
+        uint256 nonExistCommUseTermsId = 999;
+
+        address[] memory parentIpIds = new address[](1);
+        parentIpIds[0] = ipAcct[1];
+        uint256[] memory licenseTermsIds = new uint256[](1);
+        licenseTermsIds[0] = nonExistCommUseTermsId;
+
+        bool result = pilTemplate.verifyMintLicenseToken(nonExistCommUseTermsId, ipOwner[2], ipAcct[1], 1);
+        assertFalse(result);
+    }
+
     // test verifyRegisterDerivative
     function test_PILicenseTemplate_verifyRegisterDerivative() public {
         uint256 commUseTermsId = pilTemplate.registerLicenseTerms(


### PR DESCRIPTION
## Description

This PR includes changes that enhance the `PILicenseTemplate` contract. The contract now checks whether the input `licenseTermsId` exists when performing verification during the minting of a license token.

### Changes:
Modified the `PILicenseTemplate` contract to include a check for the existence of licenseTermsId. If the licenseTermsId does not exist, the contract will revert and prevent the minting of the license token.

## Test Plan 
Updated the unit tests to cover the code change in this PR.
