### PR TITLE
Refactor `registerIpAccount` to be Internal function

### DIFF
--- a/contracts/interfaces/registries/IIPAccountRegistry.sol
+++ b/contracts/interfaces/registries/IIPAccountRegistry.sol
@@ -18,23 +18,6 @@ interface IIPAccountRegistry {
         uint256 tokenId
     );
 
-    /// @notice Returns the IPAccount implementation address
-    function IP_ACCOUNT_IMPL() external view returns (address);
-
-    /// @notice Returns the IPAccount salt
-    function IP_ACCOUNT_SALT() external view returns (bytes32);
-
-    /// @notice Returns the public ERC6551 registry address
-    function ERC6551_PUBLIC_REGISTRY() external view returns (address);
-
-    /// @notice Deploys an IPAccount contract with the IPAccount implementation and returns the address of the new IP
-    /// @dev The IPAccount deployment deltegates to public ERC6551 Registry
-    /// @param chainId The chain ID where the IP Account will be created
-    /// @param tokenContract The address of the token contract to be associated with the IP Account
-    /// @param tokenId The ID of the token to be associated with the IP Account
-    /// @return ipAccountAddress The address of the newly created IP Account
-    function registerIpAccount(uint256 chainId, address tokenContract, uint256 tokenId) external returns (address);
-
     /// @notice Returns the IPAccount address for the given NFT token.
     /// @param chainId The chain ID where the IP Account is located
     /// @param tokenContract The address of the token contract associated with the IP Account

--- a/contracts/registries/IPAccountRegistry.sol
+++ b/contracts/registries/IPAccountRegistry.sol
@@ -30,27 +30,6 @@ abstract contract IPAccountRegistry is IIPAccountRegistry {
         ERC6551_PUBLIC_REGISTRY = erc6551Registry;
     }
 
-    /// @notice Deploys an IPAccount contract with the IPAccount implementation and returns the address of the new IP
-    /// @dev The IPAccount deployment deltegates to public ERC6551 Registry
-    /// @param chainId The chain ID where the IP Account will be created
-    /// @param tokenContract The address of the token contract to be associated with the IP Account
-    /// @param tokenId The ID of the token to be associated with the IP Account
-    /// @return ipAccountAddress The address of the newly created IP Account
-    function registerIpAccount(
-        uint256 chainId,
-        address tokenContract,
-        uint256 tokenId
-    ) public returns (address ipAccountAddress) {
-        ipAccountAddress = IERC6551Registry(ERC6551_PUBLIC_REGISTRY).createAccount(
-            IP_ACCOUNT_IMPL,
-            IP_ACCOUNT_SALT,
-            chainId,
-            tokenContract,
-            tokenId
-        );
-        emit IPAccountRegistered(ipAccountAddress, IP_ACCOUNT_IMPL, chainId, tokenContract, tokenId);
-    }
-
     /// @notice Returns the IPAccount address for the given NFT token.
     /// @param chainId The chain ID where the IP Account is located
     /// @param tokenContract The address of the token contract associated with the IP Account
@@ -64,6 +43,27 @@ abstract contract IPAccountRegistry is IIPAccountRegistry {
     /// @return The address of the IPAccount implementation
     function getIPAccountImpl() external view override returns (address) {
         return IP_ACCOUNT_IMPL;
+    }
+
+    /// @dev Deploys an IPAccount contract with the IPAccount implementation and returns the address of the new IP
+    /// The IPAccount deployment delegates to public ERC6551 Registry
+    /// @param chainId The chain ID where the IP Account will be created
+    /// @param tokenContract The address of the token contract to be associated with the IP Account
+    /// @param tokenId The ID of the token to be associated with the IP Account
+    /// @return ipAccountAddress The address of the newly created IP Account
+    function _registerIpAccount(
+        uint256 chainId,
+        address tokenContract,
+        uint256 tokenId
+    ) internal returns (address ipAccountAddress) {
+        ipAccountAddress = IERC6551Registry(ERC6551_PUBLIC_REGISTRY).createAccount(
+            IP_ACCOUNT_IMPL,
+            IP_ACCOUNT_SALT,
+            chainId,
+            tokenContract,
+            tokenId
+        );
+        emit IPAccountRegistered(ipAccountAddress, IP_ACCOUNT_IMPL, chainId, tokenContract, tokenId);
     }
 
     /// @dev Helper function to get the IPAccount address from the ERC6551 registry.

--- a/contracts/registries/IPAssetRegistry.sol
+++ b/contracts/registries/IPAssetRegistry.sol
@@ -65,7 +65,7 @@ contract IPAssetRegistry is IIPAssetRegistry, IPAccountRegistry, ProtocolPausabl
         address tokenContract,
         uint256 tokenId
     ) external whenNotPaused returns (address id) {
-        id = registerIpAccount(chainid, tokenContract, tokenId);
+        id = _registerIpAccount(chainid, tokenContract, tokenId);
         IIPAccount ipAccount = IIPAccount(payable(id));
 
         if (bytes(ipAccount.getString("NAME")).length != 0) {

--- a/test/foundry/IPAccount.t.sol
+++ b/test/foundry/IPAccount.t.sol
@@ -6,17 +6,31 @@ import { ERC6551 } from "@solady/src/accounts/ERC6551.sol";
 
 import { IIPAccount } from "../../contracts/interfaces/IIPAccount.sol";
 import { Errors } from "../../contracts/lib/Errors.sol";
+import { IPAccountRegistry } from "../../contracts/registries/IPAccountRegistry.sol";
 
 import { MockModule } from "./mocks/module/MockModule.sol";
 import { BaseTest } from "./utils/BaseTest.t.sol";
 
+contract MockIPAccountRegistry is IPAccountRegistry {
+    constructor(address erc6551Registry, address ipAccountImpl) IPAccountRegistry(erc6551Registry, ipAccountImpl) {}
+
+    function registerIpAccount(uint256 chainId, address tokenContract, uint256 tokenId) public returns (address) {
+        return _registerIpAccount(chainId, tokenContract, tokenId);
+    }
+}
+
 contract IPAccountTest is BaseTest {
     MockModule public module;
+    MockIPAccountRegistry public mockIpAccountRegistry;
 
     function setUp() public override {
         super.setUp();
 
         module = new MockModule(address(ipAssetRegistry), address(moduleRegistry), "MockModule");
+        mockIpAccountRegistry = new MockIPAccountRegistry(
+            ipAccountRegistry.ERC6551_PUBLIC_REGISTRY(),
+            ipAccountRegistry.IP_ACCOUNT_IMPL()
+        );
 
         vm.startPrank(u.admin); // used twice, name() and registerModule()
         moduleRegistry.registerModule(module.name(), address(module));
@@ -33,14 +47,14 @@ contract IPAccountTest is BaseTest {
 
         vm.prank(owner, owner);
 
-        address deployedAccount = ipAssetRegistry.registerIpAccount(block.chainid, address(mockNFT), tokenId);
+        address deployedAccount = mockIpAccountRegistry.registerIpAccount(block.chainid, address(mockNFT), tokenId);
 
         assertTrue(deployedAccount != address(0));
 
         assertEq(predictedAccount, deployedAccount);
 
         // Create account twice
-        deployedAccount = ipAssetRegistry.registerIpAccount(block.chainid, address(mockNFT), tokenId);
+        deployedAccount = mockIpAccountRegistry.registerIpAccount(block.chainid, address(mockNFT), tokenId);
         assertEq(predictedAccount, deployedAccount);
     }
 
@@ -51,7 +65,7 @@ contract IPAccountTest is BaseTest {
         mockNFT.mintId(owner, tokenId);
 
         vm.prank(owner, owner);
-        address account = ipAssetRegistry.registerIpAccount(block.chainid, address(mockNFT), tokenId);
+        address account =mockIpAccountRegistry.registerIpAccount(block.chainid, address(mockNFT), tokenId);
 
         IIPAccount ipAccount = IIPAccount(payable(account));
 
@@ -86,7 +100,7 @@ contract IPAccountTest is BaseTest {
         mockNFT.mintId(owner, tokenId);
 
         vm.prank(owner, owner);
-        address account = ipAssetRegistry.registerIpAccount(block.chainid, address(mockNFT), tokenId);
+        address account =mockIpAccountRegistry.registerIpAccount(block.chainid, address(mockNFT), tokenId);
 
         uint256 subTokenId = 111;
         mockNFT.mintId(account, subTokenId);
@@ -122,7 +136,7 @@ contract IPAccountTest is BaseTest {
 
         mockNFT.mintId(owner, tokenId);
 
-        address account = ipAssetRegistry.registerIpAccount(block.chainid, address(mockNFT), tokenId);
+        address account =mockIpAccountRegistry.registerIpAccount(block.chainid, address(mockNFT), tokenId);
 
         uint256 subTokenId = 111;
         mockNFT.mintId(account, subTokenId);
@@ -149,7 +163,7 @@ contract IPAccountTest is BaseTest {
 
         mockNFT.mintId(owner, tokenId);
 
-        address account = ipAssetRegistry.registerIpAccount(block.chainid, address(mockNFT), tokenId);
+        address account = mockIpAccountRegistry.registerIpAccount(block.chainid, address(mockNFT), tokenId);
 
         uint256 subTokenId = 111;
         mockNFT.mintId(account, subTokenId);
@@ -169,7 +183,7 @@ contract IPAccountTest is BaseTest {
         mockNFT.mintId(owner, tokenId);
 
         vm.prank(owner, owner);
-        address account = ipAssetRegistry.registerIpAccount(block.chainid, address(mockNFT), tokenId);
+        address account = mockIpAccountRegistry.registerIpAccount(block.chainid, address(mockNFT), tokenId);
 
         address otherOwner = vm.addr(2);
         uint256 otherTokenId = 200;
@@ -187,7 +201,7 @@ contract IPAccountTest is BaseTest {
         mockNFT.mintId(owner, tokenId);
 
         vm.prank(owner, owner);
-        address account = ipAssetRegistry.registerIpAccount(block.chainid, address(mockNFT), tokenId);
+        address account = mockIpAccountRegistry.registerIpAccount(block.chainid, address(mockNFT), tokenId);
 
         ERC6551 ipAccount = ERC6551(payable(account));
 
@@ -222,7 +236,7 @@ contract IPAccountTest is BaseTest {
         mockNFT.mintId(owner, tokenId);
 
         vm.prank(owner, owner);
-        address account = ipAssetRegistry.registerIpAccount(block.chainid, address(mockNFT), tokenId);
+        address account = mockIpAccountRegistry.registerIpAccount(block.chainid, address(mockNFT), tokenId);
 
         ERC6551 ipAccount = ERC6551(payable(account));
 
@@ -243,7 +257,7 @@ contract IPAccountTest is BaseTest {
         mockNFT.mintId(owner, tokenId);
 
         vm.prank(owner, owner);
-        address account = ipAssetRegistry.registerIpAccount(block.chainid, address(mockNFT), tokenId);
+        address account = mockIpAccountRegistry.registerIpAccount(block.chainid, address(mockNFT), tokenId);
 
         ERC6551 ipAccount = ERC6551(payable(account));
 

--- a/test/foundry/IPAccount.t.sol
+++ b/test/foundry/IPAccount.t.sol
@@ -65,7 +65,7 @@ contract IPAccountTest is BaseTest {
         mockNFT.mintId(owner, tokenId);
 
         vm.prank(owner, owner);
-        address account =mockIpAccountRegistry.registerIpAccount(block.chainid, address(mockNFT), tokenId);
+        address account = mockIpAccountRegistry.registerIpAccount(block.chainid, address(mockNFT), tokenId);
 
         IIPAccount ipAccount = IIPAccount(payable(account));
 
@@ -100,7 +100,7 @@ contract IPAccountTest is BaseTest {
         mockNFT.mintId(owner, tokenId);
 
         vm.prank(owner, owner);
-        address account =mockIpAccountRegistry.registerIpAccount(block.chainid, address(mockNFT), tokenId);
+        address account = mockIpAccountRegistry.registerIpAccount(block.chainid, address(mockNFT), tokenId);
 
         uint256 subTokenId = 111;
         mockNFT.mintId(account, subTokenId);
@@ -136,7 +136,7 @@ contract IPAccountTest is BaseTest {
 
         mockNFT.mintId(owner, tokenId);
 
-        address account =mockIpAccountRegistry.registerIpAccount(block.chainid, address(mockNFT), tokenId);
+        address account = mockIpAccountRegistry.registerIpAccount(block.chainid, address(mockNFT), tokenId);
 
         uint256 subTokenId = 111;
         mockNFT.mintId(account, subTokenId);

--- a/test/foundry/IPAccountImpl.btt.t.sol
+++ b/test/foundry/IPAccountImpl.btt.t.sol
@@ -32,7 +32,7 @@ contract IPAccountImplBTT is BaseTest {
 
         ipOwner = u.alice;
         mockNFT.mintId(ipOwner, tokenId);
-        ipAcct = IIPAccount(payable(ipAssetRegistry.registerIpAccount(chainId, address(mockNFT), tokenId)));
+        ipAcct = IIPAccount(payable(ipAssetRegistry.register(chainId, address(mockNFT), tokenId)));
     }
 
     function test_IPAccountImpl_supportsInterface() public {

--- a/test/foundry/IPAccountMetaTx.t.sol
+++ b/test/foundry/IPAccountMetaTx.t.sol
@@ -67,7 +67,7 @@ contract IPAccountMetaTxTest is BaseTest {
 
         mockNFT.mintId(owner, tokenId);
 
-        address account = ipAccountRegistry.registerIpAccount(block.chainid, address(mockNFT), tokenId);
+        address account = ipAssetRegistry.register(block.chainid, address(mockNFT), tokenId);
 
         IIPAccount ipAccount = IIPAccount(payable(account));
 
@@ -117,7 +117,7 @@ contract IPAccountMetaTxTest is BaseTest {
 
         mockNFT.mintId(owner, tokenId);
 
-        address account = ipAccountRegistry.registerIpAccount(block.chainid, address(mockNFT), tokenId);
+        address account = ipAssetRegistry.register(block.chainid, address(mockNFT), tokenId);
 
         IIPAccount ipAccount = IIPAccount(payable(account));
 
@@ -193,7 +193,7 @@ contract IPAccountMetaTxTest is BaseTest {
 
         mockNFT.mintId(owner, tokenId);
 
-        address account = ipAssetRegistry.registerIpAccount(block.chainid, address(mockNFT), tokenId);
+        address account = ipAssetRegistry.register(block.chainid, address(mockNFT), tokenId);
 
         IIPAccount ipAccount = IIPAccount(payable(account));
 
@@ -258,7 +258,7 @@ contract IPAccountMetaTxTest is BaseTest {
 
         mockNFT.mintId(owner, tokenId);
 
-        address account = ipAccountRegistry.registerIpAccount(block.chainid, address(mockNFT), tokenId);
+        address account = ipAssetRegistry.register(block.chainid, address(mockNFT), tokenId);
 
         IIPAccount ipAccount = IIPAccount(payable(account));
 
@@ -305,7 +305,7 @@ contract IPAccountMetaTxTest is BaseTest {
 
         mockNFT.mintId(owner, tokenId);
 
-        address account = ipAccountRegistry.registerIpAccount(block.chainid, address(mockNFT), tokenId);
+        address account = ipAssetRegistry.register(block.chainid, address(mockNFT), tokenId);
 
         IIPAccount ipAccount = IIPAccount(payable(account));
 
@@ -351,7 +351,7 @@ contract IPAccountMetaTxTest is BaseTest {
 
         mockNFT.mintId(owner, tokenId);
 
-        address account = ipAccountRegistry.registerIpAccount(block.chainid, address(mockNFT), tokenId);
+        address account = ipAssetRegistry.register(block.chainid, address(mockNFT), tokenId);
 
         IIPAccount ipAccount = IIPAccount(payable(account));
 
@@ -396,7 +396,7 @@ contract IPAccountMetaTxTest is BaseTest {
 
         mockNFT.mintId(owner, tokenId);
 
-        address account = ipAccountRegistry.registerIpAccount(block.chainid, address(mockNFT), tokenId);
+        address account = ipAssetRegistry.register(block.chainid, address(mockNFT), tokenId);
 
         IIPAccount ipAccount = IIPAccount(payable(account));
 
@@ -442,13 +442,13 @@ contract IPAccountMetaTxTest is BaseTest {
 
         mockNFT.mintId(owner, tokenId);
 
-        address account = ipAccountRegistry.registerIpAccount(block.chainid, address(mockNFT), tokenId);
+        address account = ipAssetRegistry.register(block.chainid, address(mockNFT), tokenId);
 
         IIPAccount ipAccount = IIPAccount(payable(account));
 
         uint256 tokenId2 = 101;
         mockNFT.mintId(owner, tokenId2);
-        address account2 = ipAccountRegistry.registerIpAccount(block.chainid, address(mockNFT), tokenId2);
+        address account2 = ipAssetRegistry.register(block.chainid, address(mockNFT), tokenId2);
         IIPAccount ipAccount2 = IIPAccount(payable(account2));
 
         uint deadline = block.timestamp + 1000;
@@ -482,7 +482,7 @@ contract IPAccountMetaTxTest is BaseTest {
 
         mockNFT.mintId(owner, tokenId);
 
-        address account = ipAccountRegistry.registerIpAccount(block.chainid, address(mockNFT), tokenId);
+        address account = ipAssetRegistry.register(block.chainid, address(mockNFT), tokenId);
 
         IIPAccount ipAccount = IIPAccount(payable(account));
 
@@ -536,7 +536,7 @@ contract IPAccountMetaTxTest is BaseTest {
 
         mockNFT.mintId(owner, tokenId);
 
-        address account = ipAccountRegistry.registerIpAccount(block.chainid, address(mockNFT), tokenId);
+        address account = ipAssetRegistry.register(block.chainid, address(mockNFT), tokenId);
 
         IIPAccount ipAccount = IIPAccount(payable(account));
 
@@ -583,7 +583,7 @@ contract IPAccountMetaTxTest is BaseTest {
 
         mockNFT.mintId(owner, tokenId);
 
-        address account = ipAccountRegistry.registerIpAccount(block.chainid, address(mockNFT), tokenId);
+        address account = ipAssetRegistry.register(block.chainid, address(mockNFT), tokenId);
 
         IIPAccount ipAccount = IIPAccount(payable(account));
 
@@ -628,7 +628,7 @@ contract IPAccountMetaTxTest is BaseTest {
 
         mockNFT.mintId(owner, tokenId);
 
-        address account = ipAccountRegistry.registerIpAccount(block.chainid, address(mockNFT), tokenId);
+        address account = ipAssetRegistry.register(block.chainid, address(mockNFT), tokenId);
 
         IIPAccount ipAccount = IIPAccount(payable(account));
 

--- a/test/foundry/IPAccountStorage.t.sol
+++ b/test/foundry/IPAccountStorage.t.sol
@@ -22,7 +22,7 @@ contract IPAccountStorageTest is BaseTest, BaseModule {
         address owner = vm.addr(1);
         uint256 tokenId = 100;
         mockNFT.mintId(owner, tokenId);
-        ipAccount = IIPAccount(payable(ipAccountRegistry.registerIpAccount(block.chainid, address(mockNFT), tokenId)));
+        ipAccount = IIPAccount(payable(ipAssetRegistry.register(block.chainid, address(mockNFT), tokenId)));
         vm.startPrank(admin);
         moduleRegistry.registerModule("MockModule", address(module));
         moduleRegistry.registerModule("IPAccountStorageTest", address(this));

--- a/test/foundry/IPAccountStorageOps.t.sol
+++ b/test/foundry/IPAccountStorageOps.t.sol
@@ -25,7 +25,7 @@ contract IPAccountStorageOpsTest is BaseTest, BaseModule {
         address owner = vm.addr(1);
         uint256 tokenId = 100;
         mockNFT.mintId(owner, tokenId);
-        ipAccount = IIPAccount(payable(ipAccountRegistry.registerIpAccount(block.chainid, address(mockNFT), tokenId)));
+        ipAccount = IIPAccount(payable(ipAssetRegistry.register(block.chainid, address(mockNFT), tokenId)));
         vm.startPrank(admin);
         moduleRegistry.registerModule("MockModule", address(module));
         moduleRegistry.registerModule("IPAccountStorageOpsTest", address(this));

--- a/test/foundry/access/AccessControlled.t.sol
+++ b/test/foundry/access/AccessControlled.t.sol
@@ -19,7 +19,7 @@ contract AccessControlledTest is BaseTest {
         super.setUp();
 
         mockNFT.mintId(owner, tokenId);
-        address deployedAccount = ipAccountRegistry.registerIpAccount(block.chainid, address(mockNFT), tokenId);
+        address deployedAccount = ipAssetRegistry.register(block.chainid, address(mockNFT), tokenId);
         ipAccount = IIPAccount(payable(deployedAccount));
 
         mockModule = new MockAccessControlledModule(
@@ -117,7 +117,7 @@ contract AccessControlledTest is BaseTest {
 
     function test_AccessControlled_revert_callIpAccountOrPermissionFunction_withOtherIpAccount() public {
         mockNFT.mintId(owner, 101);
-        address otherIpAccountAddr = ipAccountRegistry.registerIpAccount(block.chainid, address(mockNFT), 101);
+        address otherIpAccountAddr = ipAssetRegistry.register(block.chainid, address(mockNFT), 101);
         IIPAccount otherIpAccount = IIPAccount(payable(otherIpAccountAddr));
         vm.expectRevert(
             abi.encodeWithSelector(

--- a/test/foundry/access/AccessController.t.sol
+++ b/test/foundry/access/AccessController.t.sol
@@ -26,7 +26,7 @@ contract AccessControllerTest is BaseTest {
         super.setUp();
 
         mockNFT.mintId(owner, tokenId);
-        address deployedAccount = ipAccountRegistry.registerIpAccount(block.chainid, address(mockNFT), tokenId);
+        address deployedAccount = ipAssetRegistry.register(block.chainid, address(mockNFT), tokenId);
         ipAccount = IIPAccount(payable(deployedAccount));
 
         mockModule = new MockModule(address(ipAccountRegistry), address(moduleRegistry), "MockModule");

--- a/test/foundry/modules/external/TokenWithdrawalModule.t.sol
+++ b/test/foundry/modules/external/TokenWithdrawalModule.t.sol
@@ -36,8 +36,8 @@ contract TokenWithdrawalModuleTest is BaseTest {
         mockNFT.mintId(alice, 1);
         mockNFT.mintId(alice, 2);
 
-        ipAcct1 = IIPAccount(payable(ipAccountRegistry.registerIpAccount(block.chainid, address(mockNFT), 1)));
-        ipAcct2 = IIPAccount(payable(ipAccountRegistry.registerIpAccount(block.chainid, address(mockNFT), 2)));
+        ipAcct1 = IIPAccount(payable(ipAssetRegistry.register(block.chainid, address(mockNFT), 1)));
+        ipAcct2 = IIPAccount(payable(ipAssetRegistry.register(block.chainid, address(mockNFT), 2)));
 
         vm.label(address(ipAcct1), "IPAccount1");
         vm.label(address(ipAcct2), "IPAccount2");

--- a/test/foundry/modules/metadata/CoreMetadataViewModule.t.sol
+++ b/test/foundry/modules/metadata/CoreMetadataViewModule.t.sol
@@ -84,7 +84,13 @@ contract CoreMetadataViewModuleTest is BaseTest {
 
     function test_CoreMetadataViewModule_revert_isSupported() public {
         mockNFT.mintId(alice, 999);
-        address nonIpAsset = ipAssetRegistry.registerIpAccount(block.chainid, address(mockNFT), 999);
+        address nonIpAsset = erc6551Registry.createAccount(
+            ipAccountRegistry.IP_ACCOUNT_IMPL(),
+            ipAccountRegistry.IP_ACCOUNT_SALT(),
+            block.chainid,
+            address(mockNFT),
+            999
+        );
         assertFalse(coreMetadataViewModule.isSupported(nonIpAsset));
     }
 

--- a/test/foundry/modules/metadata/MetadataModule.t.sol
+++ b/test/foundry/modules/metadata/MetadataModule.t.sol
@@ -36,7 +36,7 @@ contract MetadataModuleTest is BaseTest {
 
         mockNFT.mintId(owner, tokenId);
 
-        address ipAccount = ipAssetRegistry.registerIpAccount(block.chainid, address(mockNFT), tokenId);
+        address ipAccount = ipAssetRegistry.register(block.chainid, address(mockNFT), tokenId);
 
         vm.prank(owner);
         metadataModule.setIpDescription(ipAccount, "This is a mock ERC721 token");
@@ -53,7 +53,7 @@ contract MetadataModuleTest is BaseTest {
 
         mockNFT.mintId(owner, tokenId);
 
-        address ipAccount = ipAssetRegistry.registerIpAccount(block.chainid, address(mockNFT), tokenId);
+        address ipAccount = ipAssetRegistry.register(block.chainid, address(mockNFT), tokenId);
 
         vm.prank(owner);
         metadataModule.setIpDescription(ipAccount, "This is a mock ERC721 token");
@@ -75,7 +75,7 @@ contract MetadataModuleTest is BaseTest {
 
         mockNFT.mintId(owner, tokenId);
 
-        address ipAccount = ipAssetRegistry.registerIpAccount(block.chainid, address(mockNFT), tokenId);
+        address ipAccount = ipAssetRegistry.register(block.chainid, address(mockNFT), tokenId);
 
         vm.prank(owner);
         metadataModule.setIpDescription(ipAccount, "This is a mock ERC721 token");
@@ -92,7 +92,7 @@ contract MetadataModuleTest is BaseTest {
 
         mockNFT.mintId(owner, tokenId);
 
-        address ipAccount = ipAssetRegistry.registerIpAccount(block.chainid, address(mockNFT), tokenId);
+        address ipAccount = ipAssetRegistry.register(block.chainid, address(mockNFT), tokenId);
 
         assertFalse(coreMetadataViewModule.isSupported(ipAccount));
         assertFalse(allMetadataViewModule.isSupported(ipAccount));

--- a/test/foundry/registries/IPAccountRegistry.t.sol
+++ b/test/foundry/registries/IPAccountRegistry.t.sol
@@ -19,7 +19,7 @@ contract IPAccountRegistryTest is BaseTest {
     }
 
     function test_IPAccountRegistry_registerIpAccount() public {
-        address ipAccountAddr = ipAccountRegistry.registerIpAccount(chainId, tokenAddress, tokenId);
+        address ipAccountAddr = ipAssetRegistry.register(chainId, tokenAddress, tokenId);
 
         address registryComputedAddress = ipAccountRegistry.ipAccount(chainId, tokenAddress, tokenId);
         assertEq(ipAccountAddr, registryComputedAddress);
@@ -31,6 +31,6 @@ contract IPAccountRegistryTest is BaseTest {
         assertEq(tokenAddress_, tokenAddress);
         assertEq(tokenId_, tokenId);
 
-        assertTrue(ipAccountRegistry.isRegistered(chainId, tokenAddress, tokenId));
+        assertTrue(ipAssetRegistry.isRegistered(ipAccountAddr));
     }
 }

--- a/test/foundry/registries/IPAssetRegistry.t.sol
+++ b/test/foundry/registries/IPAssetRegistry.t.sol
@@ -81,8 +81,13 @@ contract IPAssetRegistryTest is BaseTest {
     /// @notice Tests registration of IP permissionlessly for IPAccount already created.
     function test_IPAssetRegistry_RegisterPermissionless_IPAccountAlreadyExist() public {
         uint256 totalSupply = registry.totalSupply();
-
-        IIPAccountRegistry(registry).registerIpAccount(block.chainid, tokenAddress, tokenId);
+        erc6551Registry.createAccount(
+            ipAccountRegistry.IP_ACCOUNT_IMPL(),
+            ipAccountRegistry.IP_ACCOUNT_SALT(),
+            block.chainid,
+            tokenAddress,
+            tokenId
+        );
         string memory name = string.concat(block.chainid.toString(), ": Ape #99");
         vm.expectEmit(true, true, true, true);
         emit IIPAssetRegistry.IPRegistered(
@@ -156,7 +161,17 @@ contract IPAssetRegistryTest is BaseTest {
         assertTrue(!registry.isRegistered(address(0x12345)));
         assertTrue(!registry.isRegistered(address(this)));
         mockNFT.mintId(alice, 1000);
-        assertTrue(!registry.isRegistered(ipAssetRegistry.registerIpAccount(block.chainid, address(mockNFT), 1000)));
+        assertTrue(
+            !registry.isRegistered(
+                erc6551Registry.createAccount(
+                    ipAccountRegistry.IP_ACCOUNT_IMPL(),
+                    ipAccountRegistry.IP_ACCOUNT_SALT(),
+                    block.chainid,
+                    address(mockNFT),
+                    1000
+                )
+            )
+        );
     }
 
     /// @notice Tests registration of IP NFT from other chain.

--- a/test/foundry/registries/IPAssetRegistry.t.sol
+++ b/test/foundry/registries/IPAssetRegistry.t.sol
@@ -4,7 +4,6 @@ pragma solidity 0.8.23;
 import { IIPAssetRegistry } from "contracts/interfaces/registries/IIPAssetRegistry.sol";
 import { IPAccountChecker } from "contracts/lib/registries/IPAccountChecker.sol";
 import { IPAssetRegistry } from "contracts/registries/IPAssetRegistry.sol";
-import { IIPAccountRegistry } from "contracts/interfaces/registries/IIPAccountRegistry.sol";
 import { Errors } from "contracts/lib/Errors.sol";
 import { IIPAccount } from "contracts/interfaces/IIPAccount.sol";
 import { IPAccountStorageOps } from "contracts/lib/IPAccountStorageOps.sol";


### PR DESCRIPTION
## Description

This PR includes changes that refactor the `registerIpAccount` function in the `IPAccountRegistry` contract. The function has been made internal to ensure there is only one unique way to register an IPAccount, which is through the `IPAssetRegistry`. This change is aimed at making the IP Asset registration path more consistent.

### Changes:

1. Modified the `registerIpAccount` function in the `IPAccountRegistry` contract to be internal. This change ensures that IP Account registration can only be done through the `IPAssetRegistry`, providing a single, consistent path for IP registration.

2. Updated the unit tests to reflect these changes. 

3. Updated the NatSpec documentation to reflect these changes.

## Test Plan 
Updated the unit test case cover the code changes.
