### PR TITLE
Update PILicenseTemplate for Compatibility Checks of `derivativesReciprocal`

### DIFF
--- a/contracts/interfaces/modules/licensing/IPILicenseTemplate.sol
+++ b/contracts/interfaces/modules/licensing/IPILicenseTemplate.sol
@@ -28,7 +28,7 @@ import { ILicenseTemplate } from "../../../interfaces/modules/licensing/ILicense
 struct PILTerms {
     bool transferable;
     address royaltyPolicy;
-    uint256 mintingFee;
+    uint256 defaultMintingFee;
     uint256 expiration;
     bool commercialUse;
     bool commercialAttribution;

--- a/contracts/lib/PILFlavors.sol
+++ b/contracts/lib/PILFlavors.sol
@@ -102,7 +102,7 @@ library PILFlavors {
             PILTerms({
                 transferable: true,
                 royaltyPolicy: address(0),
-                mintingFee: 0,
+                defaultMintingFee: 0,
                 expiration: 0,
                 commercialUse: false,
                 commercialAttribution: false,
@@ -126,7 +126,7 @@ library PILFlavors {
             PILTerms({
                 transferable: true,
                 royaltyPolicy: address(0),
-                mintingFee: 0,
+                defaultMintingFee: 0,
                 expiration: 0,
                 commercialUse: false,
                 commercialAttribution: false,
@@ -154,7 +154,7 @@ library PILFlavors {
             PILTerms({
                 transferable: true,
                 royaltyPolicy: royaltyPolicy,
-                mintingFee: mintingFee,
+                defaultMintingFee: mintingFee,
                 expiration: 0,
                 commercialUse: true,
                 commercialAttribution: true,
@@ -183,7 +183,7 @@ library PILFlavors {
             PILTerms({
                 transferable: true,
                 royaltyPolicy: royaltyPolicy,
-                mintingFee: mintingFee,
+                defaultMintingFee: mintingFee,
                 expiration: 0,
                 commercialUse: true,
                 commercialAttribution: true,

--- a/contracts/modules/licensing/PILicenseTemplate.sol
+++ b/contracts/modules/licensing/PILicenseTemplate.sol
@@ -222,7 +222,7 @@ contract PILicenseTemplate is
         uint256 licenseTermsId
     ) external view returns (address royaltyPolicy, bytes memory royaltyData, uint256 mintingFee, address currency) {
         PILTerms memory terms = _getPILicenseTemplateStorage().licenseTerms[licenseTermsId];
-        return (terms.royaltyPolicy, abi.encode(terms.commercialRevShare), terms.mintingFee, terms.currency);
+        return (terms.royaltyPolicy, abi.encode(terms.commercialRevShare), terms.defaultMintingFee, terms.currency);
     }
 
     /// @notice Checks if a license terms is transferable.

--- a/contracts/modules/licensing/PILicenseTemplate.sol
+++ b/contracts/modules/licensing/PILicenseTemplate.sol
@@ -463,6 +463,7 @@ contract PILicenseTemplate is
         for (uint256 i = 1; i < licenseTermsIds.length; i++) {
             if ($.licenseTerms[licenseTermsIds[i]].commercialUse != commercial) return false;
             if ($.licenseTerms[licenseTermsIds[i]].derivativesReciprocal != derivativesReciprocal) return false;
+            if (derivativesReciprocal && licenseTermsIds[0] != licenseTermsIds[i]) return false;
         }
         return true;
     }

--- a/test/foundry/LicenseToken.t.sol
+++ b/test/foundry/LicenseToken.t.sol
@@ -111,7 +111,7 @@ contract LicenseTokenTest is BaseTest {
             PILTerms({
                 transferable: false,
                 royaltyPolicy: address(0),
-                mintingFee: 0,
+                defaultMintingFee: 0,
                 expiration: 0,
                 commercialUse: false,
                 commercialAttribution: false,

--- a/test/foundry/integration/big-bang/SingleNftCollection.t.sol
+++ b/test/foundry/integration/big-bang/SingleNftCollection.t.sol
@@ -43,7 +43,7 @@ contract BigBang_Integration_SingleNftCollection is BaseIntegration {
             PILTerms({
                 transferable: true,
                 royaltyPolicy: address(royaltyPolicyLAP),
-                mintingFee: mintingFee,
+                defaultMintingFee: mintingFee,
                 expiration: 0,
                 commercialUse: true,
                 commercialAttribution: false,

--- a/test/foundry/modules/licensing/LicensingModule.t.sol
+++ b/test/foundry/modules/licensing/LicensingModule.t.sol
@@ -175,7 +175,7 @@ contract LicensingModuleTest is BaseTest {
         PILTerms memory terms = PILTerms({
             transferable: true,
             royaltyPolicy: address(royaltyPolicyLAP),
-            mintingFee: 0,
+            defaultMintingFee: 0,
             expiration: 10 days,
             commercialUse: true,
             commercialAttribution: true,
@@ -419,7 +419,7 @@ contract LicensingModuleTest is BaseTest {
         PILTerms memory terms = PILTerms({
             transferable: true,
             royaltyPolicy: address(royaltyPolicyLAP),
-            mintingFee: 0,
+            defaultMintingFee: 0,
             expiration: 10 days,
             commercialUse: true,
             commercialAttribution: true,
@@ -734,20 +734,19 @@ contract LicensingModuleTest is BaseTest {
     }
 
     function test_LicensingModule_registerDerivativeWithLicenseTokens_revert_ParentExpired() public {
-        uint256 termsId = pilTemplate.registerLicenseTerms(PILFlavors.nonCommercialSocialRemixing());
         PILTerms memory expiredTerms = PILFlavors.nonCommercialSocialRemixing();
         expiredTerms.expiration = 10 days;
         uint256 expiredTermsId = pilTemplate.registerLicenseTerms(expiredTerms);
 
         vm.prank(ipOwner1);
-        licensingModule.attachLicenseTerms(ipId1, address(pilTemplate), termsId);
+        licensingModule.attachLicenseTerms(ipId1, address(pilTemplate), expiredTermsId);
         vm.prank(ipOwner2);
         licensingModule.attachLicenseTerms(ipId2, address(pilTemplate), expiredTermsId);
 
         uint256 lcTokenId1 = licensingModule.mintLicenseTokens({
             licensorIpId: ipId1,
             licenseTemplate: address(pilTemplate),
-            licenseTermsId: termsId,
+            licenseTermsId: expiredTermsId,
             amount: 1,
             receiver: ipOwner3,
             royaltyContext: ""
@@ -763,7 +762,7 @@ contract LicensingModuleTest is BaseTest {
         });
 
         assertEq(licenseToken.ownerOf(lcTokenId1), ipOwner3);
-        assertEq(licenseToken.getLicenseTermsId(lcTokenId1), termsId);
+        assertEq(licenseToken.getLicenseTermsId(lcTokenId1), expiredTermsId);
         assertEq(licenseToken.getLicenseTemplate(lcTokenId1), address(pilTemplate));
         assertEq(licenseToken.getLicensorIpId(lcTokenId1), ipId1);
 
@@ -782,9 +781,8 @@ contract LicensingModuleTest is BaseTest {
         vm.prank(ipOwner3);
         licensingModule.registerDerivativeWithLicenseTokens(ipId3, licenseTokens, "");
 
-        assertEq(licenseRegistry.hasIpAttachedLicenseTerms(ipId3, address(pilTemplate), termsId), true);
         assertEq(licenseRegistry.hasIpAttachedLicenseTerms(ipId3, address(pilTemplate), expiredTermsId), true);
-        assertEq(licenseRegistry.getAttachedLicenseTermsCount(ipId3), 2);
+        assertEq(licenseRegistry.getAttachedLicenseTermsCount(ipId3), 1);
         assertEq(licenseRegistry.isDerivativeIp(ipId3), true);
         assertEq(licenseRegistry.hasDerivativeIps(ipId3), false);
         assertEq(licenseRegistry.getDerivativeIpCount(ipId3), 0);
@@ -805,16 +803,7 @@ contract LicensingModuleTest is BaseTest {
 
         (address licenseTemplate, uint256 licenseTermsId) = licenseRegistry.getAttachedLicenseTerms(ipId3, 0);
         assertEq(licenseTemplate, address(pilTemplate));
-        assertEq(licenseTermsId, termsId);
-        (address anotherLicenseTemplate, uint256 anotherLicenseTermsId) = licenseRegistry.getAttachedLicenseTerms(
-            ipId3,
-            1
-        );
-        assertEq(anotherLicenseTemplate, address(pilTemplate));
-        assertEq(anotherLicenseTermsId, expiredTermsId);
-        uint256[] memory licenseTerms = new uint256[](2);
-        licenseTerms[0] = termsId;
-        licenseTerms[1] = expiredTermsId;
+        assertEq(licenseTermsId, expiredTermsId);
 
         assertEq(licenseRegistry.getExpireTime(ipId3), block.timestamp + 10 days, "IPA has unexpected expiration time");
         vm.warp(5 days);
@@ -822,7 +811,7 @@ contract LicensingModuleTest is BaseTest {
         uint256 lcTokenId3 = licensingModule.mintLicenseTokens({
             licensorIpId: ipId3,
             licenseTemplate: address(pilTemplate),
-            licenseTermsId: termsId,
+            licenseTermsId: expiredTermsId,
             amount: 1,
             receiver: ipOwner5,
             royaltyContext: ""
@@ -972,7 +961,7 @@ contract LicensingModuleTest is BaseTest {
         PILTerms memory terms = PILTerms({
             transferable: true,
             royaltyPolicy: address(royaltyPolicyLAP),
-            mintingFee: 0,
+            defaultMintingFee: 0,
             expiration: 0,
             commercialUse: true,
             commercialAttribution: true,
@@ -1021,7 +1010,7 @@ contract LicensingModuleTest is BaseTest {
         PILTerms memory terms = PILTerms({
             transferable: true,
             royaltyPolicy: address(royaltyPolicyLAP),
-            mintingFee: 0,
+            defaultMintingFee: 0,
             expiration: 0,
             commercialUse: true,
             commercialAttribution: true,
@@ -1068,7 +1057,7 @@ contract LicensingModuleTest is BaseTest {
         PILTerms memory terms = PILTerms({
             transferable: true,
             royaltyPolicy: address(royaltyPolicyLAP),
-            mintingFee: 0,
+            defaultMintingFee: 0,
             expiration: 0,
             commercialUse: true,
             commercialAttribution: true,

--- a/test/foundry/modules/licensing/PILicenseTemplate.t.sol
+++ b/test/foundry/modules/licensing/PILicenseTemplate.t.sol
@@ -261,7 +261,7 @@ contract PILicenseTemplateTest is BaseTest {
             })
         );
         PILTerms memory terms = pilTemplate.getLicenseTerms(commUseTermsId);
-        assertEq(terms.mintingFee, 100);
+        assertEq(terms.defaultMintingFee, 100);
         assertEq(terms.currency, address(erc20));
         assertEq(terms.royaltyPolicy, address(royaltyPolicyLAP));
     }

--- a/test/foundry/modules/licensing/PILicenseTemplate.t.sol
+++ b/test/foundry/modules/licensing/PILicenseTemplate.t.sol
@@ -418,6 +418,22 @@ contract PILicenseTemplateTest is BaseTest {
         licenseTermsIds[0] = socialRemixTermsId;
         licenseTermsIds[1] = socialRemixTermsId;
         assertTrue(pilTemplate.verifyCompatibleLicenses(licenseTermsIds));
+
+        uint256 anotherCommRemixTermsId = pilTemplate.registerLicenseTerms(
+            PILFlavors.commercialRemix({
+                mintingFee: 200,
+                commercialRevShare: 20,
+                royaltyPolicy: address(royaltyPolicyLAP),
+                currencyToken: address(erc20)
+            })
+        );
+        licenseTermsIds[0] = commRemixTermsId;
+        licenseTermsIds[1] = anotherCommRemixTermsId;
+        assertFalse(pilTemplate.verifyCompatibleLicenses(licenseTermsIds));
+
+        licenseTermsIds[0] = commRemixTermsId;
+        licenseTermsIds[1] = commRemixTermsId;
+        assertTrue(pilTemplate.verifyCompatibleLicenses(licenseTermsIds));
     }
 
     // test verifyRegisterDerivativeForAllParents

--- a/test/foundry/utils/LicensingHelper.t.sol
+++ b/test/foundry/utils/LicensingHelper.t.sol
@@ -85,7 +85,7 @@ contract LicensingHelper {
             PILTerms({
                 transferable: transferable,
                 royaltyPolicy: address(royaltyPolicyLAP),
-                mintingFee: 1 ether,
+                defaultMintingFee: 1 ether,
                 expiration: 0,
                 commercialUse: true,
                 commercialAttribution: false,
@@ -112,7 +112,7 @@ contract LicensingHelper {
             PILTerms({
                 transferable: transferable,
                 royaltyPolicy: address(0),
-                mintingFee: 0,
+                defaultMintingFee: 0,
                 expiration: 0,
                 commercialUse: false,
                 commercialAttribution: false,


### PR DESCRIPTION
## Description
This PR includes changes that update the `PILicenseTemplate` contract. The contract now checks that all `licenseTermsIds` are the same if `derivativesReciprocal` is true when checking compatibility between license terms. Additionally, the term "mintingFee" has been renamed to "defaultMintingFee" to reflect that the minting fee defined in the license terms can be overridden by the IP Owner for a specific IP Asset.

## Changes:

1. Updated the `PILicenseTemplate` contract to include a check for `licenseTermsIds` compatibility. If `derivativesReciprocal` is true, all `licenseTermsIds` must be the same. This change ensures that the compatibility between license terms is correctly enforced.

2. Renamed the term "mintingFee" to "defaultMintingFee" in the `PILicenseTemplate` contract. This change reflects that the minting fee defined in the license terms can be overridden by the IP Owner for a specific IP Asset, providing more flexibility in the licensing process.

## Test Plan 
Updated the unit tests to reflect these changes, and also add new tests to cover the code changes.



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Refactor**
  - Renamed `mintingFee` to `defaultMintingFee` across various contracts and tests for consistency.
- **New Features**
  - Added new license terms for a commercial remix with specific parameters and compatibility checks.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->