### PR TITLE
Add Zero Address Checks in Constructors of IPAccountRegistry and IPAccountStorage Contracts

### DIFF
--- a/contracts/IPAccountStorage.sol
+++ b/contracts/IPAccountStorage.sol
@@ -34,6 +34,9 @@ contract IPAccountStorage is ERC165, IIPAccountStorage {
     }
 
     constructor(address ipAssetRegistry, address licenseRegistry, address moduleRegistry) {
+        if (ipAssetRegistry == address(0)) revert Errors.IPAccountStorage__ZeroIpAssetRegistry();
+        if (licenseRegistry == address(0)) revert Errors.IPAccountStorage__ZeroLicenseRegistry();
+        if (moduleRegistry == address(0)) revert Errors.IPAccountStorage__ZeroModuleRegistry();
         MODULE_REGISTRY = moduleRegistry;
         LICENSE_REGISTRY = licenseRegistry;
         IP_ASSET_REGISTRY = ipAssetRegistry;

--- a/contracts/lib/Errors.sol
+++ b/contracts/lib/Errors.sol
@@ -48,6 +48,9 @@ library Errors {
     /// @notice Zero address provided for IP Account implementation.
     error IPAccountRegistry_ZeroIpAccountImpl();
 
+    /// @notice Zero address provided for ERC6551 Registry.
+    error IPAccountRegistry_ZeroERC6551Registry();
+
     ////////////////////////////////////////////////////////////////////////////
     //                            IP Asset Registry                           //
     ////////////////////////////////////////////////////////////////////////////

--- a/contracts/lib/Errors.sol
+++ b/contracts/lib/Errors.sol
@@ -38,6 +38,15 @@ library Errors {
     /// @notice Caller writing to IP Account storage is not a registered module.
     error IPAccountStorage__NotRegisteredModule(address module);
 
+    /// @notice Zero address provided for IP Asset Registry.
+    error IPAccountStorage__ZeroIpAssetRegistry();
+
+    /// @notice Zero address provided for License Registry.
+    error IPAccountStorage__ZeroLicenseRegistry();
+
+    /// @notice Zero address provided for Module Registry.
+    error IPAccountStorage__ZeroModuleRegistry();
+
     /// @notice Invalid batch lengths provided.
     error IPAccountStorage__InvalidBatchLengths();
 

--- a/contracts/registries/IPAccountRegistry.sol
+++ b/contracts/registries/IPAccountRegistry.sol
@@ -25,6 +25,7 @@ abstract contract IPAccountRegistry is IIPAccountRegistry {
     /// @custom:oz-upgrades-unsafe-allow constructor
     constructor(address erc6551Registry, address ipAccountImpl) {
         if (ipAccountImpl == address(0)) revert Errors.IPAccountRegistry_ZeroIpAccountImpl();
+        if (erc6551Registry == address(0)) revert Errors.IPAccountRegistry_ZeroERC6551Registry();
         IP_ACCOUNT_IMPL = ipAccountImpl;
         IP_ACCOUNT_SALT = bytes32(0);
         ERC6551_PUBLIC_REGISTRY = erc6551Registry;

--- a/test/foundry/IPAccountStorage.t.sol
+++ b/test/foundry/IPAccountStorage.t.sol
@@ -4,6 +4,7 @@ pragma solidity ^0.8.23;
 import { IIPAccount } from "../../contracts/interfaces/IIPAccount.sol";
 import { BaseModule } from "../../contracts/modules/BaseModule.sol";
 import { Errors } from "../../contracts/lib/Errors.sol";
+import { IPAccountStorage } from "../../contracts/IPAccountStorage.sol";
 
 import { MockModule } from "./mocks/module/MockModule.sol";
 import { BaseTest } from "./utils/BaseTest.t.sol";
@@ -233,6 +234,15 @@ contract IPAccountStorageTest is BaseTest, BaseModule {
         namespaces[0] = _toBytes32(address(this));
         vm.expectRevert(Errors.IPAccountStorage__InvalidBatchLengths.selector);
         ipAccount.getBytes32Batch(namespaces, keys);
+    }
+
+    function test_IPAccountStorage_constructor_revert() public {
+        vm.expectRevert(Errors.IPAccountStorage__ZeroIpAssetRegistry.selector);
+        new IPAccountStorage(address(0), address(123), address(456));
+        vm.expectRevert(Errors.IPAccountStorage__ZeroLicenseRegistry.selector);
+        new IPAccountStorage(address(123), address(0), address(456));
+        vm.expectRevert(Errors.IPAccountStorage__ZeroModuleRegistry.selector);
+        new IPAccountStorage(address(123), address(456), address(0));
     }
 
     function _toBytes32(address a) internal pure returns (bytes32) {

--- a/test/foundry/registries/IPAccountRegistry.t.sol
+++ b/test/foundry/registries/IPAccountRegistry.t.sol
@@ -4,8 +4,13 @@ pragma solidity 0.8.23;
 import { IPAccountImpl } from "../../../contracts/IPAccountImpl.sol";
 import { IPAccountChecker } from "../../../contracts/lib/registries/IPAccountChecker.sol";
 import { IPAccountRegistry } from "../../../contracts/registries/IPAccountRegistry.sol";
+import { Errors } from "contracts/lib/Errors.sol";
 
 import { BaseTest } from "../utils/BaseTest.t.sol";
+
+contract MockIPAccountRegistry is IPAccountRegistry {
+    constructor(address erc6551Registry, address ipAccountImpl) IPAccountRegistry(erc6551Registry, ipAccountImpl) {}
+}
 
 contract IPAccountRegistryTest is BaseTest {
     using IPAccountChecker for IPAccountRegistry;
@@ -32,5 +37,12 @@ contract IPAccountRegistryTest is BaseTest {
         assertEq(tokenId_, tokenId);
 
         assertTrue(ipAccountRegistry.isRegistered(chainId, tokenAddress, tokenId));
+    }
+
+    function test_IPAccountRegistry_constructor_revert() public {
+        vm.expectRevert(Errors.IPAccountRegistry_ZeroERC6551Registry.selector);
+        new MockIPAccountRegistry(address(0), address(123));
+        vm.expectRevert(Errors.IPAccountRegistry_ZeroIpAccountImpl.selector);
+        new MockIPAccountRegistry(address(123), address(0));
     }
 }


### PR DESCRIPTION
## Description
This PR includes changes that add zero address checks in the constructors of the `IPAccountRegistry` and `IPAccountStorage` contracts. These checks ensure that the contracts are initialized with valid addresses, preventing potential issues down the line.

### Changes:

1. Modified the constructor of the `IPAccountRegistry` contract to include a check for the `erc6551Registry` contract address. If the `erc6551Registry` contract address is zero, the constructor will revert and prevent the initialization of the contract.

2. Modified the constructor of the `IPAccountStorage` contract to include checks for the `ipAssetRegistry`, `licenseRegistry`, and `moduleRegistry` addresses. If any of these addresses are zero, the constructor will revert and prevent the initialization of the contract.

## Test Plan 
Updated the unit tests to reflect these changes. The tests now cover scenarios where an attempt is made to initialize the `IPAccountRegistry` and `IPAccountStorage` contracts with zero addresses.



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Improved error handling in contract constructors to ensure non-zero addresses for various registries.
  
- **Tests**
  - Added tests to verify that constructors revert with appropriate errors when provided with zero addresses.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->