### PR TITLE
Emit `DefaultLicenseTermsSet` Event and Add Zero Address Check in `setDefaultLicenseTerms`

### DIFF
--- a/contracts/interfaces/registries/ILicenseRegistry.sol
+++ b/contracts/interfaces/registries/ILicenseRegistry.sol
@@ -19,6 +19,9 @@ interface ILicenseRegistry {
         uint256 indexed licenseTermsId
     );
 
+    /// @notice Emitted when set new default license terms.
+    event DefaultLicenseTermsSet(address licenseTemplate, uint256 licenseTermsId);
+
     /// @notice Emitted when a minting license configuration is set for all licenses of an IP.
     event LicensingConfigSetForIP(address indexed ipId, Licensing.LicensingConfig licensingConfig);
 

--- a/contracts/lib/Errors.sol
+++ b/contracts/lib/Errors.sol
@@ -152,6 +152,9 @@ library Errors {
     /// @notice Provided license template and terms ID is a duplicate.
     error LicenseRegistry__DuplicateLicense(address ipId, address licenseTemplate, uint256 licenseTermsId);
 
+    /// @notice Zero address provided for License Template.
+    error LicenseRegistry__ZeroLicenseTemplate();
+
     ////////////////////////////////////////////////////////////////////////////
     //                             License Token                              //
     ////////////////////////////////////////////////////////////////////////////

--- a/contracts/registries/LicenseRegistry.sol
+++ b/contracts/registries/LicenseRegistry.sol
@@ -97,9 +97,16 @@ contract LicenseRegistry is ILicenseRegistry, AccessManagedUpgradeable, UUPSUpgr
     /// @param newLicenseTemplate The address of the new default license template.
     /// @param newLicenseTermsId The ID of the new default license terms.
     function setDefaultLicenseTerms(address newLicenseTemplate, uint256 newLicenseTermsId) external restricted {
+        if (newLicenseTemplate == address(0)) {
+            revert Errors.LicenseRegistry__ZeroLicenseTemplate();
+        }
+        if (!_exists(newLicenseTemplate, newLicenseTermsId)) {
+            revert Errors.LicenseRegistry__LicenseTermsNotExists(newLicenseTemplate, newLicenseTermsId);
+        }
         LicenseRegistryStorage storage $ = _getLicenseRegistryStorage();
         $.defaultLicenseTemplate = newLicenseTemplate;
         $.defaultLicenseTermsId = newLicenseTermsId;
+        emit DefaultLicenseTermsSet(newLicenseTemplate, newLicenseTermsId);
     }
 
     /// @notice Registers a new license template in the Story Protocol.

--- a/test/foundry/registries/LicenseRegistry.t.sol
+++ b/test/foundry/registries/LicenseRegistry.t.sol
@@ -12,6 +12,7 @@ import { MockLicenseTemplate } from "../mocks/module/MockLicenseTemplate.sol";
 import { IPAccountStorageOps } from "../../../contracts/lib/IPAccountStorageOps.sol";
 import { Licensing } from "../../../contracts/lib/Licensing.sol";
 import { PILTerms } from "../../../contracts/interfaces/modules/licensing/IPILicenseTemplate.sol";
+import { ILicenseRegistry } from "contracts/interfaces/registries/ILicenseRegistry.sol";
 
 // test
 import { MockERC721 } from "../mocks/token/MockERC721.sol";
@@ -59,11 +60,24 @@ contract LicenseRegistryTest is BaseTest {
 
     function test_LicenseRegistry_setDefaultLicenseTerms() public {
         uint256 socialRemixTermsId = pilTemplate.registerLicenseTerms(PILFlavors.nonCommercialSocialRemixing());
+        vm.expectEmit();
+        emit ILicenseRegistry.DefaultLicenseTermsSet(address(pilTemplate), socialRemixTermsId);
         vm.prank(admin);
         licenseRegistry.setDefaultLicenseTerms(address(pilTemplate), socialRemixTermsId);
         (address defaultLicenseTemplate, uint256 defaultLicenseTermsId) = licenseRegistry.getDefaultLicenseTerms();
         assertEq(defaultLicenseTemplate, address(pilTemplate));
         assertEq(defaultLicenseTermsId, socialRemixTermsId);
+    }
+
+    function test_LicenseRegistry_setDefaultLicenseTerms_revert() public {
+        vm.expectRevert(
+            abi.encodeWithSelector(Errors.LicenseRegistry__LicenseTermsNotExists.selector, address(pilTemplate), 999)
+        );
+        vm.prank(admin);
+        licenseRegistry.setDefaultLicenseTerms(address(pilTemplate), 999);
+        vm.expectRevert(Errors.LicenseRegistry__ZeroLicenseTemplate.selector);
+        vm.prank(admin);
+        licenseRegistry.setDefaultLicenseTerms(address(0), 999);
     }
 
     // test registerLicenseTemplate


### PR DESCRIPTION
## Description
This PR includes changes that enhance the `setDefaultLicenseTerms` function in the `LicenseRegistry` contract. The function now emits a `DefaultLicenseTermsSet` event when the default license terms are set. Additionally, a check has been added to prevent the setting of default license terms with a zero address of license template.

### Changes:

1. Modified the `setDefaultLicenseTerms` function in the `LicenseRegistry` contract to emit a `DefaultLicenseTermsSet` event when the default license terms are set. This change provides a way to track when and what default license terms are set.

2. Added a check in the `setDefaultLicenseTerms` function to prevent the setting of default license terms with a zero address.

## Test Plan 
Updated the unit tests to reflect these changes. The tests now cover both positive and negative scenarios where an attempt is made to set default license terms with a zero address, and they check for the emission of the `DefaultLicenseTermsSet` event.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Introduced an event `DefaultLicenseTermsSet` to notify when new default license terms are set.

- **Bug Fixes**
  - Added a validation to ensure the license template address is not zero, preventing potential errors.

- **Tests**
  - Enhanced test coverage to include scenarios for setting default license terms and handling invalid inputs.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->