### PR TITLE
TRST-R1 Fix Natspec Comment

### DIFF
--- a/contracts/interfaces/modules/licensing/ILicensingHook.sol
+++ b/contracts/interfaces/modules/licensing/ILicensingHook.sol
@@ -32,7 +32,8 @@ interface ILicensingHook is IModule {
         bytes calldata hookData
     ) external returns (uint256 totalMintingFee);
 
-    /// @notice This function is called when the LicensingModule mints license tokens.
+    /// @notice This function is called before finalizing LicensingModule.registerDerivative(), after calling
+    /// LicenseRegistry.registerDerivative().
     /// @dev The hook can be used to implement various checks and determine the minting price.
     /// The hook should revert if the registering of derivative is not allowed.
     /// @param childIpId The derivative IP ID.


### PR DESCRIPTION
Make comment on `beforeRegisterDerivative` better reflect its behavior.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
  - Updated the description and timing details of a function call in the licensing module to provide clearer instructions and purpose.
  
- **Refactor**
  - Changed the timing of a function call within the licensing interface for better integration and clarity.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->