### PR TITLE
TRST-L-3 Revenue Ceiling Checks

### DIFF
--- a/contracts/interfaces/modules/licensing/IPILicenseTemplate.sol
+++ b/contracts/interfaces/modules/licensing/IPILicenseTemplate.sol
@@ -15,14 +15,14 @@ import { ILicenseTemplate } from "../../../interfaces/modules/licensing/ILicense
 /// then no restrictions is enforced.
 /// @param commercializerCheckerData The data to be passed to the commercializer checker contract.
 /// @param commercialRevShare Percentage of revenue that must be shared with the licensor.
-/// @param commercialRevCelling The maximum revenue that can be generated from the commercial use of the work.
+/// @param commercialRevCeiling The maximum revenue that can be generated from the commercial use of the work.
 /// @param derivativesAllowed Indicates whether the licensee can create derivatives of his work or not.
 /// @param derivativesAttribution Indicates whether attribution is required for derivatives of the work or not.
 /// @param derivativesApproval Indicates whether the licensor must approve derivatives of the work before they can be
 /// linked to the licensor IP ID or not.
 /// @param derivativesReciprocal Indicates whether the licensee must license derivatives of the work under the
 /// same terms or not.
-/// @param derivativeRevCelling The maximum revenue that can be generated from the derivative use of the work.
+/// @param derivativeRevCeiling The maximum revenue that can be generated from the derivative use of the work.
 /// @param currency The ERC20 token to be used to pay the minting fee. the token must be registered in story protocol.
 /// @param uri The URI of the license terms, which can be used to fetch the offchain license terms.
 struct PILTerms {
@@ -35,12 +35,12 @@ struct PILTerms {
     address commercializerChecker;
     bytes commercializerCheckerData;
     uint32 commercialRevShare;
-    uint256 commercialRevCelling;
+    uint256 commercialRevCeiling;
     bool derivativesAllowed;
     bool derivativesAttribution;
     bool derivativesApproval;
     bool derivativesReciprocal;
-    uint256 derivativeRevCelling;
+    uint256 derivativeRevCeiling;
     address currency;
     string uri;
 }

--- a/contracts/lib/PILFlavors.sol
+++ b/contracts/lib/PILFlavors.sol
@@ -109,12 +109,12 @@ library PILFlavors {
                 commercializerChecker: address(0),
                 commercializerCheckerData: EMPTY_BYTES,
                 commercialRevShare: 0,
-                commercialRevCelling: 0,
+                commercialRevCeiling: 0,
                 derivativesAllowed: false,
                 derivativesAttribution: false,
                 derivativesApproval: false,
                 derivativesReciprocal: false,
-                derivativeRevCelling: 0,
+                derivativeRevCeiling: 0,
                 currency: address(0),
                 uri: ""
             });
@@ -133,12 +133,12 @@ library PILFlavors {
                 commercializerChecker: address(0),
                 commercializerCheckerData: EMPTY_BYTES,
                 commercialRevShare: 0,
-                commercialRevCelling: 0,
+                commercialRevCeiling: 0,
                 derivativesAllowed: true,
                 derivativesAttribution: true,
                 derivativesApproval: false,
                 derivativesReciprocal: true,
-                derivativeRevCelling: 0,
+                derivativeRevCeiling: 0,
                 currency: address(0),
                 uri: ""
             });
@@ -161,12 +161,12 @@ library PILFlavors {
                 commercializerChecker: address(0),
                 commercializerCheckerData: EMPTY_BYTES,
                 commercialRevShare: 0,
-                commercialRevCelling: 0,
+                commercialRevCeiling: 0,
                 derivativesAllowed: true,
                 derivativesAttribution: true,
                 derivativesApproval: false,
                 derivativesReciprocal: false,
-                derivativeRevCelling: 0,
+                derivativeRevCeiling: 0,
                 currency: currencyToken,
                 uri: ""
             });
@@ -190,12 +190,12 @@ library PILFlavors {
                 commercializerChecker: address(0),
                 commercializerCheckerData: EMPTY_BYTES,
                 commercialRevShare: commercialRevShare,
-                commercialRevCelling: 0,
+                commercialRevCeiling: 0,
                 derivativesAllowed: true,
                 derivativesAttribution: true,
                 derivativesApproval: false,
                 derivativesReciprocal: true,
-                derivativeRevCelling: 0,
+                derivativeRevCeiling: 0,
                 currency: currencyToken,
                 uri: ""
             });

--- a/contracts/lib/PILicenseTemplateErrors.sol
+++ b/contracts/lib/PILicenseTemplateErrors.sol
@@ -49,7 +49,7 @@ library PILicenseTemplateErrors {
     /// @notice Cannot add derivative reciprocal when derivative use is disabled.
     error PILicenseTemplate__DerivativesDisabled_CantAddReciprocal();
 
-    /// @notice Cannot add derivative revenue share when derivative use is disabled.
+    /// @notice Cannot add derivative revenue ceiling when derivative use is disabled.
     error PILicenseTemplate__DerivativesDisabled_CantAddDerivativeRevCeiling();
 
     /// @notice Zero address provided for License Registry at initialization.

--- a/contracts/lib/PILicenseTemplateErrors.sol
+++ b/contracts/lib/PILicenseTemplateErrors.sol
@@ -31,6 +31,12 @@ library PILicenseTemplateErrors {
     /// @notice Cannot add commercial royalty policy when commercial use is disabled.
     error PILicenseTemplate__CommercialDisabled_CantAddRoyaltyPolicy();
 
+    /// @notice Cannot add commercial revenue ceiling when commercial use is disabled.
+    error PILicenseTemplate__CommercialDisabled_CantAddRevCelling();
+
+    /// @notice Royalty policy is required when commercial use is enabled.
+    error PILicenseTemplate__CommercialDisabled_CantAddDerivativeRevCelling();
+
     /// @notice Royalty policy is required when commercial use is enabled.
     error PILicenseTemplate__CommercialEnabled_RoyaltyPolicyRequired();
 
@@ -42,6 +48,9 @@ library PILicenseTemplateErrors {
 
     /// @notice Cannot add derivative reciprocal when derivative use is disabled.
     error PILicenseTemplate__DerivativesDisabled_CantAddReciprocal();
+
+    /// @notice Cannot add derivative revenue share when derivative use is disabled.
+    error PILicenseTemplate__DerivativesDisabled_CantAddDerivativeRevCelling();
 
     /// @notice Zero address provided for License Registry at initialization.
     error PILicenseTemplate__ZeroLicenseRegistry();

--- a/contracts/lib/PILicenseTemplateErrors.sol
+++ b/contracts/lib/PILicenseTemplateErrors.sol
@@ -34,7 +34,7 @@ library PILicenseTemplateErrors {
     /// @notice Cannot add commercial revenue ceiling when commercial use is disabled.
     error PILicenseTemplate__CommercialDisabled_CantAddRevCeiling();
 
-    /// @notice Royalty policy is required when commercial use is enabled.
+    /// @notice Cannot add derivative rev ceiling share when commercial use is disabled.
     error PILicenseTemplate__CommercialDisabled_CantAddDerivativeRevCeiling();
 
     /// @notice Royalty policy is required when commercial use is enabled.

--- a/contracts/lib/PILicenseTemplateErrors.sol
+++ b/contracts/lib/PILicenseTemplateErrors.sol
@@ -32,10 +32,10 @@ library PILicenseTemplateErrors {
     error PILicenseTemplate__CommercialDisabled_CantAddRoyaltyPolicy();
 
     /// @notice Cannot add commercial revenue ceiling when commercial use is disabled.
-    error PILicenseTemplate__CommercialDisabled_CantAddRevCelling();
+    error PILicenseTemplate__CommercialDisabled_CantAddRevCeiling();
 
     /// @notice Royalty policy is required when commercial use is enabled.
-    error PILicenseTemplate__CommercialDisabled_CantAddDerivativeRevCelling();
+    error PILicenseTemplate__CommercialDisabled_CantAddDerivativeRevCeiling();
 
     /// @notice Royalty policy is required when commercial use is enabled.
     error PILicenseTemplate__CommercialEnabled_RoyaltyPolicyRequired();
@@ -50,7 +50,7 @@ library PILicenseTemplateErrors {
     error PILicenseTemplate__DerivativesDisabled_CantAddReciprocal();
 
     /// @notice Cannot add derivative revenue share when derivative use is disabled.
-    error PILicenseTemplate__DerivativesDisabled_CantAddDerivativeRevCelling();
+    error PILicenseTemplate__DerivativesDisabled_CantAddDerivativeRevCeiling();
 
     /// @notice Zero address provided for License Registry at initialization.
     error PILicenseTemplate__ZeroLicenseRegistry();

--- a/contracts/modules/licensing/PILTermsRenderer.sol
+++ b/contracts/modules/licensing/PILTermsRenderer.sol
@@ -4,22 +4,9 @@ pragma solidity 0.8.23;
 
 // external
 import { Strings } from "@openzeppelin/contracts/utils/Strings.sol";
-import { IERC165 } from "@openzeppelin/contracts/utils/introspection/IERC165.sol";
-import { ERC165Checker } from "@openzeppelin/contracts/utils/introspection/ERC165Checker.sol";
-// solhint-disable-next-line max-line-length
-import { AccessManagedUpgradeable } from "@openzeppelin/contracts-upgradeable/access/manager/AccessManagedUpgradeable.sol";
-import { ReentrancyGuardUpgradeable } from "@openzeppelin/contracts-upgradeable/utils/ReentrancyGuardUpgradeable.sol";
-import { UUPSUpgradeable } from "@openzeppelin/contracts-upgradeable/proxy/utils/UUPSUpgradeable.sol";
 
 // contracts
-import { IHookModule } from "../../interfaces/modules/base/IHookModule.sol";
-import { ILicenseRegistry } from "../../interfaces/registries/ILicenseRegistry.sol";
-import { IRoyaltyModule } from "../../interfaces/modules/royalty/IRoyaltyModule.sol";
-import { PILicenseTemplateErrors } from "../../lib/PILicenseTemplateErrors.sol";
-import { ExpiringOps } from "../../lib/ExpiringOps.sol";
-import { IPILicenseTemplate, PILTerms } from "../../interfaces/modules/licensing/IPILicenseTemplate.sol";
-import { BaseLicenseTemplateUpgradeable } from "../../modules/licensing/BaseLicenseTemplateUpgradeable.sol";
-import { LicensorApprovalChecker } from "../../modules/licensing/parameter-helpers/LicensorApprovalChecker.sol";
+import { PILTerms } from "../../interfaces/modules/licensing/IPILicenseTemplate.sol";
 
 /// @title PILicenseTemplate
 contract PILTermsRenderer {
@@ -29,7 +16,6 @@ contract PILTermsRenderer {
     /// @param terms The PIL terms to encode
     /// @return The JSON string
     function termsToJson(PILTerms memory terms) external pure returns (string memory) {
-
         /* solhint-disable */
         // Follows the OpenSea standard for JSON metadata.
         // **Attributions**

--- a/contracts/modules/licensing/PILTermsRenderer.sol
+++ b/contracts/modules/licensing/PILTermsRenderer.sol
@@ -1,0 +1,112 @@
+// SPDX-License-Identifier: BUSL-1.1
+
+pragma solidity 0.8.23;
+
+// external
+import { Strings } from "@openzeppelin/contracts/utils/Strings.sol";
+import { IERC165 } from "@openzeppelin/contracts/utils/introspection/IERC165.sol";
+import { ERC165Checker } from "@openzeppelin/contracts/utils/introspection/ERC165Checker.sol";
+// solhint-disable-next-line max-line-length
+import { AccessManagedUpgradeable } from "@openzeppelin/contracts-upgradeable/access/manager/AccessManagedUpgradeable.sol";
+import { ReentrancyGuardUpgradeable } from "@openzeppelin/contracts-upgradeable/utils/ReentrancyGuardUpgradeable.sol";
+import { UUPSUpgradeable } from "@openzeppelin/contracts-upgradeable/proxy/utils/UUPSUpgradeable.sol";
+
+// contracts
+import { IHookModule } from "../../interfaces/modules/base/IHookModule.sol";
+import { ILicenseRegistry } from "../../interfaces/registries/ILicenseRegistry.sol";
+import { IRoyaltyModule } from "../../interfaces/modules/royalty/IRoyaltyModule.sol";
+import { PILicenseTemplateErrors } from "../../lib/PILicenseTemplateErrors.sol";
+import { ExpiringOps } from "../../lib/ExpiringOps.sol";
+import { IPILicenseTemplate, PILTerms } from "../../interfaces/modules/licensing/IPILicenseTemplate.sol";
+import { BaseLicenseTemplateUpgradeable } from "../../modules/licensing/BaseLicenseTemplateUpgradeable.sol";
+import { LicensorApprovalChecker } from "../../modules/licensing/parameter-helpers/LicensorApprovalChecker.sol";
+
+/// @title PILicenseTemplate
+contract PILTermsRenderer {
+    using Strings for *;
+
+    /// @notice Encodes the PIL terms into a JSON string on the OpenSea standard
+    /// @param terms The PIL terms to encode
+    /// @return The JSON string
+    function termsToJson(PILTerms memory terms) external pure returns (string memory) {
+
+        /* solhint-disable */
+        // Follows the OpenSea standard for JSON metadata.
+        // **Attributions**
+        string memory json = string(
+            abi.encodePacked(
+                '{"trait_type": "Expiration", "value": "',
+                terms.expiration == 0 ? "never" : terms.expiration.toString(),
+                '"},',
+                '{"trait_type": "Currency", "value": "',
+                terms.currency.toHexString(),
+                '"},',
+                '{"trait_type": "URI", "value": "',
+                terms.uri,
+                '"},',
+                // Skip transferable, it's already added in the common attributes by the LicenseRegistry.
+                _policyCommercialTraitsToJson(terms),
+                _policyDerivativeTraitsToJson(terms)
+            )
+        );
+
+        // NOTE: (above) last trait added by LicenseTemplate should have a comma at the end.
+
+        /* solhint-enable */
+
+        return json;
+    }
+
+    /// @dev Encodes the commercial traits of PIL policy into a JSON string for OpenSea
+    function _policyCommercialTraitsToJson(PILTerms memory terms) internal pure returns (string memory) {
+        /* solhint-disable */
+        return
+            string(
+                abi.encodePacked(
+                    '{"trait_type": "Commercial Use", "value": "',
+                    terms.commercialUse ? "true" : "false",
+                    '"},',
+                    '{"trait_type": "Commercial Attribution", "value": "',
+                    terms.commercialAttribution ? "true" : "false",
+                    '"},',
+                    '{"trait_type": "Commercial Revenue Share", "max_value": 1000, "value": ',
+                    terms.commercialRevShare.toString(),
+                    "},",
+                    '{"trait_type": "Commercial Revenue Ceiling", "value": ',
+                    terms.commercialRevCeiling.toString(),
+                    "},",
+                    '{"trait_type": "Commercializer Check", "value": "',
+                    terms.commercializerChecker.toHexString(),
+                    // Skip on commercializerCheckerData as it's bytes as irrelevant for the user metadata
+                    '"},'
+                )
+            );
+        /* solhint-enable */
+    }
+
+    /// @dev Encodes the derivative traits of PILTerm into a JSON string for OpenSea
+    function _policyDerivativeTraitsToJson(PILTerms memory terms) internal pure returns (string memory) {
+        /* solhint-disable */
+        return
+            string(
+                abi.encodePacked(
+                    '{"trait_type": "Derivatives Allowed", "value": "',
+                    terms.derivativesAllowed ? "true" : "false",
+                    '"},',
+                    '{"trait_type": "Derivatives Attribution", "value": "',
+                    terms.derivativesAttribution ? "true" : "false",
+                    '"},',
+                    '{"trait_type": "Derivatives Revenue Ceiling", "value": ',
+                    terms.derivativeRevCeiling.toString(),
+                    "},",
+                    '{"trait_type": "Derivatives Approval", "value": "',
+                    terms.derivativesApproval ? "true" : "false",
+                    '"},',
+                    '{"trait_type": "Derivatives Reciprocal", "value": "',
+                    terms.derivativesReciprocal ? "true" : "false",
+                    '"},'
+                )
+            );
+        /* solhint-enable */
+    }
+}

--- a/contracts/modules/licensing/PILicenseTemplate.sol
+++ b/contracts/modules/licensing/PILicenseTemplate.sol
@@ -20,6 +20,7 @@ import { ExpiringOps } from "../../lib/ExpiringOps.sol";
 import { IPILicenseTemplate, PILTerms } from "../../interfaces/modules/licensing/IPILicenseTemplate.sol";
 import { BaseLicenseTemplateUpgradeable } from "../../modules/licensing/BaseLicenseTemplateUpgradeable.sol";
 import { LicensorApprovalChecker } from "../../modules/licensing/parameter-helpers/LicensorApprovalChecker.sol";
+import { PILTermsRenderer } from "./PILTermsRenderer.sol";
 
 /// @title PILicenseTemplate
 contract PILicenseTemplate is
@@ -45,6 +46,9 @@ contract PILicenseTemplate is
     ILicenseRegistry public immutable LICENSE_REGISTRY;
     /// @custom:oz-upgrades-unsafe-allow state-variable-immutable
     IRoyaltyModule public immutable ROYALTY_MODULE;
+    /// @custom:oz-upgrades-unsafe-allow state-variable-immutable
+    PILTermsRenderer public immutable TERMS_RENDERER;
+
 
     // keccak256(abi.encode(uint256(keccak256("story-protocol.PILicenseTemplate")) - 1)) & ~bytes32(uint256(0xff));
     bytes32 private constant PILicenseTemplateStorageLocation =
@@ -61,6 +65,7 @@ contract PILicenseTemplate is
         if (royaltyModule == address(0)) revert PILicenseTemplateErrors.PILicenseTemplate__ZeroRoyaltyModule();
         LICENSE_REGISTRY = ILicenseRegistry(licenseRegistry);
         ROYALTY_MODULE = IRoyaltyModule(royaltyModule);
+        TERMS_RENDERER = new PILTermsRenderer();
         _disableInitializers();
     }
 
@@ -299,85 +304,7 @@ contract PILicenseTemplate is
     /// @return The JSON string of the license terms, follow the OpenSea metadata standard.
     function toJson(uint256 licenseTermsId) public view returns (string memory) {
         PILTerms memory terms = _getPILicenseTemplateStorage().licenseTerms[licenseTermsId];
-
-        /* solhint-disable */
-        // Follows the OpenSea standard for JSON metadata.
-        // **Attributions**
-        string memory json = string(
-            abi.encodePacked(
-                '{"trait_type": "Expiration", "value": "',
-                terms.expiration == 0 ? "never" : terms.expiration.toString(),
-                '"},',
-                '{"trait_type": "Currency", "value": "',
-                terms.currency.toHexString(),
-                '"},',
-                '{"trait_type": "URI", "value": "',
-                terms.uri,
-                '"},',
-                // Skip transferable, it's already added in the common attributes by the LicenseRegistry.
-                _policyCommercialTraitsToJson(terms),
-                _policyDerivativeTraitsToJson(terms)
-            )
-        );
-
-        // NOTE: (above) last trait added by LicenseTemplate should have a comma at the end.
-
-        /* solhint-enable */
-
-        return json;
-    }
-
-    /// @dev Encodes the commercial traits of PIL policy into a JSON string for OpenSea
-    function _policyCommercialTraitsToJson(PILTerms memory terms) internal pure returns (string memory) {
-        /* solhint-disable */
-        return
-            string(
-                abi.encodePacked(
-                    '{"trait_type": "Commercial Use", "value": "',
-                    terms.commercialUse ? "true" : "false",
-                    '"},',
-                    '{"trait_type": "Commercial Attribution", "value": "',
-                    terms.commercialAttribution ? "true" : "false",
-                    '"},',
-                    '{"trait_type": "Commercial Revenue Share", "max_value": 1000, "value": ',
-                    terms.commercialRevShare.toString(),
-                    "},",
-                    '{"trait_type": "Commercial Revenue Ceiling", "value": ',
-                    terms.commercialRevCeiling.toString(),
-                    "},",
-                    '{"trait_type": "Commercializer Check", "value": "',
-                    terms.commercializerChecker.toHexString(),
-                    // Skip on commercializerCheckerData as it's bytes as irrelevant for the user metadata
-                    '"},'
-                )
-            );
-        /* solhint-enable */
-    }
-
-    /// @dev Encodes the derivative traits of PILTerm into a JSON string for OpenSea
-    function _policyDerivativeTraitsToJson(PILTerms memory terms) internal pure returns (string memory) {
-        /* solhint-disable */
-        return
-            string(
-                abi.encodePacked(
-                    '{"trait_type": "Derivatives Allowed", "value": "',
-                    terms.derivativesAllowed ? "true" : "false",
-                    '"},',
-                    '{"trait_type": "Derivatives Attribution", "value": "',
-                    terms.derivativesAttribution ? "true" : "false",
-                    '"},',
-                    '{"trait_type": "Derivatives Revenue Ceiling", "value": ',
-                    terms.derivativeRevCeiling.toString(),
-                    "},",
-                    '{"trait_type": "Derivatives Approval", "value": "',
-                    terms.derivativesApproval ? "true" : "false",
-                    '"},',
-                    '{"trait_type": "Derivatives Reciprocal", "value": "',
-                    terms.derivativesReciprocal ? "true" : "false",
-                    '"},'
-                )
-            );
-        /* solhint-enable */
+        return TERMS_RENDERER.termsToJson(terms);
     }
 
     /// @dev Checks the configuration of commercial use and throws if the policy is not compliant

--- a/contracts/modules/licensing/PILicenseTemplate.sol
+++ b/contracts/modules/licensing/PILicenseTemplate.sol
@@ -49,7 +49,6 @@ contract PILicenseTemplate is
     /// @custom:oz-upgrades-unsafe-allow state-variable-immutable
     PILTermsRenderer public immutable TERMS_RENDERER;
 
-
     // keccak256(abi.encode(uint256(keccak256("story-protocol.PILicenseTemplate")) - 1)) & ~bytes32(uint256(0xff));
     bytes32 private constant PILicenseTemplateStorageLocation =
         0xc6c6991297bc120d0383f0017fab72b8ca34fd4849ed6478dbaac67a33c3a700;

--- a/contracts/modules/licensing/PILicenseTemplate.sol
+++ b/contracts/modules/licensing/PILicenseTemplate.sol
@@ -393,6 +393,12 @@ contract PILicenseTemplate is
             if (terms.commercialRevShare > 0) {
                 revert PILicenseTemplateErrors.PILicenseTemplate__CommercialDisabled_CantAddRevShare();
             }
+            if (terms.commercialRevCelling > 0) {
+                revert PILicenseTemplateErrors.PILicenseTemplate__CommercialDisabled_CantAddRevCelling();
+            }
+            if (terms.derivativeRevCelling > 0) {
+                revert PILicenseTemplateErrors.PILicenseTemplate__CommercialDisabled_CantAddDerivativeRevCelling();
+            }
             if (terms.royaltyPolicy != address(0)) {
                 revert PILicenseTemplateErrors.PILicenseTemplate__CommercialDisabled_CantAddRoyaltyPolicy();
             }
@@ -422,6 +428,9 @@ contract PILicenseTemplate is
             }
             if (terms.derivativesReciprocal) {
                 revert PILicenseTemplateErrors.PILicenseTemplate__DerivativesDisabled_CantAddReciprocal();
+            }
+            if (terms.derivativeRevCelling > 0) {
+                revert PILicenseTemplateErrors.PILicenseTemplate__DerivativesDisabled_CantAddDerivativeRevCelling();
             }
         }
     }

--- a/contracts/modules/licensing/PILicenseTemplate.sol
+++ b/contracts/modules/licensing/PILicenseTemplate.sol
@@ -342,8 +342,8 @@ contract PILicenseTemplate is
                     '{"trait_type": "Commercial Revenue Share", "max_value": 1000, "value": ',
                     terms.commercialRevShare.toString(),
                     "},",
-                    '{"trait_type": "Commercial Revenue Celling", "value": ',
-                    terms.commercialRevCelling.toString(),
+                    '{"trait_type": "Commercial Revenue Ceiling", "value": ',
+                    terms.commercialRevCeiling.toString(),
                     "},",
                     '{"trait_type": "Commercializer Check", "value": "',
                     terms.commercializerChecker.toHexString(),
@@ -366,8 +366,8 @@ contract PILicenseTemplate is
                     '{"trait_type": "Derivatives Attribution", "value": "',
                     terms.derivativesAttribution ? "true" : "false",
                     '"},',
-                    '{"trait_type": "Derivatives Revenue Celling", "value": ',
-                    terms.derivativeRevCelling.toString(),
+                    '{"trait_type": "Derivatives Revenue Ceiling", "value": ',
+                    terms.derivativeRevCeiling.toString(),
                     "},",
                     '{"trait_type": "Derivatives Approval", "value": "',
                     terms.derivativesApproval ? "true" : "false",
@@ -393,11 +393,11 @@ contract PILicenseTemplate is
             if (terms.commercialRevShare > 0) {
                 revert PILicenseTemplateErrors.PILicenseTemplate__CommercialDisabled_CantAddRevShare();
             }
-            if (terms.commercialRevCelling > 0) {
-                revert PILicenseTemplateErrors.PILicenseTemplate__CommercialDisabled_CantAddRevCelling();
+            if (terms.commercialRevCeiling > 0) {
+                revert PILicenseTemplateErrors.PILicenseTemplate__CommercialDisabled_CantAddRevCeiling();
             }
-            if (terms.derivativeRevCelling > 0) {
-                revert PILicenseTemplateErrors.PILicenseTemplate__CommercialDisabled_CantAddDerivativeRevCelling();
+            if (terms.derivativeRevCeiling > 0) {
+                revert PILicenseTemplateErrors.PILicenseTemplate__CommercialDisabled_CantAddDerivativeRevCeiling();
             }
             if (terms.royaltyPolicy != address(0)) {
                 revert PILicenseTemplateErrors.PILicenseTemplate__CommercialDisabled_CantAddRoyaltyPolicy();
@@ -429,8 +429,8 @@ contract PILicenseTemplate is
             if (terms.derivativesReciprocal) {
                 revert PILicenseTemplateErrors.PILicenseTemplate__DerivativesDisabled_CantAddReciprocal();
             }
-            if (terms.derivativeRevCelling > 0) {
-                revert PILicenseTemplateErrors.PILicenseTemplate__DerivativesDisabled_CantAddDerivativeRevCelling();
+            if (terms.derivativeRevCeiling > 0) {
+                revert PILicenseTemplateErrors.PILicenseTemplate__DerivativesDisabled_CantAddDerivativeRevCeiling();
             }
         }
     }

--- a/test/foundry/IPAccount.t.sol
+++ b/test/foundry/IPAccount.t.sol
@@ -136,7 +136,7 @@ contract IPAccountTest is BaseTest {
 
         mockNFT.mintId(owner, tokenId);
 
-        address account = ipAssetRegistry.registerIpAccount(block.chainid, address(mockNFT), tokenId);
+        address account = mockIpAccountRegistry.registerIpAccount(block.chainid, address(mockNFT), tokenId);
 
         IIPAccount ipAccount = IIPAccount(payable(account));
 
@@ -165,7 +165,7 @@ contract IPAccountTest is BaseTest {
 
         mockNFT.mintId(owner, tokenId);
 
-        address account = ipAssetRegistry.registerIpAccount(block.chainid, address(mockNFT), tokenId);
+        address account = mockIpAccountRegistry.registerIpAccount(block.chainid, address(mockNFT), tokenId);
 
         IIPAccount ipAccount = IIPAccount(payable(account));
 

--- a/test/foundry/LicenseToken.t.sol
+++ b/test/foundry/LicenseToken.t.sol
@@ -118,12 +118,12 @@ contract LicenseTokenTest is BaseTest {
                 commercializerChecker: address(0),
                 commercializerCheckerData: "",
                 commercialRevShare: 0,
-                commercialRevCelling: 0,
+                commercialRevCeiling: 0,
                 derivativesAllowed: true,
                 derivativesAttribution: true,
                 derivativesApproval: false,
                 derivativesReciprocal: true,
-                derivativeRevCelling: 0,
+                derivativeRevCeiling: 0,
                 currency: address(USDC),
                 uri: ""
             })
@@ -168,7 +168,7 @@ contract LicenseTokenTest is BaseTest {
         );
         expectedURI = abi.encodePacked(
             expectedURI,
-            ',"attributes": [{"trait_type": "Expiration", "value": "never"},{"trait_type": "Currency", "value": "0x0000000000000000000000000000000000000000"},{"trait_type": "URI", "value": ""},{"trait_type": "Commercial Use", "value": "false"},{"trait_type": "Commercial Attribution", "value": "false"},{"trait_type": "Commercial Revenue Share", "max_value": 1000, "value": 0},{"trait_type": "Commercial Revenue Celling", "value": 0},{"trait_type": "Commercializer Check", "value": "0x0000000000000000000000000000000000000000"},{"trait_type": "Derivatives Allowed", "value": "true"},{"trait_type": "Derivatives Attribution", "value": "true"},{"trait_type": "Derivatives Revenue Celling", "value": 0},{"trait_type": "Derivatives Approval", "value": "false"},{"trait_type": "Derivatives Reciprocal", "value": "true"}'
+            ',"attributes": [{"trait_type": "Expiration", "value": "never"},{"trait_type": "Currency", "value": "0x0000000000000000000000000000000000000000"},{"trait_type": "URI", "value": ""},{"trait_type": "Commercial Use", "value": "false"},{"trait_type": "Commercial Attribution", "value": "false"},{"trait_type": "Commercial Revenue Share", "max_value": 1000, "value": 0},{"trait_type": "Commercial Revenue Ceiling", "value": 0},{"trait_type": "Commercializer Check", "value": "0x0000000000000000000000000000000000000000"},{"trait_type": "Derivatives Allowed", "value": "true"},{"trait_type": "Derivatives Attribution", "value": "true"},{"trait_type": "Derivatives Revenue Ceiling", "value": 0},{"trait_type": "Derivatives Approval", "value": "false"},{"trait_type": "Derivatives Reciprocal", "value": "true"}'
         );
         expectedURI = abi.encodePacked(
             expectedURI,

--- a/test/foundry/integration/big-bang/SingleNftCollection.t.sol
+++ b/test/foundry/integration/big-bang/SingleNftCollection.t.sol
@@ -51,12 +51,12 @@ contract BigBang_Integration_SingleNftCollection is BaseIntegration {
                 // Gated via balance > 1 of mockGatedNft
                 commercializerCheckerData: abi.encode(address(mockGatedNft)),
                 commercialRevShare: derivCheapFlexibleRevShare,
-                commercialRevCelling: 0,
+                commercialRevCeiling: 0,
                 derivativesAllowed: true,
                 derivativesAttribution: false,
                 derivativesApproval: false,
                 derivativesReciprocal: false,
-                derivativeRevCelling: 0,
+                derivativeRevCeiling: 0,
                 currency: address(erc20),
                 uri: ""
             })

--- a/test/foundry/modules/dispute/btt/DisputeModule.actions.tree
+++ b/test/foundry/modules/dispute/btt/DisputeModule.actions.tree
@@ -38,7 +38,7 @@ DisputeModule.sol:actions
 │                   ├── it should call arbitration policy hook
 │                   ├── it should emit an event
 │                   └── it should succeed
-├── when cancelling dispute
+├── when canCeiling dispute
 │   ├── when dispute ID is not IN_DISPUTE
 │   │   └── it should revert
 │   └── when dispute ID is IN_DISPUTE

--- a/test/foundry/modules/dispute/btt/DisputeModule.actions.tree
+++ b/test/foundry/modules/dispute/btt/DisputeModule.actions.tree
@@ -38,7 +38,7 @@ DisputeModule.sol:actions
 │                   ├── it should call arbitration policy hook
 │                   ├── it should emit an event
 │                   └── it should succeed
-├── when canCeiling dispute
+├── when canceling dispute
 │   ├── when dispute ID is not IN_DISPUTE
 │   │   └── it should revert
 │   └── when dispute ID is IN_DISPUTE

--- a/test/foundry/modules/licensing/LicensingModule.t.sol
+++ b/test/foundry/modules/licensing/LicensingModule.t.sol
@@ -182,12 +182,12 @@ contract LicensingModuleTest is BaseTest {
             commercializerChecker: address(0),
             commercializerCheckerData: "",
             commercialRevShare: 0,
-            commercialRevCelling: 0,
+            commercialRevCeiling: 0,
             derivativesAllowed: true,
             derivativesAttribution: true,
             derivativesApproval: false,
             derivativesReciprocal: true,
-            derivativeRevCelling: 0,
+            derivativeRevCeiling: 0,
             currency: address(0x123),
             uri: ""
         });
@@ -426,12 +426,12 @@ contract LicensingModuleTest is BaseTest {
             commercializerChecker: address(0),
             commercializerCheckerData: "",
             commercialRevShare: 0,
-            commercialRevCelling: 0,
+            commercialRevCeiling: 0,
             derivativesAllowed: true,
             derivativesAttribution: true,
             derivativesApproval: false,
             derivativesReciprocal: true,
-            derivativeRevCelling: 0,
+            derivativeRevCeiling: 0,
             currency: address(0x123),
             uri: ""
         });
@@ -1036,12 +1036,12 @@ contract LicensingModuleTest is BaseTest {
             commercializerChecker: address(tokenGatedHook),
             commercializerCheckerData: abi.encode(address(gatedNftBar)),
             commercialRevShare: 0,
-            commercialRevCelling: 0,
+            commercialRevCeiling: 0,
             derivativesAllowed: true,
             derivativesAttribution: true,
             derivativesApproval: false,
             derivativesReciprocal: true,
-            derivativeRevCelling: 0,
+            derivativeRevCeiling: 0,
             currency: address(0x123),
             uri: ""
         });
@@ -1085,12 +1085,12 @@ contract LicensingModuleTest is BaseTest {
             commercializerChecker: address(tokenGatedHook),
             commercializerCheckerData: abi.encode(address(gatedNftBar)),
             commercialRevShare: 0,
-            commercialRevCelling: 0,
+            commercialRevCeiling: 0,
             derivativesAllowed: true,
             derivativesAttribution: true,
             derivativesApproval: false,
             derivativesReciprocal: true,
-            derivativeRevCelling: 0,
+            derivativeRevCeiling: 0,
             currency: address(0x123),
             uri: ""
         });
@@ -1132,12 +1132,12 @@ contract LicensingModuleTest is BaseTest {
             commercializerChecker: address(tokenGatedHook),
             commercializerCheckerData: abi.encode(address(gatedNftBar)),
             commercialRevShare: 0,
-            commercialRevCelling: 0,
+            commercialRevCeiling: 0,
             derivativesAllowed: true,
             derivativesAttribution: true,
             derivativesApproval: false,
             derivativesReciprocal: true,
-            derivativeRevCelling: 0,
+            derivativeRevCeiling: 0,
             currency: address(0x123),
             uri: ""
         });

--- a/test/foundry/modules/licensing/LicensingModule.t.sol
+++ b/test/foundry/modules/licensing/LicensingModule.t.sol
@@ -462,9 +462,7 @@ contract LicensingModuleTest is BaseTest {
         vm.prank(ipOwner1);
         licensingModule.attachLicenseTerms(ipId1, address(pilTemplate), termsId);
 
-        vm.expectRevert(
-            abi.encodeWithSelector(Errors.LicensingModule__LicensorIpNotRegistered.selector)
-        );
+        vm.expectRevert(abi.encodeWithSelector(Errors.LicensingModule__LicensorIpNotRegistered.selector));
         uint256 lcTokenId = licensingModule.mintLicenseTokens({
             licensorIpId: address(0x123),
             licenseTemplate: address(pilTemplate),
@@ -474,7 +472,6 @@ contract LicensingModuleTest is BaseTest {
             royaltyContext: ""
         });
     }
-
 
     function test_LicensingModule_mintLicenseTokens_revert_invalidInputs() public {
         uint256 termsId = pilTemplate.registerLicenseTerms(PILFlavors.defaultValuesLicenseTerms());

--- a/test/foundry/modules/licensing/LicensingModule.t.sol
+++ b/test/foundry/modules/licensing/LicensingModule.t.sol
@@ -633,7 +633,7 @@ contract LicensingModuleTest is BaseTest {
     function test_LicensingModule_registerDerivativeWithLicenseTokens_revert_pause() public {
         uint256 termsId = pilTemplate.registerLicenseTerms(PILFlavors.nonCommercialSocialRemixing());
         vm.prank(ipOwner1);
-        
+
         licensingModule.attachLicenseTerms(ipId1, address(pilTemplate), termsId);
 
         uint256 lcTokenId = licensingModule.mintLicenseTokens({

--- a/test/foundry/modules/licensing/PILicenseTemplate.t.sol
+++ b/test/foundry/modules/licensing/PILicenseTemplate.t.sol
@@ -142,7 +142,9 @@ contract PILicenseTemplateTest is BaseTest {
 
         terms.commercialRevCeiling = 0;
         terms.derivativeRevCeiling = 10;
-        vm.expectRevert(PILicenseTemplateErrors.PILicenseTemplate__CommercialDisabled_CantAddDerivativeRevCeiling.selector);
+        vm.expectRevert(
+            PILicenseTemplateErrors.PILicenseTemplate__CommercialDisabled_CantAddDerivativeRevCeiling.selector
+        );
         pilTemplate.registerLicenseTerms(terms);
 
         terms.commercialRevCeiling = 0;
@@ -151,7 +153,9 @@ contract PILicenseTemplateTest is BaseTest {
         terms.currency = address(erc20);
         terms.derivativesAllowed = false;
         terms.derivativeRevCeiling = 10;
-        vm.expectRevert(PILicenseTemplateErrors.PILicenseTemplate__DerivativesDisabled_CantAddDerivativeRevCeiling.selector);
+        vm.expectRevert(
+            PILicenseTemplateErrors.PILicenseTemplate__DerivativesDisabled_CantAddDerivativeRevCeiling.selector
+        );
         pilTemplate.registerLicenseTerms(terms);
     }
 

--- a/test/foundry/modules/licensing/PILicenseTemplate.t.sol
+++ b/test/foundry/modules/licensing/PILicenseTemplate.t.sol
@@ -136,22 +136,22 @@ contract PILicenseTemplateTest is BaseTest {
 
     function test_PILicenseTemplate_revert_registerRevCeiling() public {
         PILTerms memory terms = PILFlavors.defaultValuesLicenseTerms();
-        terms.commercialRevCelling = 10;
-        vm.expectRevert(PILicenseTemplateErrors.PILicenseTemplate__CommercialDisabled_CantAddRevCelling.selector);
+        terms.commercialRevCeiling = 10;
+        vm.expectRevert(PILicenseTemplateErrors.PILicenseTemplate__CommercialDisabled_CantAddRevCeiling.selector);
         pilTemplate.registerLicenseTerms(terms);
 
-        terms.commercialRevCelling = 0;
-        terms.derivativeRevCelling = 10;
-        vm.expectRevert(PILicenseTemplateErrors.PILicenseTemplate__CommercialDisabled_CantAddDerivativeRevCelling.selector);
+        terms.commercialRevCeiling = 0;
+        terms.derivativeRevCeiling = 10;
+        vm.expectRevert(PILicenseTemplateErrors.PILicenseTemplate__CommercialDisabled_CantAddDerivativeRevCeiling.selector);
         pilTemplate.registerLicenseTerms(terms);
 
-        terms.commercialRevCelling = 0;
+        terms.commercialRevCeiling = 0;
         terms.commercialUse = true;
         terms.royaltyPolicy = address(royaltyPolicyLAP);
         terms.currency = address(erc20);
         terms.derivativesAllowed = false;
-        terms.derivativeRevCelling = 10;
-        vm.expectRevert(PILicenseTemplateErrors.PILicenseTemplate__DerivativesDisabled_CantAddDerivativeRevCelling.selector);
+        terms.derivativeRevCeiling = 10;
+        vm.expectRevert(PILicenseTemplateErrors.PILicenseTemplate__DerivativesDisabled_CantAddDerivativeRevCeiling.selector);
         pilTemplate.registerLicenseTerms(terms);
     }
 
@@ -593,7 +593,7 @@ contract PILicenseTemplateTest is BaseTest {
     function _DefaultToJson() internal pure returns (string memory) {
         /* solhint-disable */
         return
-            '{"trait_type": "Expiration", "value": "never"},{"trait_type": "Currency", "value": "0x0000000000000000000000000000000000000000"},{"trait_type": "URI", "value": ""},{"trait_type": "Commercial Use", "value": "false"},{"trait_type": "Commercial Attribution", "value": "false"},{"trait_type": "Commercial Revenue Share", "max_value": 1000, "value": 0},{"trait_type": "Commercial Revenue Celling", "value": 0},{"trait_type": "Commercializer Check", "value": "0x0000000000000000000000000000000000000000"},{"trait_type": "Derivatives Allowed", "value": "false"},{"trait_type": "Derivatives Attribution", "value": "false"},{"trait_type": "Derivatives Revenue Celling", "value": 0},{"trait_type": "Derivatives Approval", "value": "false"},{"trait_type": "Derivatives Reciprocal", "value": "false"},';
+            '{"trait_type": "Expiration", "value": "never"},{"trait_type": "Currency", "value": "0x0000000000000000000000000000000000000000"},{"trait_type": "URI", "value": ""},{"trait_type": "Commercial Use", "value": "false"},{"trait_type": "Commercial Attribution", "value": "false"},{"trait_type": "Commercial Revenue Share", "max_value": 1000, "value": 0},{"trait_type": "Commercial Revenue Ceiling", "value": 0},{"trait_type": "Commercializer Check", "value": "0x0000000000000000000000000000000000000000"},{"trait_type": "Derivatives Allowed", "value": "false"},{"trait_type": "Derivatives Attribution", "value": "false"},{"trait_type": "Derivatives Revenue Ceiling", "value": 0},{"trait_type": "Derivatives Approval", "value": "false"},{"trait_type": "Derivatives Reciprocal", "value": "false"},';
         /* solhint-enable */
     }
 }

--- a/test/foundry/modules/licensing/PILicenseTemplate.t.sol
+++ b/test/foundry/modules/licensing/PILicenseTemplate.t.sol
@@ -133,6 +133,28 @@ contract PILicenseTemplateTest is BaseTest {
 
         assertEq(pilTemplate.toJson(defaultTermsId), _DefaultToJson());
     }
+
+    function test_PILicenseTemplate_revert_registerRevCeiling() public {
+        PILTerms memory terms = PILFlavors.defaultValuesLicenseTerms();
+        terms.commercialRevCelling = 10;
+        vm.expectRevert(PILicenseTemplateErrors.PILicenseTemplate__CommercialDisabled_CantAddRevCelling.selector);
+        pilTemplate.registerLicenseTerms(terms);
+
+        terms.commercialRevCelling = 0;
+        terms.derivativeRevCelling = 10;
+        vm.expectRevert(PILicenseTemplateErrors.PILicenseTemplate__CommercialDisabled_CantAddDerivativeRevCelling.selector);
+        pilTemplate.registerLicenseTerms(terms);
+
+        terms.commercialRevCelling = 0;
+        terms.commercialUse = true;
+        terms.royaltyPolicy = address(royaltyPolicyLAP);
+        terms.currency = address(erc20);
+        terms.derivativesAllowed = false;
+        terms.derivativeRevCelling = 10;
+        vm.expectRevert(PILicenseTemplateErrors.PILicenseTemplate__DerivativesDisabled_CantAddDerivativeRevCelling.selector);
+        pilTemplate.registerLicenseTerms(terms);
+    }
+
     // register license terms twice
     function test_PILicenseTemplate_registerLicenseTerms_twice() public {
         uint256 defaultTermsId = pilTemplate.registerLicenseTerms(PILFlavors.defaultValuesLicenseTerms());

--- a/test/foundry/utils/LicensingHelper.t.sol
+++ b/test/foundry/utils/LicensingHelper.t.sol
@@ -92,12 +92,12 @@ contract LicensingHelper {
                 commercializerChecker: address(0),
                 commercializerCheckerData: "",
                 commercialRevShare: commercialRevShare,
-                commercialRevCelling: 0,
+                commercialRevCeiling: 0,
                 derivativesAllowed: derivatives,
                 derivativesAttribution: false,
                 derivativesApproval: false,
                 derivativesReciprocal: reciprocal,
-                derivativeRevCelling: 0,
+                derivativeRevCeiling: 0,
                 currency: address(erc20),
                 uri: ""
             });
@@ -119,12 +119,12 @@ contract LicensingHelper {
                 commercializerChecker: address(0),
                 commercializerCheckerData: "",
                 commercialRevShare: 0,
-                commercialRevCelling: 0,
+                commercialRevCeiling: 0,
                 derivativesAllowed: derivatives,
                 derivativesAttribution: false,
                 derivativesApproval: false,
                 derivativesReciprocal: reciprocal,
-                derivativeRevCelling: 0,
+                derivativeRevCeiling: 0,
                 currency: address(0),
                 uri: ""
             });


### PR DESCRIPTION
Adds test on PILTerms registration to avoid having:
- commercial rev ceilings when terms are non commercial
- derivatives rev ceilings when terms are non commercial
- derivatives rev ceilings when derivatives are not allowed

Also fixing a typo (celling -> ceiling)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Introduced a new contract `PILTermsRenderer` to encode PIL terms into JSON for OpenSea.

- **Bug Fixes**
  - Corrected typos in variables and function names related to revenue ceilings and dispute actions across various contracts and libraries.
  - Updated test scenarios to reflect corrected variable names.

- **Tests**
  - Added a new test function `test_PILicenseTemplate_revert_registerRevCeiling` to ensure proper handling of license terms and relevant conditions.
  - Modified the registration method in `IPAccountTest` to use `mockIpAccountRegistry.registerIpAccount`.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->