### PR TITLE
TRST-L-4 Mint Tokens To Registered Licensor

### DIFF
--- a/contracts/lib/Errors.sol
+++ b/contracts/lib/Errors.sol
@@ -196,6 +196,9 @@ library Errors {
     /// @notice Mint amount is zero.
     error LicensingModule__MintAmountZero();
 
+    /// @notice minting a license for non-registered IP.
+    error LicensingModule__LicensorIpNotRegistered();
+
     /// @notice IP is dispute tagged.
     error LicensingModule__DisputedIpId();
 

--- a/contracts/modules/licensing/LicensingModule.sol
+++ b/contracts/modules/licensing/LicensingModule.sol
@@ -163,7 +163,9 @@ contract LicensingModule is
         if (receiver == address(0)) {
             revert Errors.LicensingModule__ReceiverZeroAddress();
         }
-
+        if (!IP_ACCOUNT_REGISTRY.isIpAccount(licensorIpId)) {
+            revert Errors.LicensingModule__LicensorIpNotRegistered();
+        }
         _verifyIpNotDisputed(licensorIpId);
         Licensing.LicensingConfig memory lsc = LICENSE_REGISTRY.verifyMintLicenseToken(
             licensorIpId,

--- a/test/foundry/modules/licensing/LicensingModule.t.sol
+++ b/test/foundry/modules/licensing/LicensingModule.t.sol
@@ -457,6 +457,25 @@ contract LicensingModuleTest is BaseTest {
         assertEq(licenseToken.balanceOf(ipOwner2), 1);
     }
 
+    function test_LicensingModule_mintLicenseTokens_revert_licensorIpNotRegistered() public {
+        uint256 termsId = pilTemplate.registerLicenseTerms(PILFlavors.defaultValuesLicenseTerms());
+        vm.prank(ipOwner1);
+        licensingModule.attachLicenseTerms(ipId1, address(pilTemplate), termsId);
+
+        vm.expectRevert(
+            abi.encodeWithSelector(Errors.LicensingModule__LicensorIpNotRegistered.selector)
+        );
+        uint256 lcTokenId = licensingModule.mintLicenseTokens({
+            licensorIpId: address(0x123),
+            licenseTemplate: address(pilTemplate),
+            licenseTermsId: termsId,
+            amount: 1,
+            receiver: address(0x777),
+            royaltyContext: ""
+        });
+    }
+
+
     function test_LicensingModule_mintLicenseTokens_revert_invalidInputs() public {
         uint256 termsId = pilTemplate.registerLicenseTerms(PILFlavors.defaultValuesLicenseTerms());
         vm.prank(ipOwner1);


### PR DESCRIPTION
Check licensor Ip is registered when calling `LicenseModule` `mintTokens`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added error handling for minting a license for non-registered intellectual property (IP).
  - Added error handling for disputed IP tagged cases.
- **Bug Fixes**
  - Implemented a check to ensure licensor IP is registered before proceeding with license minting operations.
- **Tests**
  - Added a new test to verify the system properly reverts when attempting to mint a license for an unregistered licensor IP.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->