### PR TITLE
v1.1 TRST-M-2 Fix nonce type hash calculation for EIP-712

### DIFF
--- a/contracts/lib/MetaTx.sol
+++ b/contracts/lib/MetaTx.sol
@@ -13,7 +13,7 @@ library MetaTx {
         keccak256("EIP712Domain(string name,string version,uint256 chainId,address verifyingContract)");
     /// @dev Execute type hash.
     bytes32 public constant EXECUTE =
-        keccak256("Execute(address to,uint256 value,bytes data,uint256 nonce,uint256 deadline)");
+        keccak256("Execute(address to,uint256 value,bytes data,bytes32 nonce,uint256 deadline)");
 
     /// @dev Structure for the Execute type.
     struct Execute {


### PR DESCRIPTION
`Execute.nonce` type is changed from `uint256` to `bytes32`. But the execute type
hash, `EXECUTE`, is not updated and is still using `uint256` for the nonce.

```
/// @dev Execute type hash.
bytes32 public constant EXECUTE =
keccak256("Execute(address to,uint256 value,bytes data,uint256 nonce,uint256 deadline)");
```

As a result, the execute type hash is incorrectly calculated, breaking EIP-712 compatibility and
potentially causing the signature verification in `IPAccountImpl::executeWithSig()` to fail.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
	- Enhanced security by changing the `nonce` parameter type from `uint256` to `bytes32` in meta transactions, improving consistency and reducing potential vulnerabilities.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->