### PR TITLE
Add royalty policy LAP events

### DIFF
--- a/contracts/interfaces/modules/royalty/policies/IRoyaltyPolicyLAP.sol
+++ b/contracts/interfaces/modules/royalty/policies/IRoyaltyPolicyLAP.sol
@@ -24,6 +24,14 @@ interface IRoyaltyPolicyLAP is IRoyaltyPolicy {
     /// @param vault The address of the vault
     event RevenueTokenAddedToVault(address token, address vault);
 
+    /// @notice Event emitted when the snapshot interval is set
+    /// @param interval The snapshot interval
+    event SnapshotIntervalSet(uint256 interval);
+
+    /// @notice Event emitted when the ip royalty vault beacon is set
+    /// @param beacon The address of the ip royalty vault beacon
+    event IpRoyaltyVaultBeaconSet(address beacon);
+
     /// @notice The state data of the LAP royalty policy
     /// @param isUnlinkableToParents Indicates if the ipId is unlinkable to new parents
     /// @param ipRoyaltyVault The ip royalty vault address

--- a/contracts/modules/royalty/policies/RoyaltyPolicyLAP.sol
+++ b/contracts/modules/royalty/policies/RoyaltyPolicyLAP.sol
@@ -91,6 +91,8 @@ contract RoyaltyPolicyLAP is
     function setSnapshotInterval(uint256 timestampInterval) public restricted {
         RoyaltyPolicyLAPStorage storage $ = _getRoyaltyPolicyLAPStorage();
         $.snapshotInterval = timestampInterval;
+
+        emit SnapshotIntervalSet(timestampInterval);
     }
 
     /// @dev Set the ip royalty vault beacon
@@ -100,6 +102,8 @@ contract RoyaltyPolicyLAP is
         if (beacon == address(0)) revert Errors.RoyaltyPolicyLAP__ZeroIpRoyaltyVaultBeacon();
         RoyaltyPolicyLAPStorage storage $ = _getRoyaltyPolicyLAPStorage();
         $.ipRoyaltyVaultBeacon = beacon;
+
+        emit IpRoyaltyVaultBeaconSet(beacon);
     }
 
     /// @dev Upgrades the ip royalty vault beacon

--- a/test/foundry/modules/royalty/RoyaltyPolicyLAP.t.sol
+++ b/test/foundry/modules/royalty/RoyaltyPolicyLAP.t.sol
@@ -160,7 +160,7 @@ contract TestRoyaltyPolicyLAP is BaseTest {
 
         vm.expectEmit(true, true, true, true, address(royaltyPolicyLAP));
         emit SnapshotIntervalSet(100);
-        
+
         royaltyPolicyLAP.setSnapshotInterval(100);
         assertEq(royaltyPolicyLAP.getSnapshotInterval(), 100);
     }

--- a/test/foundry/modules/royalty/RoyaltyPolicyLAP.t.sol
+++ b/test/foundry/modules/royalty/RoyaltyPolicyLAP.t.sol
@@ -8,6 +8,9 @@ import { BaseTest } from "../../utils/BaseTest.t.sol";
 import { IAccessManaged } from "@openzeppelin/contracts/access/manager/IAccessManaged.sol";
 
 contract TestRoyaltyPolicyLAP is BaseTest {
+    event SnapshotIntervalSet(uint256 interval);
+    event IpRoyaltyVaultBeaconSet(address beacon);
+
     RoyaltyPolicyLAP internal testRoyaltyPolicyLAP;
 
     address[] internal MAX_ANCESTORS_ = new address[](14);
@@ -154,6 +157,10 @@ contract TestRoyaltyPolicyLAP is BaseTest {
 
     function test_RoyaltyPolicyLAP_setSnapshotInterval() public {
         vm.startPrank(u.admin);
+
+        vm.expectEmit(true, true, true, true, address(royaltyPolicyLAP));
+        emit SnapshotIntervalSet(100);
+        
         royaltyPolicyLAP.setSnapshotInterval(100);
         assertEq(royaltyPolicyLAP.getSnapshotInterval(), 100);
     }
@@ -171,6 +178,10 @@ contract TestRoyaltyPolicyLAP is BaseTest {
 
     function test_RoyaltyPolicyLAP_setIpRoyaltyVaultBeacon() public {
         vm.startPrank(u.admin);
+
+        vm.expectEmit(true, true, true, true, address(royaltyPolicyLAP));
+        emit IpRoyaltyVaultBeaconSet(address(1));
+
         royaltyPolicyLAP.setIpRoyaltyVaultBeacon(address(1));
         assertEq(royaltyPolicyLAP.getIpRoyaltyVaultBeacon(), address(1));
     }


### PR DESCRIPTION
## Description
Adds the events `SnapshotIntervalSet` and `IpRoyaltyVaultBeaconSet`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
	- Introduced events for setting snapshot intervals and IP royalty vault beacons in royalty policies.
- **Tests**
	- Updated tests to verify the emission of new events for snapshot intervals and IP royalty vault beacons.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->