### PR TITLE
v1.1 TRST-H-1 Clarify Hooks must be registered as modules for the time being

### DIFF
--- a/contracts/interfaces/modules/licensing/ILicensingHook.sol
+++ b/contracts/interfaces/modules/licensing/ILicensingHook.sol
@@ -9,6 +9,7 @@ import { IModule } from "../base/IModule.sol";
 /// IP owners can configure the hook to a specific license terms or all licenses of an IP Asset.
 /// @dev Developers can create a contract that implements this interface to implement various checks
 /// and determine the minting price.
+/// Initially, the hooks must be registered as modules in the ModuleRegistry.
 interface ILicensingHook is IModule {
     /// @notice This function is called when the LicensingModule mints license tokens.
     /// @dev The hook can be used to implement various checks and determine the minting price.


### PR DESCRIPTION
Adding comment to let reviewers now module registration is not permissionless yet,

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
  - Added a new comment to the `ILicensingHook` interface about the registration of hooks as modules in the ModuleRegistry.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->