### PR TITLE
Fix royalty redundancies

### DIFF
--- a/contracts/modules/royalty/RoyaltyModule.sol
+++ b/contracts/modules/royalty/RoyaltyModule.sol
@@ -223,8 +223,6 @@ contract RoyaltyModule is
     ) external onlyLicensingModule {
         RoyaltyModuleStorage storage $ = _getRoyaltyModuleStorage();
         if (!$.isWhitelistedRoyaltyToken[token]) revert Errors.RoyaltyModule__NotWhitelistedRoyaltyToken();
-        if (DISPUTE_MODULE.isIpTagged(receiverIpId)) revert Errors.RoyaltyModule__IpIsTagged();
-        if (licenseRoyaltyPolicy == address(0)) revert Errors.RoyaltyModule__NoRoyaltyPolicySet();
         if (!$.isWhitelistedRoyaltyPolicy[licenseRoyaltyPolicy])
             revert Errors.RoyaltyModule__NotWhitelistedRoyaltyPolicy();
         if (LICENSE_REGISTRY.isExpiredNow(receiverIpId)) revert Errors.RoyaltyModule__IpIsExpired();

--- a/contracts/modules/royalty/policies/RoyaltyPolicyLAP.sol
+++ b/contracts/modules/royalty/policies/RoyaltyPolicyLAP.sol
@@ -217,11 +217,7 @@ contract RoyaltyPolicyLAP is
     /// @param ipId The to initialize the policy for
     /// @param parentIpIds The parent ipIds that the children ipId is being linked to (if any)
     /// @param licenseData The license data custom to each the royalty policy
-    function _initPolicy(
-        address ipId,
-        address[] memory parentIpIds,
-        bytes[] memory licenseData
-    ) internal onlyRoyaltyModule {
+    function _initPolicy(address ipId, address[] memory parentIpIds, bytes[] memory licenseData) internal {
         RoyaltyPolicyLAPStorage storage $ = _getRoyaltyPolicyLAPStorage();
         // decode license data
         uint32[] memory parentRoyalties = new uint32[](parentIpIds.length);

--- a/test/foundry/modules/royalty/RoyaltyModule.t.sol
+++ b/test/foundry/modules/royalty/RoyaltyModule.t.sol
@@ -370,23 +370,6 @@ contract TestRoyaltyModule is BaseTest {
         assertEq(ipRoyaltyVaultUSDCBalAfter - ipRoyaltyVaultUSDCBalBefore, royaltyAmount);
     }
 
-    function test_RoyaltyModule_payLicenseMintingFee_revert_IpIsTagged() public {
-        // raise dispute
-        vm.startPrank(ipAccount1);
-        USDC.approve(address(arbitrationPolicySP), ARBITRATION_PRICE);
-        disputeModule.raiseDispute(ipAddr, string("urlExample"), "PLAGIARISM", "");
-        vm.stopPrank();
-
-        // set dispute judgement
-        vm.startPrank(arbitrationRelayer);
-        disputeModule.setDisputeJudgement(1, true, "");
-
-        vm.startPrank(address(licensingModule));
-
-        vm.expectRevert(Errors.RoyaltyModule__IpIsTagged.selector);
-        royaltyModule.payLicenseMintingFee(ipAddr, ipAccount1, address(royaltyPolicyLAP), address(USDC), 100);
-    }
-
     function test_RoyaltyModule_payLicenseMintingFee_revert_NotWhitelistedRoyaltyToken() public {
         uint256 royaltyAmount = 100 * 10 ** 6;
         address receiverIpId = address(2);


### PR DESCRIPTION
## Description
Removes redundant checks from royalty related contracts


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Refactor**
  - Updated the `RoyaltyModule` contract to simplify royalty checking logic.

- **Style**
  - Improved the readability of parameter lists in the `_initPolicy` function of the `RoyaltyPolicyLAP` contract.

- **Tests**
  - Removed outdated test `test_RoyaltyModule_payLicenseMintingFee_revert_IpIsTagged` to streamline the testing process.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->