### PR TITLE
Restrict `registerDerivativeWithLicenseTokens` to License Token Owners

### DIFF
--- a/contracts/LicenseToken.sol
+++ b/contracts/LicenseToken.sol
@@ -118,16 +118,16 @@ contract LicenseToken is ILicenseToken, ERC721EnumerableUpgradeable, AccessManag
     /// @notice Validates License Tokens for registering a derivative IP.
     /// @dev This function checks if the License Tokens are valid for the derivative IP registration process.
     /// The function will be called by LicensingModule when registering a derivative IP with license tokens.
+    /// @param caller The address of the caller who register derivative with the given tokens.
     /// @param childIpId The ID of the derivative IP.
-    /// @param childIpOwner The address of the owner of the derivative IP.
     /// @param tokenIds An array of IDs of the License Tokens to validate for the derivative
     /// IP to register as derivative of the licensor IPs which minted the license tokens.
     /// @return licenseTemplate The address of the License Template associated with the License Tokens.
     /// @return licensorIpIds An array of licensor IPs associated with each License Token.
     /// @return licenseTermsIds An array of License Terms associated with each validated License Token.
     function validateLicenseTokensForDerivative(
+        address caller,
         address childIpId,
-        address childIpOwner,
         uint256[] calldata tokenIds
     )
         external
@@ -141,8 +141,9 @@ contract LicenseToken is ILicenseToken, ERC721EnumerableUpgradeable, AccessManag
 
         for (uint256 i = 0; i < tokenIds.length; i++) {
             LicenseTokenMetadata memory ltm = $.licenseTokenMetadatas[tokenIds[i]];
-            if (ownerOf(tokenIds[i]) != childIpOwner) {
-                revert Errors.LicenseToken__NotLicenseTokenOwner(tokenIds[i], childIpOwner, ownerOf(tokenIds[i]));
+            address tokenOwner = ownerOf(tokenIds[i]);
+            if (ownerOf(tokenIds[i]) != caller && tokenOwner != childIpId) {
+                revert Errors.LicenseToken__CallerAndChildIPNotTokenOwner(tokenIds[i], caller, childIpId, tokenOwner);
             }
             if (licenseTemplate != ltm.licenseTemplate) {
                 revert Errors.LicenseToken__AllLicenseTokensMustFromSameLicenseTemplate(

--- a/contracts/interfaces/ILicenseToken.sol
+++ b/contracts/interfaces/ILicenseToken.sol
@@ -86,16 +86,16 @@ interface ILicenseToken is IERC721Metadata, IERC721Enumerable {
     /// @notice Validates License Tokens for registering a derivative IP.
     /// @dev This function checks if the License Tokens are valid for the derivative IP registration process.
     /// The function will be called by LicensingModule when registering a derivative IP with license tokens.
+    /// @param caller The address of the caller who register derivative with the given tokens.
     /// @param childIpId The ID of the derivative IP.
-    /// @param childIpOwner The address of the owner of the derivative IP.
     /// @param tokenIds An array of IDs of the License Tokens to validate for the derivative
     /// IP to register as derivative of the licensor IPs which minted the license tokens.
     /// @return licenseTemplate The address of the License Template associated with the License Tokens.
     /// @return licensorIpIds An array of licensor IPs associated with each License Token.
     /// @return licenseTermsIds An array of License Terms associated with each validated License Token.
     function validateLicenseTokensForDerivative(
+        address caller,
         address childIpId,
-        address childIpOwner,
         uint256[] calldata tokenIds
     ) external view returns (address licenseTemplate, address[] memory licensorIpIds, uint256[] memory licenseTermsIds);
 }

--- a/contracts/lib/Errors.sol
+++ b/contracts/lib/Errors.sol
@@ -174,8 +174,13 @@ library Errors {
     /// @notice License token is not transferable.
     error LicenseToken__NotTransferable();
 
-    /// @notice License token is not owned by the caller.
-    error LicenseToken__NotLicenseTokenOwner(uint256 tokenId, address iPowner, address tokenOwner);
+    /// @notice License token is not owned by the either caller or child IP.
+    error LicenseToken__CallerAndChildIPNotTokenOwner(
+        uint256 tokenId,
+        address caller,
+        address childIpIp,
+        address actualTokenOwner
+    );
 
     /// @notice All license tokens must be from the same license template.
     error LicenseToken__AllLicenseTokensMustFromSameLicenseTemplate(

--- a/contracts/modules/licensing/LicensingModule.sol
+++ b/contracts/modules/licensing/LicensingModule.sol
@@ -302,7 +302,7 @@ contract LicensingModule is
         // Validate that the owner of the derivative IP is also the owner of the license tokens.
         address childIpOwner = IIPAccount(payable(childIpId)).owner();
         (address licenseTemplate, address[] memory parentIpIds, uint256[] memory licenseTermsIds) = LICENSE_NFT
-            .validateLicenseTokensForDerivative(msg.sender, childIpId, childIpOwner, licenseTokenIds);
+            .validateLicenseTokensForDerivative(msg.sender, childIpId, licenseTokenIds);
 
         _verifyIpNotDisputed(childIpId);
 

--- a/contracts/modules/licensing/LicensingModule.sol
+++ b/contracts/modules/licensing/LicensingModule.sol
@@ -302,7 +302,7 @@ contract LicensingModule is
         // Validate that the owner of the derivative IP is also the owner of the license tokens.
         address childIpOwner = IIPAccount(payable(childIpId)).owner();
         (address licenseTemplate, address[] memory parentIpIds, uint256[] memory licenseTermsIds) = LICENSE_NFT
-            .validateLicenseTokensForDerivative(childIpId, childIpOwner, licenseTokenIds);
+            .validateLicenseTokensForDerivative(msg.sender, childIpId, childIpOwner, licenseTokenIds);
 
         _verifyIpNotDisputed(childIpId);
 

--- a/test/foundry/modules/licensing/LicensingModule.t.sol
+++ b/test/foundry/modules/licensing/LicensingModule.t.sol
@@ -14,6 +14,7 @@ import { MockLicenseTemplate } from "../../mocks/module/MockLicenseTemplate.sol"
 import { MockLicensingHook } from "../../mocks/module/MockLicensingHook.sol";
 import { PILTerms } from "../../../../contracts/interfaces/modules/licensing/IPILicenseTemplate.sol";
 import { Licensing } from "../../../../contracts/lib/Licensing.sol";
+import { AccessPermission } from "../../../../contracts/lib/AccessPermission.sol";
 
 // test
 import { MockERC721 } from "../../mocks/token/MockERC721.sol";
@@ -897,6 +898,50 @@ contract LicensingModuleTest is BaseTest {
         licensingModule.registerDerivativeWithLicenseTokens(ipId3, licenseTokens, "");
     }
 
+    function test_LicensingModule_registerDerivativeWithLicenseTokens_ownedByDelegator() public {
+        vm.prank(ipOwner3);
+        accessController.setAllPermissions(ipId3, ipOwner2, AccessPermission.ALLOW);
+        uint256 termsId = pilTemplate.registerLicenseTerms(PILFlavors.nonCommercialSocialRemixing());
+        vm.prank(ipOwner1);
+        licensingModule.attachLicenseTerms(ipId1, address(pilTemplate), termsId);
+
+        uint256 lcTokenId = licensingModule.mintLicenseTokens({
+            licensorIpId: ipId1,
+            licenseTemplate: address(pilTemplate),
+            licenseTermsId: termsId,
+            amount: 1,
+            receiver: ipOwner2,
+            royaltyContext: ""
+        });
+
+        uint256[] memory licenseTokens = new uint256[](1);
+        licenseTokens[0] = lcTokenId;
+
+        vm.prank(ipOwner2);
+        licensingModule.registerDerivativeWithLicenseTokens(ipId3, licenseTokens, "");
+    }
+
+    function test_LicensingModule_registerDerivativeWithLicenseTokens_ownedByChildIp() public {
+        uint256 termsId = pilTemplate.registerLicenseTerms(PILFlavors.nonCommercialSocialRemixing());
+        vm.prank(ipOwner1);
+        licensingModule.attachLicenseTerms(ipId1, address(pilTemplate), termsId);
+
+        uint256 lcTokenId = licensingModule.mintLicenseTokens({
+            licensorIpId: ipId1,
+            licenseTemplate: address(pilTemplate),
+            licenseTermsId: termsId,
+            amount: 1,
+            receiver: ipId3,
+            royaltyContext: ""
+        });
+
+        uint256[] memory licenseTokens = new uint256[](1);
+        licenseTokens[0] = lcTokenId;
+
+        vm.prank(ipOwner3);
+        licensingModule.registerDerivativeWithLicenseTokens(ipId3, licenseTokens, "");
+    }
+
     function test_LicensingModule_registerDerivativeWithLicenseTokens_revert_notLicensee() public {
         uint256 termsId = pilTemplate.registerLicenseTerms(PILFlavors.nonCommercialSocialRemixing());
         vm.prank(ipOwner1);
@@ -915,7 +960,13 @@ contract LicensingModuleTest is BaseTest {
         licenseTokens[0] = lcTokenId;
 
         vm.expectRevert(
-            abi.encodeWithSelector(Errors.LicenseToken__NotLicenseTokenOwner.selector, lcTokenId, ipOwner3, ipOwner2)
+            abi.encodeWithSelector(
+                Errors.LicenseToken__CallerAndChildIPNotTokenOwner.selector,
+                lcTokenId,
+                ipOwner3,
+                ipId3,
+                ipOwner2
+            )
         );
         vm.prank(ipOwner3);
         licensingModule.registerDerivativeWithLicenseTokens(ipId3, licenseTokens, "");


### PR DESCRIPTION
## Description
This PR includes changes that restrict the `registerDerivativeWithLicenseTokens` function in the `LicensingModule` contract. The function can now only be called by the owner of the specified license tokens or by the IPAccount that owns the license tokens. This change prevents the potential of burning of arbitrary license tokens from other users.

## Changes:

1. Modified the `registerDerivativeWithLicenseTokens` function in the `LicensingModule` contract to include a check for the ownership of the license tokens. If the caller is not the owner of the specified license tokens or the IPAccount that owns the license tokens, the function will revert and prevent the registration of the derivative.

2. Updated the unit tests to reflect these changes. 

3. Updated the documentation to reflect these changes. The documentation now accurately describes the behavior of the `registerDerivativeWithLicenseTokens` function and the updated process for registering a derivative with license tokens.

## Test Plan 
Added new tests covered the changed code.
The tests also cover scenarios where an attempt is made to call `registerDerivativeWithLicenseTokens` by a user who does not own the specified license tokens.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Updated license token validation to improve ownership verification.

- **Bug Fixes**
  - Enhanced error messaging for token ownership validation.

- **Tests**
  - Added new test cases for registering derivatives with license tokens owned by different entities.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->