### PR TITLE
Check `derivativesReciprocal` for Registering a Derivative of a Derivative

### DIFF
--- a/contracts/modules/licensing/PILicenseTemplate.sol
+++ b/contracts/modules/licensing/PILicenseTemplate.sol
@@ -438,6 +438,13 @@ contract PILicenseTemplate is
             return false;
         }
 
+        //  reciprocal derivatives must be true, if want to allow derivatives of derivatives
+        if (LICENSE_REGISTRY.isDerivativeIp(parentIpId)) {
+            if (!terms.derivativesReciprocal) {
+                return false;
+            }
+        }
+
         // If the policy defines the licensor must approve derivatives, check if the
         // derivative is approved by the licensor
         if (terms.derivativesApproval && !isDerivativeApproved(parentIpId, licenseTermsId, childIpId)) {

--- a/test/foundry/modules/licensing/LicensingModule.t.sol
+++ b/test/foundry/modules/licensing/LicensingModule.t.sol
@@ -1175,6 +1175,37 @@ contract LicensingModuleTest is BaseTest {
         licensingModule.registerDerivative(ipId3, parentIpIds, licenseTermsIds, address(pilTemplate), "");
     }
 
+    function test_LicensingModule_registerDerivative_revert_NotAllowDerivativesReciprocal() public {
+        // register license terms allow derivative but not allow derivative of derivative
+        PILTerms memory terms = PILFlavors.nonCommercialSocialRemixing();
+        // not allow derivative of derivative
+        terms.derivativesReciprocal = false;
+        uint256 socialRemixTermsId = pilTemplate.registerLicenseTerms(terms);
+
+        // register derivative
+        vm.prank(ipOwner1);
+        licensingModule.attachLicenseTerms(ipId1, address(pilTemplate), socialRemixTermsId);
+
+        address[] memory parentIpIds = new address[](1);
+        parentIpIds[0] = ipId1;
+
+        uint256[] memory licenseTermsIds = new uint256[](1);
+        licenseTermsIds[0] = socialRemixTermsId;
+
+        vm.prank(ipOwner2);
+        licensingModule.registerDerivative(ipId2, parentIpIds, licenseTermsIds, address(pilTemplate), "");
+
+        // register derivative of derivative, should revert
+        parentIpIds = new address[](1);
+        parentIpIds[0] = ipId2;
+
+        vm.expectRevert(
+            abi.encodeWithSelector(Errors.LicensingModule__LicenseNotCompatibleForDerivative.selector, ipId3)
+        );
+        vm.prank(ipOwner3);
+        licensingModule.registerDerivative(ipId3, parentIpIds, licenseTermsIds, address(pilTemplate), "");
+    }
+
     function test_LicensingModule_setLicensingConfig() public {
         uint256 socialRemixTermsId = pilTemplate.registerLicenseTerms(PILFlavors.nonCommercialSocialRemixing());
         MockLicensingHook licensingHook = new MockLicensingHook();

--- a/test/foundry/modules/licensing/PILicenseTemplate.t.sol
+++ b/test/foundry/modules/licensing/PILicenseTemplate.t.sol
@@ -352,6 +352,28 @@ contract PILicenseTemplateTest is BaseTest {
         assertTrue(result);
     }
 
+    // test verifyRegisterDerivative
+    function test_PILicenseTemplate_verifyRegisterDerivative_NotDerivativesReciprocal() public {
+        // register license terms allow derivative but not allow derivative of derivative
+        PILTerms memory terms = PILFlavors.nonCommercialSocialRemixing();
+        terms.derivativesReciprocal = false;
+        uint256 socialRemixTermsId = pilTemplate.registerLicenseTerms(terms);
+
+        // register derivative
+        vm.prank(ipOwner[1]);
+        licensingModule.attachLicenseTerms(ipAcct[1], address(pilTemplate), socialRemixTermsId);
+        address[] memory parentIpIds = new address[](1);
+        parentIpIds[0] = ipAcct[1];
+        uint256[] memory licenseTermsIds = new uint256[](1);
+        licenseTermsIds[0] = socialRemixTermsId;
+        vm.prank(ipOwner[2]);
+        licensingModule.registerDerivative(ipAcct[2], parentIpIds, licenseTermsIds, address(pilTemplate), "");
+
+        // checking register derivative of derivative, expect false
+        bool result = pilTemplate.verifyRegisterDerivative(ipAcct[3], ipAcct[2], socialRemixTermsId, ipOwner[3]);
+        assertFalse(result);
+    }
+
     function test_PILicenseTemplate_verifyRegisterDerivative_WithApproval() public {
         PILTerms memory terms = PILFlavors.nonCommercialSocialRemixing();
         terms.derivativesApproval = true;


### PR DESCRIPTION
## Description
This PR includes changes to the `registerDerivative` work flow in the `LicensingModule` contract. The function now checks if the `derivativesReciprocal` term in the PIL is set to `true` when registering a derivative of a derivative. This change ensures that a derivative of a derivative can only be registered if the original derivative allows for reciprocal derivatives.

## Changes:

1. Modified the `_verifyRegisterDerivative` function in the `PILicenseTemplate` to include a check for the `derivativesReciprocal` term in the PIL terms. If a derivative of a derivative is being registered and the `derivativesReciprocal` field is not set to true, the verify function return false and prevent the registration of the derivative.

2. Updated the unit tests to reflect these changes. The tests now cover scenarios where an attempt is made to register a derivative of a derivative when the `derivativesReciprocal` field is not set to true.

## Test Plan 
Add unit tests to cover the code changes above.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Enhanced licensing contract to ensure derivatives of derivatives are reciprocally true if allowed.
  
- **Tests**
  - Added tests to verify the correct behavior of derivative registrations under specific licensing terms.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->