### PR TITLE
Fix after merge problems

### DIFF
--- a/contracts/modules/royalty/policies/IpRoyaltyVault.sol
+++ b/contracts/modules/royalty/policies/IpRoyaltyVault.sol
@@ -257,19 +257,19 @@ contract IpRoyaltyVault is IIpRoyaltyVault, ERC20SnapshotUpgradeable, Reentrancy
 
     /// @notice Collect the accrued tokens (if any)
     /// @param ancestorIpId The ip id of the ancestor to whom the royalty tokens belong to
-    /// @param tokens The list of revenue tokens to claim
-    function collectAccruedTokens(address ancestorIpId, address[] calldata tokens) external nonReentrant whenNotPaused {
+    /// @param _tokens The list of revenue tokens to claim
+    function collectAccruedTokens(address ancestorIpId, address[] calldata _tokens) external nonReentrant whenNotPaused {
         IpRoyaltyVaultStorage storage $ = _getIpRoyaltyVaultStorage();
 
         if (DISPUTE_MODULE.isIpTagged($.ipId)) revert Errors.IpRoyaltyVault__IpTagged();
 
-        for (uint256 i = 0; i < tokens.length; ++i) {
-            uint256 collectAmount = $.collectableAmount[ancestorIpId][tokens[i]];
-            $.ancestorsVaultAmount[tokens[i]] -= collectAmount;
-            $.collectableAmount[ancestorIpId][tokens[i]] -= collectAmount;
-            IERC20Upgradeable(tokens[i]).safeTransfer(ancestorIpId, collectAmount);
+        for (uint256 i = 0; i < _tokens.length; ++i) {
+            uint256 collectAmount = $.collectableAmount[ancestorIpId][_tokens[i]];
+            $.ancestorsVaultAmount[_tokens[i]] -= collectAmount;
+            $.collectableAmount[ancestorIpId][_tokens[i]] -= collectAmount;
+            IERC20Upgradeable(_tokens[i]).safeTransfer(ancestorIpId, collectAmount);
 
-            emit RevenueTokenClaimed(ancestorIpId, tokens[i], collectAmount);
+            emit RevenueTokenClaimed(ancestorIpId, _tokens[i], collectAmount);
         }
     }
 

--- a/contracts/modules/royalty/policies/IpRoyaltyVault.sol
+++ b/contracts/modules/royalty/policies/IpRoyaltyVault.sol
@@ -258,7 +258,10 @@ contract IpRoyaltyVault is IIpRoyaltyVault, ERC20SnapshotUpgradeable, Reentrancy
     /// @notice Collect the accrued tokens (if any)
     /// @param ancestorIpId The ip id of the ancestor to whom the royalty tokens belong to
     /// @param _tokens The list of revenue tokens to claim
-    function collectAccruedTokens(address ancestorIpId, address[] calldata _tokens) external nonReentrant whenNotPaused {
+    function collectAccruedTokens(
+        address ancestorIpId,
+        address[] calldata _tokens
+    ) external nonReentrant whenNotPaused {
         IpRoyaltyVaultStorage storage $ = _getIpRoyaltyVaultStorage();
 
         if (DISPUTE_MODULE.isIpTagged($.ipId)) revert Errors.IpRoyaltyVault__IpTagged();

--- a/test/foundry/invariants/IPAccount.t.sol
+++ b/test/foundry/invariants/IPAccount.t.sol
@@ -34,10 +34,10 @@ contract IPAccountHarnessBase {
         bytes data;
     }
 
-    function batchExecute(CallToRecorder[] calldata calls, uint8 operation) external {
-        ERC6551.Call[] memory calls = new ERC6551.Call[](calls.length);
-        for (uint256 i = 0; i < calls.length; i++) {
-            calls[i] = ERC6551.Call({ target: address(recorder), value: calls[i].value, data: calls[i].data });
+    function batchExecute(CallToRecorder[] calldata _calls, uint8 operation) external {
+        ERC6551.Call[] memory calls = new ERC6551.Call[](_calls.length);
+        for (uint256 i = 0; i < _calls.length; i++) {
+            calls[i] = ERC6551.Call({ target: address(recorder), value: _calls[i].value, data: _calls[i].data });
         }
         ipAccount.executeBatch(calls, operation);
     }
@@ -132,29 +132,30 @@ contract IPAccountPermissionlessInvariants is BaseTest {
 
 /// @notice Invariants for IPAccount that bound to non-exist NFT
 /// and the fuzzer has no permissions to execute transactions
-contract IPAccountPermissionlessNoNftInvariants is IPAccountPermissionlessInvariants {
-    function setUp() public override {
-        super.setUp();
-        address _ipAccount = ipAccountRegistry.registerIpAccount(block.chainid, address(200), 300);
-        super.afterSetUp(_ipAccount);
-    }
+// TODO: refactor this test, since registerIpAccount is no longer reachable
+// contract IPAccountPermissionlessNoNftInvariants is IPAccountPermissionlessInvariants {
+//     function setUp() public override {
+//         super.setUp();
+//         address _ipAccount = ipAccountRegistry.registerIpAccount(block.chainid, address(200), 300);
+//         super.afterSetUp(_ipAccount);
+//     }
 
-    /// @dev As all callers have no permissions, the IPAccount should not be able to execute any transactions
-    /// @notice Invariant to check the owner, state, chainId, tokenContract, and tokenId of the IPAccount
-    function invariant_permissionless() public {
-        address _owner = ipAccount.owner();
-        bytes32 _state = ipAccount.state();
-        (uint256 _chainId, address _tokenContract, uint256 _tokenId) = ipAccount.token();
+//     /// @dev As all callers have no permissions, the IPAccount should not be able to execute any transactions
+//     /// @notice Invariant to check the owner, state, chainId, tokenContract, and tokenId of the IPAccount
+//     function invariant_permissionless() public {
+//         address _owner = ipAccount.owner();
+//         bytes32 _state = ipAccount.state();
+//         (uint256 _chainId, address _tokenContract, uint256 _tokenId) = ipAccount.token();
 
-        uint256 recorded = recorder.recorded();
+//         uint256 recorded = recorder.recorded();
 
-        assertEq(recorded, 0, "recorded");
-        assertEq(_state, state, "state");
-        assertEq(_chainId, block.chainid, "chainId");
-        assertEq(_tokenContract, tokenContract, "tokenContract");
-        assertEq(_owner, address(0), "owner");
-    }
-}
+//         assertEq(recorded, 0, "recorded");
+//         assertEq(_state, state, "state");
+//         assertEq(_chainId, block.chainid, "chainId");
+//         assertEq(_tokenContract, tokenContract, "tokenContract");
+//         assertEq(_owner, address(0), "owner");
+//     }
+// }
 
 /// @notice Invariants for IPAccount that bound to NFT and the fuzzer has no permissions to execute transactions
 contract IPAccountPermissionlessWithNftInvariants is IPAccountPermissionlessInvariants {

--- a/test/foundry/invariants/IPAccount.t.sol
+++ b/test/foundry/invariants/IPAccount.t.sol
@@ -130,33 +130,6 @@ contract IPAccountPermissionlessInvariants is BaseTest {
     }
 }
 
-/// @notice Invariants for IPAccount that bound to non-exist NFT
-/// and the fuzzer has no permissions to execute transactions
-// TODO: refactor this test, since registerIpAccount is no longer reachable
-// contract IPAccountPermissionlessNoNftInvariants is IPAccountPermissionlessInvariants {
-//     function setUp() public override {
-//         super.setUp();
-//         address _ipAccount = ipAccountRegistry.registerIpAccount(block.chainid, address(200), 300);
-//         super.afterSetUp(_ipAccount);
-//     }
-
-//     /// @dev As all callers have no permissions, the IPAccount should not be able to execute any transactions
-//     /// @notice Invariant to check the owner, state, chainId, tokenContract, and tokenId of the IPAccount
-//     function invariant_permissionless() public {
-//         address _owner = ipAccount.owner();
-//         bytes32 _state = ipAccount.state();
-//         (uint256 _chainId, address _tokenContract, uint256 _tokenId) = ipAccount.token();
-
-//         uint256 recorded = recorder.recorded();
-
-//         assertEq(recorded, 0, "recorded");
-//         assertEq(_state, state, "state");
-//         assertEq(_chainId, block.chainid, "chainId");
-//         assertEq(_tokenContract, tokenContract, "tokenContract");
-//         assertEq(_owner, address(0), "owner");
-//     }
-// }
-
 /// @notice Invariants for IPAccount that bound to NFT and the fuzzer has no permissions to execute transactions
 contract IPAccountPermissionlessWithNftInvariants is IPAccountPermissionlessInvariants {
     function setUp() public override {

--- a/test/foundry/invariants/IPAssetRegistry.t.sol
+++ b/test/foundry/invariants/IPAssetRegistry.t.sol
@@ -49,11 +49,6 @@ contract IPAssetRegistryHarness is Test {
         registered++;
     }
 
-    function registerIpAccount(uint8 index) public {
-        vm.warp(10000);
-        IPAccount memory ipAccount = ipAccounts[index];
-        ipAssetRegistry.registerIpAccount(ipAccount.chainId, ipAccount.tokenAddress, ipAccount.tokenId);
-    }
 }
 
 /// @notice Base invariants for IPAssetRegistry contract
@@ -68,9 +63,8 @@ contract IPAssetRegistryBaseInvariants is BaseTest {
 
         targetContract(address(harness));
 
-        bytes4[] memory selectors = new bytes4[](2);
+        bytes4[] memory selectors = new bytes4[](1);
         selectors[0] = harness.register.selector;
-        selectors[1] = harness.registerIpAccount.selector;
         targetSelector(FuzzSelector(address(harness), selectors));
 
         vm.warp(10000);

--- a/test/foundry/invariants/IPAssetRegistry.t.sol
+++ b/test/foundry/invariants/IPAssetRegistry.t.sol
@@ -48,7 +48,6 @@ contract IPAssetRegistryHarness is Test {
         ipAssetRegistry.register(ipAccount.chainId, ipAccount.tokenAddress, ipAccount.tokenId);
         registered++;
     }
-
 }
 
 /// @notice Base invariants for IPAssetRegistry contract

--- a/test/foundry/invariants/LicensingModule.t.sol
+++ b/test/foundry/invariants/LicensingModule.t.sol
@@ -540,7 +540,7 @@ contract LicensingModuleExpensiveInvariant is LicensingModuleBaseInvariant {
 
         vm.prank(multisig);
         royaltyModule.whitelistRoyaltyToken(address(erc20), true);
-        
+
         PILTerms memory terms = PILTerms({
             transferable: true,
             royaltyPolicy: address(royaltyPolicyLAP),

--- a/test/foundry/invariants/LicensingModule.t.sol
+++ b/test/foundry/invariants/LicensingModule.t.sol
@@ -540,22 +540,23 @@ contract LicensingModuleExpensiveInvariant is LicensingModuleBaseInvariant {
 
         vm.prank(multisig);
         royaltyModule.whitelistRoyaltyToken(address(erc20), true);
+        
         PILTerms memory terms = PILTerms({
             transferable: true,
             royaltyPolicy: address(royaltyPolicyLAP),
-            mintingFee: type(uint256).max,
+            defaultMintingFee: type(uint256).max,
             expiration: 10 days,
             commercialUse: true,
             commercialAttribution: true,
             commercializerChecker: address(0),
             commercializerCheckerData: "",
             commercialRevShare: 0,
-            commercialRevCelling: 0,
+            commercialRevCeiling: 0,
             derivativesAllowed: true,
             derivativesAttribution: true,
             derivativesApproval: false,
             derivativesReciprocal: true,
-            derivativeRevCelling: 0,
+            derivativeRevCeiling: 0,
             currency: address(erc20),
             uri: ""
         });


### PR DESCRIPTION
## Description
This PR fixes the invariant tests that fail after merging audit PRs
- Fixing conflicting variable names
- Removing redundant invariant test (registration is now always through `IPAssetRegistry.register()`
- Renaming `mintingFee` to `defaultMintingFee`

## Test Plan 
This is test related



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Enhanced clarity in the `collectAccruedTokens` function by updating parameter names for improved readability.
	- Streamlined the `batchExecute` method in the `IPAccountHarnessBase` contract.
	- Simplified the registration process within the `IPAssetRegistry` by removing the `registerIpAccount` function.
  
- **Bug Fixes**
	- Corrected terminology in the `PILTerms` structure, improving clarity and accuracy in revenue management. 

- **Chores**
	- Removed redundant contracts to simplify the testing framework and improve code maintainability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->