### PR TITLE
Add Function to Predict License Minting Fee in Licensing Module

### DIFF
--- a/contracts/interfaces/modules/licensing/ILicensingHook.sol
+++ b/contracts/interfaces/modules/licensing/ILicensingHook.sol
@@ -55,6 +55,16 @@ interface ILicensingHook is IModule {
     /// @notice This function is called when the LicensingModule calculates/predict the minting fee for license tokens.
     /// @dev The hook should guarantee the minting fee calculation is correct and return the minting fee which is
     /// the exact same amount with returned by beforeMintLicenseTokens().
+    /// The hook should revert if the minting fee calculation is not allowed.
+    /// @param caller The address of the caller who calling the mintLicenseTokens() function.
+    /// @param licensorIpId The ID of licensor IP from which issue the license tokens.
+    /// @param licenseTemplate The address of the license template.
+    /// @param licenseTermsId The ID of the license terms within the license template,
+    /// which is used to mint license tokens.
+    /// @param amount The amount of license tokens to mint.
+    /// @param receiver The address of the receiver who receive the license tokens.
+    /// @param hookData The data to be used by the licensing hook.
+    /// @return totalMintingFee The total minting fee to be paid when minting amount of license tokens.
     function calculateMintingFee(
         address caller,
         address licensorIpId,

--- a/contracts/interfaces/modules/licensing/ILicensingHook.sol
+++ b/contracts/interfaces/modules/licensing/ILicensingHook.sol
@@ -52,7 +52,6 @@ interface ILicensingHook is IModule {
         bytes calldata hookData
     ) external returns (uint256 mintingFee);
 
-
     function calculateMintingFee(
         address caller,
         address licensorIpId,

--- a/contracts/interfaces/modules/licensing/ILicensingHook.sol
+++ b/contracts/interfaces/modules/licensing/ILicensingHook.sol
@@ -52,6 +52,9 @@ interface ILicensingHook is IModule {
         bytes calldata hookData
     ) external returns (uint256 mintingFee);
 
+    /// @notice This function is called when the LicensingModule calculates/predict the minting fee for license tokens.
+    /// @dev The hook should guarantee the minting fee calculation is correct and return the minting fee which is
+    /// the exact same amount with returned by beforeMintLicenseTokens().
     function calculateMintingFee(
         address caller,
         address licensorIpId,

--- a/contracts/interfaces/modules/licensing/ILicensingHook.sol
+++ b/contracts/interfaces/modules/licensing/ILicensingHook.sol
@@ -51,4 +51,15 @@ interface ILicensingHook is IModule {
         uint256 licenseTermsId,
         bytes calldata hookData
     ) external returns (uint256 mintingFee);
+
+
+    function calculateMintingFee(
+        address caller,
+        address licensorIpId,
+        address licenseTemplate,
+        uint256 licenseTermsId,
+        uint256 amount,
+        address receiver,
+        bytes calldata hookData
+    ) external view returns (uint256 totalMintingFee);
 }

--- a/contracts/interfaces/modules/licensing/ILicensingModule.sol
+++ b/contracts/interfaces/modules/licensing/ILicensingModule.sol
@@ -147,6 +147,8 @@ interface ILicensingModule is IModule {
     /// @param amount The amount of license tokens to mint.
     /// @param receiver The address of the receiver.
     /// @param royaltyContext The context of the royalty.
+    /// @return currencyToken The address of the ERC20 token used for minting license fee.
+    /// @return tokenAmount The amount of the currency token to be paid for minting license tokens.
     function predictMintingLicenseFee(
         address licensorIpId,
         address licenseTemplate,

--- a/contracts/interfaces/modules/licensing/ILicensingModule.sol
+++ b/contracts/interfaces/modules/licensing/ILicensingModule.sol
@@ -138,4 +138,21 @@ interface ILicensingModule is IModule {
         uint256 licenseTermsId,
         Licensing.LicensingConfig memory licensingConfig
     ) external;
+
+    /// @notice pre-compute the minting license fee for the given IP and license terms.
+    /// the function can be used to calculate the minting license fee before minting license tokens.
+    /// @param licensorIpId The IP ID of the licensor.
+    /// @param licenseTemplate The address of the license template.
+    /// @param licenseTermsId The ID of the license terms.
+    /// @param amount The amount of license tokens to mint.
+    /// @param receiver The address of the receiver.
+    /// @param royaltyContext The context of the royalty.
+    function predictMintingLicenseFee(
+        address licensorIpId,
+        address licenseTemplate,
+        uint256 licenseTermsId,
+        uint256 amount,
+        address receiver,
+        bytes calldata royaltyContext
+    ) external view returns (address currencyToken, uint256 tokenAmount);
 }

--- a/contracts/modules/licensing/LicensingModule.sol
+++ b/contracts/modules/licensing/LicensingModule.sol
@@ -408,7 +408,7 @@ contract LicensingModule is
         );
         uint256 mintingFeeByHook = 0;
         if (lsc.licensingHook != address(0)) {
-            mintingFeeByHook = ILicensingHook(lsc.licensingHook).beforeMintLicenseTokens(
+            mintingFeeByHook = ILicensingHook(lsc.licensingHook).calculateMintingFee(
                 msg.sender,
                 licensorIpId,
                 licenseTemplate,

--- a/contracts/modules/licensing/LicensingModule.sol
+++ b/contracts/modules/licensing/LicensingModule.sol
@@ -382,7 +382,7 @@ contract LicensingModule is
         }
     }
 
-    function getLicensingFee(
+    function calculateLicensingFee(
         address licensorIpId,
         address licenseTemplate,
         uint256 licenseTermsId,

--- a/contracts/modules/licensing/LicensingModule.sol
+++ b/contracts/modules/licensing/LicensingModule.sol
@@ -382,7 +382,15 @@ contract LicensingModule is
         }
     }
 
-    function calculateLicensingFee(
+    /// @notice pre-compute the minting license fee for the given IP and license terms.
+    /// the function can be used to calculate the minting license fee before minting license tokens.
+    /// @param licensorIpId The IP ID of the licensor.
+    /// @param licenseTemplate The address of the license template.
+    /// @param licenseTermsId The ID of the license terms.
+    /// @param amount The amount of license tokens to mint.
+    /// @param receiver The address of the receiver.
+    /// @param royaltyContext The context of the royalty.
+    function predictMintingLicenseFee(
         address licensorIpId,
         address licenseTemplate,
         uint256 licenseTermsId,
@@ -407,7 +415,7 @@ contract LicensingModule is
             _hasPermission(licensorIpId)
         );
         uint256 mintingFeeByHook = 0;
-        if (lsc.licensingHook != address(0)) {
+        if (lsc.isSet && lsc.licensingHook != address(0)) {
             mintingFeeByHook = ILicensingHook(lsc.licensingHook).calculateMintingFee(
                 msg.sender,
                 licensorIpId,
@@ -415,7 +423,7 @@ contract LicensingModule is
                 licenseTermsId,
                 amount,
                 receiver,
-                royaltyContext
+                lsc.hookData
             );
         }
 

--- a/contracts/modules/licensing/LicensingModule.sol
+++ b/contracts/modules/licensing/LicensingModule.sol
@@ -390,6 +390,8 @@ contract LicensingModule is
     /// @param amount The amount of license tokens to mint.
     /// @param receiver The address of the receiver.
     /// @param royaltyContext The context of the royalty.
+    /// @return currencyToken The address of the ERC20 token used for minting license fee.
+    /// @return tokenAmount The amount of the currency token to be paid for minting license tokens.
     function predictMintingLicenseFee(
         address licensorIpId,
         address licenseTemplate,

--- a/test/foundry/mocks/module/MockLicensingHook.sol
+++ b/test/foundry/mocks/module/MockLicensingHook.sol
@@ -37,6 +37,22 @@ contract MockLicensingHook is BaseModule, ILicensingHook {
         return 100;
     }
 
+    function calculateMintingFee(
+        address caller,
+        address licensorIpId,
+        address licenseTemplate,
+        uint256 licenseTermsId,
+        uint256 amount,
+        address receiver,
+        bytes calldata hookData
+    ) external view returns (uint256 totalMintingFee) {
+        address unqualifiedAddress = abi.decode(hookData, (address));
+        if (caller == unqualifiedAddress) revert("MockLicensingHook: caller is invalid");
+        if (receiver == unqualifiedAddress) revert("MockLicensingHook: receiver is invalid");
+        return amount * 100;
+
+    }
+
     function supportsInterface(bytes4 interfaceId) public view virtual override(BaseModule, IERC165) returns (bool) {
         return interfaceId == type(ILicensingHook).interfaceId || super.supportsInterface(interfaceId);
     }

--- a/test/foundry/mocks/module/MockLicensingHook.sol
+++ b/test/foundry/mocks/module/MockLicensingHook.sol
@@ -50,7 +50,6 @@ contract MockLicensingHook is BaseModule, ILicensingHook {
         if (caller == unqualifiedAddress) revert("MockLicensingHook: caller is invalid");
         if (receiver == unqualifiedAddress) revert("MockLicensingHook: receiver is invalid");
         return amount * 100;
-
     }
 
     function supportsInterface(bytes4 interfaceId) public view virtual override(BaseModule, IERC165) returns (bool) {


### PR DESCRIPTION
## Description

This PR introduces a new function to the Licensing Module that allows users to predict the minting fee for a given license and IP. This enhancement provides better transparency and planning for users by allowing them to estimate the costs associated with minting license tokens.

## Key Changes

- **New Function**: Added a function to predict the minting fee for a given license and IP.

This enhancement is part of our ongoing efforts to improve the functionality and user experience of the Licensing Module.

## Related Issues:
Closes #240 