### PR TITLE
Support multiple versions of IpAccountImpl

### DIFF
--- a/contracts/interfaces/registries/IIPAccountRegistry.sol
+++ b/contracts/interfaces/registries/IIPAccountRegistry.sol
@@ -25,7 +25,24 @@ interface IIPAccountRegistry {
     /// @return ipAccountAddress The address of the IP Account associated with the given NFT token
     function ipAccount(uint256 chainId, address tokenContract, uint256 tokenId) external view returns (address);
 
+    /// @notice Returns the IPAccount address for the given NFT token, with the IPAccount implementation address.
+    /// This methods allows support of legacy implementations.
+    /// @param chainId The chain ID where the IP Account is located
+    /// @param tokenContract The address of the token contract associated with the IP Account
+    /// @param tokenId The ID of the token associated with the IP Account
+    /// @return ipAccountAddress The address of the IP Account associated with the given NFT token,
+    /// Zero address if unsupported ipAccountImpl
+    function ipAccount(
+        uint256 chainId,
+        address tokenContract,
+        uint256 tokenId,
+        address ipAccountImpl
+    ) external view returns (address);
+
     /// @notice Returns the IPAccount implementation address.
     /// @return The address of the IPAccount implementation
     function getIPAccountImpl() external view returns (address);
+
+    /// @notice Returns true if the IPAccount implementation is supported (either current or legacy).
+    function isIpAccountImplSupported(address ipAccountImpl) external view returns (bool);
 }

--- a/contracts/interfaces/registries/IIPAssetRegistry.sol
+++ b/contracts/interfaces/registries/IIPAssetRegistry.sol
@@ -46,4 +46,11 @@ interface IIPAssetRegistry is IIPAccountRegistry {
     /// @param id The canonical identifier for the IP.
     /// @return isRegistered Whether the IP was registered into the protocol.
     function isRegistered(address id) external view returns (bool);
+
+    /// @notice Checks whether an IP was registered based on its chain ID, token contract, and token ID.
+    /// @param chainId The chain identifier of where the IP resides.
+    /// @param tokenContract The address of the IP.
+    /// @param tokenId The token identifier of the IP.
+    /// @return isRegistered Whether the IP was registered into the protocol.
+    function isRegistered(uint256 chainId, address tokenContract, uint256 tokenId) external view returns (bool);
 }

--- a/contracts/lib/Errors.sol
+++ b/contracts/lib/Errors.sol
@@ -60,6 +60,9 @@ library Errors {
     /// @notice Zero address provided for ERC6551 Registry.
     error IPAccountRegistry_ZeroERC6551Registry();
 
+    /// @notice Emitted when an NFT has already been registered as an IP, with any supported IPAccount implementation.
+    error IPAccountRegistry__AlreadyRegistered();
+
     ////////////////////////////////////////////////////////////////////////////
     //                            IP Asset Registry                           //
     ////////////////////////////////////////////////////////////////////////////

--- a/contracts/lib/registries/IPAccountChecker.sol
+++ b/contracts/lib/registries/IPAccountChecker.sol
@@ -2,11 +2,11 @@
 pragma solidity 0.8.23;
 
 import { ERC165Checker } from "@openzeppelin/contracts/utils/introspection/ERC165Checker.sol";
-import { IERC6551Account } from "erc6551/interfaces/IERC6551Account.sol";
+import { LibERC6551 } from "@solady/src/accounts/LibERC6551.sol";
 
 import { IIPAccountRegistry } from "../../interfaces/registries/IIPAccountRegistry.sol";
+import { IIPAssetRegistry } from "../../interfaces/registries/IIPAssetRegistry.sol";
 import { IIPAccount } from "../../interfaces/IIPAccount.sol";
-import { IIPAccountStorage } from "../../interfaces/IIPAccountStorage.sol";
 
 /// @title IPAccountChecker
 /// @dev This library provides utility functions to check the registration and validity of IP Accounts.
@@ -19,12 +19,12 @@ library IPAccountChecker {
     /// @param tokenId_ The ID of the token associated with the IP Account.
     /// @return True if the IP Account is registered, false otherwise.
     function isRegistered(
-        IIPAccountRegistry ipAccountRegistry_,
+        IIPAccountRegistry ipAssetRegistry_,
         uint256 chainId_,
         address tokenContract_,
         uint256 tokenId_
     ) internal view returns (bool) {
-        return ipAccountRegistry_.ipAccount(chainId_, tokenContract_, tokenId_).code.length != 0;
+        return IIPAssetRegistry(address(ipAssetRegistry_)).isRegistered(chainId_, tokenContract_, tokenId_);
     }
 
     /// @notice Checks if the given address is a valid IP Account.
@@ -35,13 +35,12 @@ library IPAccountChecker {
         IIPAccountRegistry ipAccountRegistry_,
         address ipAccountAddress_
     ) internal view returns (bool) {
+        address impl = LibERC6551.implementation(ipAccountAddress_);
         if (ipAccountAddress_ == address(0)) return false;
         if (ipAccountAddress_.code.length == 0) return false;
         if (!ERC165Checker.supportsERC165(ipAccountAddress_)) return false;
-        if (!ERC165Checker.supportsInterface(ipAccountAddress_, type(IERC6551Account).interfaceId)) return false;
         if (!ERC165Checker.supportsInterface(ipAccountAddress_, type(IIPAccount).interfaceId)) return false;
-        if (!ERC165Checker.supportsInterface(ipAccountAddress_, type(IIPAccountStorage).interfaceId)) return false;
         (uint chainId, address tokenContract, uint tokenId) = IIPAccount(payable(ipAccountAddress_)).token();
-        return ipAccountAddress_ == ipAccountRegistry_.ipAccount(chainId, tokenContract, tokenId);
+        return ipAccountAddress_ == ipAccountRegistry_.ipAccount(chainId, tokenContract, tokenId, impl);
     }
 }

--- a/contracts/registries/IPAccountRegistry.sol
+++ b/contracts/registries/IPAccountRegistry.sol
@@ -2,6 +2,7 @@
 pragma solidity 0.8.23;
 
 import { IERC6551Registry } from "erc6551/interfaces/IERC6551Registry.sol";
+import { Initializable } from "@openzeppelin/contracts-upgradeable/proxy/utils/Initializable.sol";
 
 import { IIPAccountRegistry } from "../interfaces/registries/IIPAccountRegistry.sol";
 import { Errors } from "../lib/Errors.sol";
@@ -9,10 +10,10 @@ import { Errors } from "../lib/Errors.sol";
 /// @title IPAccountRegistry
 /// @notice This contract is responsible for managing the registration and tracking of IP Accounts.
 /// It leverages a public ERC6551 registry to deploy IPAccount contracts.
-abstract contract IPAccountRegistry is IIPAccountRegistry {
-    /// @notice Returns the IPAccount implementation address
+abstract contract IPAccountRegistry is IIPAccountRegistry, Initializable {
+    /// @notice Returns the current IPAccount implementation address
     /// @custom:oz-upgrades-unsafe-allow state-variable-immutable
-    address public immutable IP_ACCOUNT_IMPL;
+    address public immutable CURRENT_IP_ACCOUNT_IMPL;
 
     /// @notice Returns the IPAccount salt
     /// @custom:oz-upgrades-unsafe-allow state-variable-immutable
@@ -22,11 +23,22 @@ abstract contract IPAccountRegistry is IIPAccountRegistry {
     /// @custom:oz-upgrades-unsafe-allow state-variable-immutable
     address public immutable ERC6551_PUBLIC_REGISTRY;
 
+    // @dev Storage structure for the IPAccountRegistry
+    /// @custom:storage-location erc7201:story-protocol.IPAccountRegistry
+    struct IPAccountRegistryStorage {
+        mapping(address => bool) legacyIPAccountImpls;
+        mapping(bytes32 => address) registeredNFTsImpls;
+    }
+
+    // keccak256(abi.encode(uint256(keccak256("story-protocol.IPAccountRegistry")) - 1)) & ~bytes32(uint256(0xff));
+    bytes32 private constant IPAccountRegistryStorageLocation =
+        0xf893abfe903060526ef89f585f926eabf001a2825da700d2d2ccb92d6c666400;
+
     /// @custom:oz-upgrades-unsafe-allow constructor
     constructor(address erc6551Registry, address ipAccountImpl) {
         if (ipAccountImpl == address(0)) revert Errors.IPAccountRegistry_ZeroIpAccountImpl();
         if (erc6551Registry == address(0)) revert Errors.IPAccountRegistry_ZeroERC6551Registry();
-        IP_ACCOUNT_IMPL = ipAccountImpl;
+        CURRENT_IP_ACCOUNT_IMPL = ipAccountImpl;
         IP_ACCOUNT_SALT = bytes32(0);
         ERC6551_PUBLIC_REGISTRY = erc6551Registry;
     }
@@ -37,13 +49,77 @@ abstract contract IPAccountRegistry is IIPAccountRegistry {
     /// @param tokenId The ID of the token associated with the IP Account
     /// @return ipAccountAddress The address of the IP Account associated with the given NFT token
     function ipAccount(uint256 chainId, address tokenContract, uint256 tokenId) public view returns (address) {
-        return _get6551AccountAddress(chainId, tokenContract, tokenId);
+        return
+            IERC6551Registry(ERC6551_PUBLIC_REGISTRY).account(
+                CURRENT_IP_ACCOUNT_IMPL,
+                IP_ACCOUNT_SALT,
+                chainId,
+                tokenContract,
+                tokenId
+            );
     }
 
-    /// @notice Returns the IPAccount implementation address.
+    /// @notice Returns the IPAccount address for the given NFT token, with the IPAccount implementation address.
+    /// This methods allows support of legacy implementations.
+    /// @param chainId The chain ID where the IP Account is located
+    /// @param tokenContract The address of the token contract associated with the IP Account
+    /// @param tokenId The ID of the token associated with the IP Account
+    /// @return ipAccountAddress The address of the IP Account associated with the given NFT token,
+    /// Zero address if unsupported ipAccountImpl
+    function ipAccount(
+        uint256 chainId,
+        address tokenContract,
+        uint256 tokenId,
+        address ipAccountImpl
+    ) public view returns (address) {
+        if (!isIpAccountImplSupported(ipAccountImpl)) return address(0);
+        return
+            IERC6551Registry(ERC6551_PUBLIC_REGISTRY).account(
+                ipAccountImpl,
+                IP_ACCOUNT_SALT,
+                chainId,
+                tokenContract,
+                tokenId
+            );
+    }
+
+    /// @notice Returns the current IPAccount implementation address.
     /// @return The address of the IPAccount implementation
     function getIPAccountImpl() external view override returns (address) {
-        return IP_ACCOUNT_IMPL;
+        return CURRENT_IP_ACCOUNT_IMPL;
+    }
+
+    /// @notice Returns true if the IPAccount implementation is supported (either current or legacy).
+    function isIpAccountImplSupported(address ipAccountImpl) public view returns (bool) {
+        return
+            ipAccountImpl == CURRENT_IP_ACCOUNT_IMPL ||
+            _getIPAccountRegistryStorage().legacyIPAccountImpls[ipAccountImpl];
+    }
+
+    /// @notice Helper function to calculate an id representing of an NFT.
+    /// @param chainId The chain ID where the NFT is located
+    /// @param tokenContract The address of the token contract associated with the NFT
+    /// @param tokenId The ID of the token associated with the NFT
+    /// @return nftRepresentation The hashed representation of the NFT
+    function _nftRepresentation(
+        uint256 chainId,
+        address tokenContract,
+        uint256 tokenId
+    ) internal pure returns (bytes32) {
+        return keccak256(abi.encode(chainId, tokenContract, tokenId));
+    }
+
+    /// @notice Returns the IPAccount implementation address for the given NFT token.
+    /// @param chainId The chain ID where the IP Account is located
+    /// @param tokenContract The address of the token contract associated with the IP Account
+    /// @param tokenId The ID of the token associated with the IP Account
+    /// @return ipAccountAddress The address of the IP Account implementation associated with the given NFT token
+    function _getIPAccountImplForNft(
+        uint256 chainId,
+        address tokenContract,
+        uint256 tokenId
+    ) internal view returns (address) {
+        return _getIPAccountRegistryStorage().registeredNFTsImpls[_nftRepresentation(chainId, tokenContract, tokenId)];
     }
 
     /// @dev Deploys an IPAccount contract with the IPAccount implementation and returns the address of the new IP
@@ -57,29 +133,29 @@ abstract contract IPAccountRegistry is IIPAccountRegistry {
         address tokenContract,
         uint256 tokenId
     ) internal returns (address ipAccountAddress) {
+        bytes32 nftRepresentation = _nftRepresentation(chainId, tokenContract, tokenId);
+        if (_getIPAccountRegistryStorage().registeredNFTsImpls[nftRepresentation] != address(0))
+            revert Errors.IPAccountRegistry__AlreadyRegistered();
         ipAccountAddress = IERC6551Registry(ERC6551_PUBLIC_REGISTRY).createAccount(
-            IP_ACCOUNT_IMPL,
+            CURRENT_IP_ACCOUNT_IMPL,
             IP_ACCOUNT_SALT,
             chainId,
             tokenContract,
             tokenId
         );
-        emit IPAccountRegistered(ipAccountAddress, IP_ACCOUNT_IMPL, chainId, tokenContract, tokenId);
+        _getIPAccountRegistryStorage().registeredNFTsImpls[nftRepresentation] = CURRENT_IP_ACCOUNT_IMPL;
+        emit IPAccountRegistered(ipAccountAddress, CURRENT_IP_ACCOUNT_IMPL, chainId, tokenContract, tokenId);
     }
 
-    /// @dev Helper function to get the IPAccount address from the ERC6551 registry.
-    function _get6551AccountAddress(
-        uint256 chainId,
-        address tokenContract,
-        uint256 tokenId
-    ) internal view returns (address) {
-        return
-            IERC6551Registry(ERC6551_PUBLIC_REGISTRY).account(
-                IP_ACCOUNT_IMPL,
-                IP_ACCOUNT_SALT,
-                chainId,
-                tokenContract,
-                tokenId
-            );
+    /// @dev WARNING: This should only be called as part of the upgrade process, by an authorized account.
+    function _moveCurrentImplToLegacy() internal {
+        _getIPAccountRegistryStorage().legacyIPAccountImpls[CURRENT_IP_ACCOUNT_IMPL] = true;
+    }
+
+    /// @dev Returns the storage struct of IPAccountRegistry.
+    function _getIPAccountRegistryStorage() private pure returns (IPAccountRegistryStorage storage $) {
+        assembly {
+            $.slot := IPAccountRegistryStorageLocation
+        }
     }
 }

--- a/script/foundry/utils/upgrades/ERC7201Helper.s.sol
+++ b/script/foundry/utils/upgrades/ERC7201Helper.s.sol
@@ -12,7 +12,7 @@ import { console2 } from "forge-std/console2.sol";
 contract ERC7201HelperScript is Script {
     
     string constant NAMESPACE = "story-protocol";
-    string constant CONTRACT_NAME = "ArbitrationPolicySP";
+    string constant CONTRACT_NAME = "IPAccountRegistry";
 
     function run() external {
         bytes memory erc7201Key = abi.encodePacked(NAMESPACE, ".", CONTRACT_NAME);

--- a/test/foundry/IPAccount.t.sol
+++ b/test/foundry/IPAccount.t.sol
@@ -29,7 +29,7 @@ contract IPAccountTest is BaseTest {
         module = new MockModule(address(ipAssetRegistry), address(moduleRegistry), "MockModule");
         mockIpAccountRegistry = new MockIPAccountRegistry(
             ipAccountRegistry.ERC6551_PUBLIC_REGISTRY(),
-            ipAccountRegistry.IP_ACCOUNT_IMPL()
+            ipAccountRegistry.getIPAccountImpl()
         );
 
         vm.startPrank(u.admin); // used twice, name() and registerModule()
@@ -51,10 +51,6 @@ contract IPAccountTest is BaseTest {
 
         assertTrue(deployedAccount != address(0));
 
-        assertEq(predictedAccount, deployedAccount);
-
-        // Create account twice
-        deployedAccount = mockIpAccountRegistry.registerIpAccount(block.chainid, address(mockNFT), tokenId);
         assertEq(predictedAccount, deployedAccount);
     }
 

--- a/test/foundry/invariants/IPAssetRegistry.t.sol
+++ b/test/foundry/invariants/IPAssetRegistry.t.sol
@@ -172,7 +172,7 @@ contract IPAssetRegistryAllRegisteredInvariants is IPAssetRegistryInvariants {
     /// @dev Invariant: every registration should revert when the IP Account is already registered
     function invariant_allRevert() public {
         for (uint256 i = 0; i < harness.ipAccountCount(); i++) {
-            vm.expectRevert(abi.encodeWithSelector(Errors.IPAssetRegistry__AlreadyRegistered.selector));
+            vm.expectRevert(abi.encodeWithSelector(Errors.IPAccountRegistry__AlreadyRegistered.selector));
             harness.register(uint8(i));
         }
     }

--- a/test/foundry/modules/metadata/CoreMetadataViewModule.t.sol
+++ b/test/foundry/modules/metadata/CoreMetadataViewModule.t.sol
@@ -85,7 +85,7 @@ contract CoreMetadataViewModuleTest is BaseTest {
     function test_CoreMetadataViewModule_revert_isSupported() public {
         mockNFT.mintId(alice, 999);
         address nonIpAsset = erc6551Registry.createAccount(
-            ipAccountRegistry.IP_ACCOUNT_IMPL(),
+            ipAccountRegistry.getIPAccountImpl(),
             ipAccountRegistry.IP_ACCOUNT_SALT(),
             block.chainid,
             address(mockNFT),

--- a/test/foundry/registries/btt/IPAssetRegistry.tree
+++ b/test/foundry/registries/btt/IPAssetRegistry.tree
@@ -22,16 +22,22 @@ IPAssetRegistry.sol
 │               ├── it should set the IP registration date
 │               ├── it should increment the total supply
 │               └── it should emit an event
-└── when checking if IP is registered
-    ├── given the IP ID is zero address
-    │   └── it should return false
-    ├── given the IP ID has no code
-    │   └── it should return false
-    ├── given the IP ID does not support IIPAccount interface
-    │   └── it should return false
-    ├── given the IP ID does not match the expected registered IP ID
-    │   └── it should return false
-    ├── given the IP ID does not have name set in storage
-    │   └── it should return false
-    └── given the IP ID is valid, matches the expected ID, and has name set in storage
-        └── it should return true
+├── when checking if IP is registered
+|   ├── given the IP ID is zero address
+│   │   └── it should return false
+│   ├── given the IP ID has no code
+│   │   └── it should return false
+│   ├── given the IP ID does not support IIPAccount interface
+│   │   └── it should return false
+│   ├── given the IP ID does not match the expected registered IP ID
+│   │   └── it should return false
+│   ├── given the IP ID does not have name set in storage
+│   │   └── it should return false
+│   └── given the IP ID is valid, matches the expected ID, and has name set in storage
+│       └── it should return true
+└─── when upgrading ipAccountImpl
+    ├── given an IPAccount registered with old IPAccountImpl
+    │   └── it should return true in isRegistered
+    ├── given an unsupported IPAccountImpl
+        └── it should return false in isRegistered
+        


### PR DESCRIPTION
## Description
This PR will allow changing the IPAccountImpl for new wallets without breaking previously registered IPAs.


## Test Plan 
Test pass locally

## Related Issue
Issue #201 

## Notes
There are a lot of redundancies on the IPAccount/IPAddress front.