### PR TITLE
Bump Solidity Compiler Version to 0.8.26

### DIFF
--- a/contracts/GroupNFT.sol
+++ b/contracts/GroupNFT.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: BUSL-1.1
-pragma solidity 0.8.23;
+pragma solidity 0.8.26;
 import { Base64 } from "@openzeppelin/contracts/utils/Base64.sol";
 import { Strings } from "@openzeppelin/contracts/utils/Strings.sol";
 import { IERC165 } from "@openzeppelin/contracts/utils/introspection/ERC165.sol";

--- a/contracts/IPAccountImpl.sol
+++ b/contracts/IPAccountImpl.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: BUSL-1.1
-pragma solidity 0.8.23;
+pragma solidity 0.8.26;
 
 import { IERC165 } from "@openzeppelin/contracts/utils/introspection/ERC165.sol";
 import { IERC721Receiver } from "@openzeppelin/contracts/token/ERC721/IERC721Receiver.sol";

--- a/contracts/IPAccountStorage.sol
+++ b/contracts/IPAccountStorage.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: BUSL-1.1
-pragma solidity 0.8.23;
+pragma solidity 0.8.26;
 
 import { IIPAccountStorage } from "./interfaces/IIPAccountStorage.sol";
 import { IModuleRegistry } from "./interfaces/registries/IModuleRegistry.sol";

--- a/contracts/LicenseToken.sol
+++ b/contracts/LicenseToken.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: BUSL-1.1
-pragma solidity 0.8.23;
+pragma solidity 0.8.26;
 import { Base64 } from "@openzeppelin/contracts/utils/Base64.sol";
 import { Strings } from "@openzeppelin/contracts/utils/Strings.sol";
 // solhint-disable-next-line max-line-length

--- a/contracts/access/AccessControlled.sol
+++ b/contracts/access/AccessControlled.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: BUSL-1.1
-pragma solidity 0.8.23;
+pragma solidity 0.8.26;
 
 import { IAccessController } from "../interfaces/access/IAccessController.sol";
 import { IPAccountChecker } from "../lib/registries/IPAccountChecker.sol";

--- a/contracts/access/AccessController.sol
+++ b/contracts/access/AccessController.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: BUSL-1.1
-pragma solidity 0.8.23;
+pragma solidity 0.8.26;
 
 import { UUPSUpgradeable } from "@openzeppelin/contracts-upgradeable/proxy/utils/UUPSUpgradeable.sol";
 // solhint-disable-next-line max-line-length

--- a/contracts/access/IPGraphACL.sol
+++ b/contracts/access/IPGraphACL.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: BUSL-1.1
-pragma solidity 0.8.23;
+pragma solidity 0.8.26;
 
 import { AccessManaged } from "@openzeppelin/contracts/access/manager/AccessManaged.sol";
 import { Errors } from "../lib/Errors.sol";

--- a/contracts/interfaces/IGroupNFT.sol
+++ b/contracts/interfaces/IGroupNFT.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: BUSL-1.1
-pragma solidity 0.8.23;
+pragma solidity 0.8.26;
 
 import { IERC721Metadata } from "@openzeppelin/contracts/token/ERC721/extensions/IERC721Metadata.sol";
 

--- a/contracts/interfaces/IIPAccount.sol
+++ b/contracts/interfaces/IIPAccount.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: BUSL-1.1
-pragma solidity 0.8.23;
+pragma solidity 0.8.26;
 
 import { IIPAccountStorage } from "./IIPAccountStorage.sol";
 

--- a/contracts/interfaces/IIPAccountStorage.sol
+++ b/contracts/interfaces/IIPAccountStorage.sol
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: UNLICENSED
 // See https://github.com/storyprotocol/protocol-contracts/blob/main/StoryProtocol-AlphaTestingAgreement-17942166.3.pdf
-pragma solidity 0.8.23;
+pragma solidity 0.8.26;
 
 import { IERC165 } from "@openzeppelin/contracts/utils/introspection/ERC165.sol";
 

--- a/contracts/interfaces/ILicenseToken.sol
+++ b/contracts/interfaces/ILicenseToken.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: BUSL-1.1
-pragma solidity 0.8.23;
+pragma solidity 0.8.26;
 
 import { IERC721Metadata } from "@openzeppelin/contracts/token/ERC721/extensions/IERC721Metadata.sol";
 import { IERC721Enumerable } from "@openzeppelin/contracts/token/ERC721/extensions/IERC721Enumerable.sol";

--- a/contracts/interfaces/access/IAccessController.sol
+++ b/contracts/interfaces/access/IAccessController.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: BUSL-1.1
-pragma solidity 0.8.23;
+pragma solidity 0.8.26;
 
 import { AccessPermission } from "../../lib/AccessPermission.sol";
 

--- a/contracts/interfaces/modules/base/IHookModule.sol
+++ b/contracts/interfaces/modules/base/IHookModule.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: BUSL-1.1
-pragma solidity 0.8.23;
+pragma solidity 0.8.26;
 
 import { IModule } from "./IModule.sol";
 

--- a/contracts/interfaces/modules/base/IModule.sol
+++ b/contracts/interfaces/modules/base/IModule.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: BUSL-1.1
-pragma solidity 0.8.23;
+pragma solidity 0.8.26;
 
 import { IERC165 } from "@openzeppelin/contracts/utils/introspection/IERC165.sol";
 

--- a/contracts/interfaces/modules/base/IViewModule.sol
+++ b/contracts/interfaces/modules/base/IViewModule.sol
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: UNLICENSED
 // See https://github.com/storyprotocol/protocol-contracts/blob/main/StoryProtocol-AlphaTestingAgreement-17942166.3.pdf
-pragma solidity 0.8.23;
+pragma solidity 0.8.26;
 
 import { IModule } from "./IModule.sol";
 

--- a/contracts/interfaces/modules/dispute/IDisputeModule.sol
+++ b/contracts/interfaces/modules/dispute/IDisputeModule.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: BUSL-1.1
-pragma solidity 0.8.23;
+pragma solidity 0.8.26;
 
 /// @title Dispute Module Interface
 interface IDisputeModule {

--- a/contracts/interfaces/modules/dispute/policies/IArbitrationPolicy.sol
+++ b/contracts/interfaces/modules/dispute/policies/IArbitrationPolicy.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: BUSL-1.1
-pragma solidity 0.8.23;
+pragma solidity 0.8.26;
 
 /// @title Arbitration Policy Interface
 interface IArbitrationPolicy {

--- a/contracts/interfaces/modules/external/ITokenWithdrawalModule.sol
+++ b/contracts/interfaces/modules/external/ITokenWithdrawalModule.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: BUSL-1.1
-pragma solidity 0.8.23;
+pragma solidity 0.8.26;
 
 import { IModule } from "../base/IModule.sol";
 

--- a/contracts/interfaces/modules/grouping/IGroupRewardPool.sol
+++ b/contracts/interfaces/modules/grouping/IGroupRewardPool.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: BUSL-1.1
-pragma solidity 0.8.23;
+pragma solidity 0.8.26;
 
 /// @title IGroupingPolicy
 /// @notice Interface for grouping policies

--- a/contracts/interfaces/modules/grouping/IGroupingModule.sol
+++ b/contracts/interfaces/modules/grouping/IGroupingModule.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: BUSL-1.1
-pragma solidity 0.8.23;
+pragma solidity 0.8.26;
 
 import { IModule } from "../base/IModule.sol";
 

--- a/contracts/interfaces/modules/licensing/ILicenseTemplate.sol
+++ b/contracts/interfaces/modules/licensing/ILicenseTemplate.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: BUSL-1.1
-pragma solidity 0.8.23;
+pragma solidity 0.8.26;
 
 import { IERC165 } from "@openzeppelin/contracts/interfaces/IERC165.sol";
 

--- a/contracts/interfaces/modules/licensing/ILicensingHook.sol
+++ b/contracts/interfaces/modules/licensing/ILicensingHook.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: BUSL-1.1
-pragma solidity 0.8.23;
+pragma solidity 0.8.26;
 
 import { IModule } from "../base/IModule.sol";
 

--- a/contracts/interfaces/modules/licensing/ILicensingModule.sol
+++ b/contracts/interfaces/modules/licensing/ILicensingModule.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: BUSL-1.1
-pragma solidity 0.8.23;
+pragma solidity 0.8.26;
 
 import { IModule } from "../base/IModule.sol";
 import { Licensing } from "../../../lib/Licensing.sol";

--- a/contracts/interfaces/modules/licensing/IPILicenseTemplate.sol
+++ b/contracts/interfaces/modules/licensing/IPILicenseTemplate.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: BUSL-1.1
-pragma solidity 0.8.23;
+pragma solidity 0.8.26;
 
 import { ILicenseTemplate } from "../../../interfaces/modules/licensing/ILicenseTemplate.sol";
 

--- a/contracts/interfaces/modules/metadata/ICoreMetadataModule.sol
+++ b/contracts/interfaces/modules/metadata/ICoreMetadataModule.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: BUSL-1.1
-pragma solidity 0.8.23;
+pragma solidity 0.8.26;
 
 import { IModule } from "../../../../contracts/interfaces/modules/base/IModule.sol";
 

--- a/contracts/interfaces/modules/metadata/ICoreMetadataViewModule.sol
+++ b/contracts/interfaces/modules/metadata/ICoreMetadataViewModule.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: BUSL-1.1
-pragma solidity 0.8.23;
+pragma solidity 0.8.26;
 
 import { IViewModule } from "../base/IViewModule.sol";
 

--- a/contracts/interfaces/modules/royalty/IRoyaltyModule.sol
+++ b/contracts/interfaces/modules/royalty/IRoyaltyModule.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: BUSL-1.1
-pragma solidity 0.8.23;
+pragma solidity 0.8.26;
 
 import { IModule } from "../../modules/base/IModule.sol";
 

--- a/contracts/interfaces/modules/royalty/policies/IExternalRoyaltyPolicy.sol
+++ b/contracts/interfaces/modules/royalty/policies/IExternalRoyaltyPolicy.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: BUSL-1.1
-pragma solidity 0.8.23;
+pragma solidity 0.8.26;
 
 /// @title IExternalRoyaltyPolicy interface
 interface IExternalRoyaltyPolicy {

--- a/contracts/interfaces/modules/royalty/policies/IIpRoyaltyVault.sol
+++ b/contracts/interfaces/modules/royalty/policies/IIpRoyaltyVault.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-pragma solidity 0.8.23;
+pragma solidity 0.8.26;
 
 /// @title IpRoyaltyVault interface
 interface IIpRoyaltyVault {

--- a/contracts/interfaces/modules/royalty/policies/IRoyaltyPolicy.sol
+++ b/contracts/interfaces/modules/royalty/policies/IRoyaltyPolicy.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: BUSL-1.1
-pragma solidity 0.8.23;
+pragma solidity 0.8.26;
 
 /// @title RoyaltyPolicy interface
 interface IRoyaltyPolicy {

--- a/contracts/interfaces/modules/royalty/policies/IVaultController.sol
+++ b/contracts/interfaces/modules/royalty/policies/IVaultController.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-pragma solidity 0.8.23;
+pragma solidity 0.8.26;
 
 /// @title VaultController interface
 interface IVaultController {

--- a/contracts/interfaces/modules/royalty/policies/LAP/IRoyaltyPolicyLAP.sol
+++ b/contracts/interfaces/modules/royalty/policies/LAP/IRoyaltyPolicyLAP.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: BUSL-1.1
-pragma solidity 0.8.23;
+pragma solidity 0.8.26;
 
 import { IRoyaltyPolicy } from "../../../../../interfaces/modules/royalty/policies/IRoyaltyPolicy.sol";
 

--- a/contracts/interfaces/modules/royalty/policies/LRP/IRoyaltyPolicyLRP.sol
+++ b/contracts/interfaces/modules/royalty/policies/LRP/IRoyaltyPolicyLRP.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: BUSL-1.1
-pragma solidity 0.8.23;
+pragma solidity 0.8.26;
 
 import { IRoyaltyPolicy } from "../../../../../interfaces/modules/royalty/policies/IRoyaltyPolicy.sol";
 

--- a/contracts/interfaces/pause/IProtocolPauseAdmin.sol
+++ b/contracts/interfaces/pause/IProtocolPauseAdmin.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: BUSL-1.1
-pragma solidity 0.8.23;
+pragma solidity 0.8.26;
 
 /// @title ProtocolPauseAdmin
 /// @notice Contract that allows the pausing and unpausing of the protocol. It allows adding and removing

--- a/contracts/interfaces/registries/IGroupIPAssetRegistry.sol
+++ b/contracts/interfaces/registries/IGroupIPAssetRegistry.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: BUSL-1.1
-pragma solidity 0.8.23;
+pragma solidity 0.8.26;
 
 /// @title Interface for Group IPA  Registry
 /// @notice This interface manages the registration and tracking of Group IPA

--- a/contracts/interfaces/registries/IIPAccountRegistry.sol
+++ b/contracts/interfaces/registries/IIPAccountRegistry.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: BUSL-1.1
-pragma solidity 0.8.23;
+pragma solidity 0.8.26;
 
 /// @title Interface for IP Account Registry
 /// @notice This interface manages the registration and tracking of IP Accounts

--- a/contracts/interfaces/registries/IIPAssetRegistry.sol
+++ b/contracts/interfaces/registries/IIPAssetRegistry.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: BUSL-1.1
-pragma solidity 0.8.23;
+pragma solidity 0.8.26;
 
 import { IIPAccountRegistry } from "./IIPAccountRegistry.sol";
 

--- a/contracts/interfaces/registries/ILicenseRegistry.sol
+++ b/contracts/interfaces/registries/ILicenseRegistry.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: BUSL-1.1
-pragma solidity 0.8.23;
+pragma solidity 0.8.26;
 
 import { Licensing } from "../../lib/Licensing.sol";
 

--- a/contracts/interfaces/registries/IModuleRegistry.sol
+++ b/contracts/interfaces/registries/IModuleRegistry.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: BUSL-1.1
-pragma solidity 0.8.23;
+pragma solidity 0.8.26;
 
 /// @title IModuleRegistry
 /// @dev This interface defines the methods for a module registry in the Story Protocol.

--- a/contracts/lib/AccessPermission.sol
+++ b/contracts/lib/AccessPermission.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: BUSL-1.1
-pragma solidity 0.8.23;
+pragma solidity 0.8.26;
 
 /// @title Access Permission Library
 /// @notice Library for IPAccount access control permissions.

--- a/contracts/lib/ArrayUtils.sol
+++ b/contracts/lib/ArrayUtils.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: BUSL-1.1
-pragma solidity 0.8.23;
+pragma solidity 0.8.26;
 
 /// @title Address Array Utils
 /// @notice Library for address array operations

--- a/contracts/lib/Errors.sol
+++ b/contracts/lib/Errors.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: BUSL-1.1
-pragma solidity 0.8.23;
+pragma solidity 0.8.26;
 
 /// @title Errors Library
 /// @notice Library for all Story Protocol contract errors.

--- a/contracts/lib/ExpiringOps.sol
+++ b/contracts/lib/ExpiringOps.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: BUSL-1.1
-pragma solidity 0.8.23;
+pragma solidity 0.8.26;
 
 library ExpiringOps {
     /// @dev Get the earliest expiration time from two expiration times

--- a/contracts/lib/IPAccountStorageOps.sol
+++ b/contracts/lib/IPAccountStorageOps.sol
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: UNLICENSED
 // See https://github.com/storyprotocol/protocol-contracts/blob/main/StoryProtocol-AlphaTestingAgreement-17942166.3.pdf
-pragma solidity 0.8.23;
+pragma solidity 0.8.26;
 
 import { IIPAccountStorage } from "../interfaces/IIPAccountStorage.sol";
 import { ShortString, ShortStrings } from "@openzeppelin/contracts/utils/ShortStrings.sol";

--- a/contracts/lib/Licensing.sol
+++ b/contracts/lib/Licensing.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: BUSL-1.1
-pragma solidity 0.8.23;
+pragma solidity 0.8.26;
 
 /// @title Licensing
 /// @notice Types and constants used by the licensing related contracts

--- a/contracts/lib/MetaTx.sol
+++ b/contracts/lib/MetaTx.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: BUSL-1.1
-pragma solidity 0.8.23;
+pragma solidity 0.8.26;
 
 /// @title MetaTx
 /// @dev This library provides functions for handling meta transactions in the Story Protocol.

--- a/contracts/lib/PILFlavors.sol
+++ b/contracts/lib/PILFlavors.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: BUSL-1.1
-pragma solidity 0.8.23;
+pragma solidity 0.8.26;
 
 import { IPILicenseTemplate, PILTerms } from "../interfaces/modules/licensing/IPILicenseTemplate.sol";
 

--- a/contracts/lib/PILicenseTemplateErrors.sol
+++ b/contracts/lib/PILicenseTemplateErrors.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: BUSL-1.1
-pragma solidity 0.8.23;
+pragma solidity 0.8.26;
 
 /// @title PILicenseTemplate Errors Library
 /// @notice Library for all PILicenseTemplate related contract errors.

--- a/contracts/lib/ProtocolAdmin.sol
+++ b/contracts/lib/ProtocolAdmin.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: BUSL-1.1
-pragma solidity 0.8.23;
+pragma solidity 0.8.26;
 
 /// @title ProtocolAdmin
 /// @dev This library provides roles and utils to configure protocol AccessManager

--- a/contracts/lib/ShortStringOps.sol
+++ b/contracts/lib/ShortStringOps.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: BUSL-1.1
-pragma solidity 0.8.23;
+pragma solidity 0.8.26;
 
 import { ShortString, ShortStrings } from "@openzeppelin/contracts/utils/ShortStrings.sol";
 import { Strings } from "@openzeppelin/contracts/utils/Strings.sol";

--- a/contracts/lib/modules/Module.sol
+++ b/contracts/lib/modules/Module.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: BUSL-1.1
-pragma solidity 0.8.23;
+pragma solidity 0.8.26;
 
 // Default Module Type, all modules in this type by default
 string constant MODULE_TYPE_DEFAULT = "MODULE";

--- a/contracts/lib/registries/IPAccountChecker.sol
+++ b/contracts/lib/registries/IPAccountChecker.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: BUSL-1.1
-pragma solidity 0.8.23;
+pragma solidity 0.8.26;
 
 import { ERC165Checker } from "@openzeppelin/contracts/utils/introspection/ERC165Checker.sol";
 import { IERC6551Account } from "erc6551/interfaces/IERC6551Account.sol";

--- a/contracts/modules/BaseModule.sol
+++ b/contracts/modules/BaseModule.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: BUSL-1.1
-pragma solidity 0.8.23;
+pragma solidity 0.8.26;
 
 import { IERC165, ERC165 } from "@openzeppelin/contracts/utils/introspection/ERC165.sol";
 import { IModule } from "../interfaces/modules/base/IModule.sol";

--- a/contracts/modules/dispute/DisputeModule.sol
+++ b/contracts/modules/dispute/DisputeModule.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: BUSL-1.1
-pragma solidity 0.8.23;
+pragma solidity 0.8.26;
 
 import { ReentrancyGuardUpgradeable } from "@openzeppelin/contracts-upgradeable/utils/ReentrancyGuardUpgradeable.sol";
 import { UUPSUpgradeable } from "@openzeppelin/contracts-upgradeable/proxy/utils/UUPSUpgradeable.sol";

--- a/contracts/modules/dispute/policies/ArbitrationPolicySP.sol
+++ b/contracts/modules/dispute/policies/ArbitrationPolicySP.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: BUSL-1.1
-pragma solidity 0.8.23;
+pragma solidity 0.8.26;
 
 import { SafeERC20 } from "@openzeppelin/contracts/token/ERC20/utils/SafeERC20.sol";
 import { IERC20 } from "@openzeppelin/contracts/token/ERC20/IERC20.sol";

--- a/contracts/modules/grouping/GroupingModule.sol
+++ b/contracts/modules/grouping/GroupingModule.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: BUSL-1.1
-pragma solidity 0.8.23;
+pragma solidity 0.8.26;
 
 // external
 import { Strings } from "@openzeppelin/contracts/utils/Strings.sol";

--- a/contracts/modules/licensing/BaseLicenseTemplateUpgradeable.sol
+++ b/contracts/modules/licensing/BaseLicenseTemplateUpgradeable.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: BUSL-1.1
-pragma solidity 0.8.23;
+pragma solidity 0.8.26;
 
 // external
 import { ERC165 } from "@openzeppelin/contracts/utils/introspection/ERC165.sol";

--- a/contracts/modules/licensing/LicensingModule.sol
+++ b/contracts/modules/licensing/LicensingModule.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: BUSL-1.1
-pragma solidity 0.8.23;
+pragma solidity 0.8.26;
 
 // external
 import { EnumerableSet } from "@openzeppelin/contracts/utils/structs/EnumerableSet.sol";

--- a/contracts/modules/licensing/PILTermsRenderer.sol
+++ b/contracts/modules/licensing/PILTermsRenderer.sol
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: BUSL-1.1
 
-pragma solidity 0.8.23;
+pragma solidity 0.8.26;
 
 // external
 import { Strings } from "@openzeppelin/contracts/utils/Strings.sol";

--- a/contracts/modules/licensing/PILicenseTemplate.sol
+++ b/contracts/modules/licensing/PILicenseTemplate.sol
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: BUSL-1.1
 
-pragma solidity 0.8.23;
+pragma solidity 0.8.26;
 
 // external
 import { Strings } from "@openzeppelin/contracts/utils/Strings.sol";

--- a/contracts/modules/licensing/parameter-helpers/LicensorApprovalChecker.sol
+++ b/contracts/modules/licensing/parameter-helpers/LicensorApprovalChecker.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: BUSL-1.1
-pragma solidity 0.8.23;
+pragma solidity 0.8.26;
 
 import { AccessControlled } from "../../../access/AccessControlled.sol";
 import { Initializable } from "@openzeppelin/contracts-upgradeable/proxy/utils/Initializable.sol";

--- a/contracts/modules/metadata/CoreMetadataModule.sol
+++ b/contracts/modules/metadata/CoreMetadataModule.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: BUSL-1.1
-pragma solidity 0.8.23;
+pragma solidity 0.8.26;
 
 import { IERC165 } from "@openzeppelin/contracts/utils/introspection/IERC165.sol";
 import { IERC721Metadata } from "@openzeppelin/contracts/token/ERC721/extensions/IERC721Metadata.sol";

--- a/contracts/modules/metadata/CoreMetadataViewModule.sol
+++ b/contracts/modules/metadata/CoreMetadataViewModule.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: BUSL-1.1
-pragma solidity 0.8.23;
+pragma solidity 0.8.26;
 
 import { IERC165 } from "@openzeppelin/contracts/utils/introspection/IERC165.sol";
 import { Strings } from "@openzeppelin/contracts/utils/Strings.sol";

--- a/contracts/modules/royalty/RoyaltyModule.sol
+++ b/contracts/modules/royalty/RoyaltyModule.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: BUSL-1.1
-pragma solidity 0.8.23;
+pragma solidity 0.8.26;
 
 import { ReentrancyGuardUpgradeable } from "@openzeppelin/contracts-upgradeable/utils/ReentrancyGuardUpgradeable.sol";
 import { UUPSUpgradeable } from "@openzeppelin/contracts-upgradeable/proxy/utils/UUPSUpgradeable.sol";

--- a/contracts/modules/royalty/policies/IpRoyaltyVault.sol
+++ b/contracts/modules/royalty/policies/IpRoyaltyVault.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-pragma solidity 0.8.23;
+pragma solidity 0.8.26;
 
 import { EnumerableSet } from "@openzeppelin/contracts/utils/structs/EnumerableSet.sol";
 import { PausableUpgradeable } from "@openzeppelin/contracts-upgradeable/utils/PausableUpgradeable.sol";

--- a/contracts/modules/royalty/policies/LAP/RoyaltyPolicyLAP.sol
+++ b/contracts/modules/royalty/policies/LAP/RoyaltyPolicyLAP.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: BUSL-1.1
-pragma solidity 0.8.23;
+pragma solidity 0.8.26;
 
 import { IERC20 } from "@openzeppelin/contracts/token/ERC20/IERC20.sol";
 import { SafeERC20 } from "@openzeppelin/contracts/token/ERC20/utils/SafeERC20.sol";

--- a/contracts/modules/royalty/policies/LRP/RoyaltyPolicyLRP.sol
+++ b/contracts/modules/royalty/policies/LRP/RoyaltyPolicyLRP.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: BUSL-1.1
-pragma solidity 0.8.23;
+pragma solidity 0.8.26;
 
 import { IERC20 } from "@openzeppelin/contracts/token/ERC20/IERC20.sol";
 import { SafeERC20 } from "@openzeppelin/contracts/token/ERC20/utils/SafeERC20.sol";

--- a/contracts/modules/royalty/policies/VaultController.sol
+++ b/contracts/modules/royalty/policies/VaultController.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-pragma solidity 0.8.23;
+pragma solidity 0.8.26;
 
 import { UpgradeableBeacon } from "@openzeppelin/contracts/proxy/beacon/UpgradeableBeacon.sol";
 

--- a/contracts/pause/ProtocolPausableUpgradeable.sol
+++ b/contracts/pause/ProtocolPausableUpgradeable.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: BUSL-1.1
-pragma solidity 0.8.23;
+pragma solidity 0.8.26;
 
 // solhint-disable-next-line max-line-length
 import { AccessManagedUpgradeable } from "@openzeppelin/contracts-upgradeable/access/manager/AccessManagedUpgradeable.sol";

--- a/contracts/pause/ProtocolPauseAdmin.sol
+++ b/contracts/pause/ProtocolPauseAdmin.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: BUSL-1.1
-pragma solidity 0.8.23;
+pragma solidity 0.8.26;
 
 import { AccessManaged } from "@openzeppelin/contracts/access/manager/AccessManaged.sol";
 import { EnumerableSet } from "@openzeppelin/contracts/utils/structs/EnumerableSet.sol";

--- a/contracts/registries/GroupIPAssetRegistry.sol
+++ b/contracts/registries/GroupIPAssetRegistry.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: BUSL-1.1
-pragma solidity 0.8.23;
+pragma solidity 0.8.26;
 
 import { EnumerableSet } from "@openzeppelin/contracts/utils/structs/EnumerableSet.sol";
 

--- a/contracts/registries/IPAccountRegistry.sol
+++ b/contracts/registries/IPAccountRegistry.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: BUSL-1.1
-pragma solidity 0.8.23;
+pragma solidity 0.8.26;
 
 import { IERC6551Registry } from "erc6551/interfaces/IERC6551Registry.sol";
 

--- a/contracts/registries/IPAssetRegistry.sol
+++ b/contracts/registries/IPAssetRegistry.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: BUSL-1.1
-pragma solidity 0.8.23;
+pragma solidity 0.8.26;
 
 import { IERC721 } from "@openzeppelin/contracts/token/ERC721/IERC721.sol";
 import { IERC721Metadata } from "@openzeppelin/contracts/token/ERC721/extensions/IERC721Metadata.sol";

--- a/contracts/registries/LicenseRegistry.sol
+++ b/contracts/registries/LicenseRegistry.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: BUSL-1.1
-pragma solidity 0.8.23;
+pragma solidity 0.8.26;
 
 import { Strings } from "@openzeppelin/contracts/utils/Strings.sol";
 import { EnumerableSet } from "@openzeppelin/contracts/utils/structs/EnumerableSet.sol";

--- a/contracts/registries/ModuleRegistry.sol
+++ b/contracts/registries/ModuleRegistry.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: BUSL-1.1
-pragma solidity 0.8.23;
+pragma solidity 0.8.26;
 
 import { ERC165Checker } from "@openzeppelin/contracts/utils/introspection/ERC165Checker.sol";
 import { Strings } from "@openzeppelin/contracts/utils/Strings.sol";

--- a/foundry.toml
+++ b/foundry.toml
@@ -7,9 +7,10 @@ gas_reports = ["*"]
 optimizer = true
 optimizer_runs = 20000
 test = 'test'
-solc = '0.8.23'
+solc = '0.8.26'
 fs_permissions = [{ access = 'read-write', path = './deploy-out' }, { access = 'read', path = './out' }]
 extra_output = ["storageLayout"]
+evm_version = "cancun"
 
 [rpc_endpoints]
 mainnet = "${MAINNET_RPC_URL}"

--- a/test/foundry/IPAccount.t.sol
+++ b/test/foundry/IPAccount.t.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: BUSL-1.1
-pragma solidity 0.8.23;
+pragma solidity 0.8.26;
 
 import { IERC6551Account } from "erc6551/interfaces/IERC6551Account.sol";
 import { ERC6551 } from "@solady/src/accounts/ERC6551.sol";

--- a/test/foundry/IPAccountImpl.btt.t.sol
+++ b/test/foundry/IPAccountImpl.btt.t.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: BUSL-1.1
-pragma solidity 0.8.23;
+pragma solidity 0.8.26;
 
 import { IERC165 } from "@openzeppelin/contracts/utils/introspection/ERC165.sol";
 import { IERC721Receiver } from "@openzeppelin/contracts/token/ERC721/IERC721Receiver.sol";

--- a/test/foundry/IPAccountMetaTx.t.sol
+++ b/test/foundry/IPAccountMetaTx.t.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: BUSL-1.1
-pragma solidity 0.8.23;
+pragma solidity 0.8.26;
 
 import { MessageHashUtils } from "@openzeppelin/contracts/utils/cryptography/MessageHashUtils.sol";
 

--- a/test/foundry/LicenseToken.t.sol
+++ b/test/foundry/LicenseToken.t.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: BUSL-1.1
-pragma solidity 0.8.23;
+pragma solidity 0.8.26;
 
 import { Base64 } from "@openzeppelin/contracts/utils/Base64.sol";
 import { Strings } from "@openzeppelin/contracts/utils/Strings.sol";

--- a/test/foundry/access/AccessControlled.t.sol
+++ b/test/foundry/access/AccessControlled.t.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: BUSL-1.1
-pragma solidity 0.8.23;
+pragma solidity 0.8.26;
 
 import { IIPAccount } from "contracts/interfaces/IIPAccount.sol";
 import { AccessPermission } from "contracts/lib/AccessPermission.sol";

--- a/test/foundry/access/AccessController.t.sol
+++ b/test/foundry/access/AccessController.t.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: BUSL-1.1
-pragma solidity 0.8.23;
+pragma solidity 0.8.26;
 
 import { IIPAccount } from "../../../contracts/interfaces/IIPAccount.sol";
 import { AccessPermission } from "../../../contracts/lib/AccessPermission.sol";

--- a/test/foundry/access/IPGraphACL.t.sol
+++ b/test/foundry/access/IPGraphACL.t.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: BUSL-1.1
-pragma solidity 0.8.23;
+pragma solidity 0.8.26;
 
 import { Errors } from "../../../contracts/lib/Errors.sol";
 import { BaseTest } from "../utils/BaseTest.t.sol";

--- a/test/foundry/integration/BaseIntegration.t.sol
+++ b/test/foundry/integration/BaseIntegration.t.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: BUSL-1.1
-pragma solidity 0.8.23;
+pragma solidity 0.8.26;
 
 // external
 import { IERC6551Registry } from "erc6551/interfaces/IERC6551Registry.sol";

--- a/test/foundry/integration/big-bang/SingleNftCollection.t.sol
+++ b/test/foundry/integration/big-bang/SingleNftCollection.t.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: BUSL-1.1
-pragma solidity 0.8.23;
+pragma solidity 0.8.26;
 
 // external
 import { EnumerableSet } from "@openzeppelin/contracts/utils/structs/EnumerableSet.sol";

--- a/test/foundry/integration/flows/disputes/Disputes.t.sol
+++ b/test/foundry/integration/flows/disputes/Disputes.t.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: BUSL-1.1
-pragma solidity 0.8.23;
+pragma solidity 0.8.26;
 
 // external
 import { EnumerableSet } from "@openzeppelin/contracts/utils/structs/EnumerableSet.sol";

--- a/test/foundry/integration/flows/grouping/Grouping.t.sol
+++ b/test/foundry/integration/flows/grouping/Grouping.t.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: BUSL-1.1
-pragma solidity 0.8.23;
+pragma solidity ^0.8.23;
 
 // external
 import { EnumerableSet } from "@openzeppelin/contracts/utils/structs/EnumerableSet.sol";

--- a/test/foundry/integration/flows/licensing/LicensingIntegration.t.sol
+++ b/test/foundry/integration/flows/licensing/LicensingIntegration.t.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: BUSL-1.1
-pragma solidity 0.8.23;
+pragma solidity 0.8.26;
 
 // contracts
 import { PILFlavors } from "../../../../../contracts/lib/PILFlavors.sol";

--- a/test/foundry/integration/flows/licensing/LicensingScenarios.t.sol
+++ b/test/foundry/integration/flows/licensing/LicensingScenarios.t.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: BUSL-1.1
-pragma solidity 0.8.23;
+pragma solidity 0.8.26;
 
 // external
 import { EnumerableSet } from "@openzeppelin/contracts/utils/structs/EnumerableSet.sol";

--- a/test/foundry/integration/flows/royalty/Royalty.t.sol
+++ b/test/foundry/integration/flows/royalty/Royalty.t.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: BUSL-1.1
-pragma solidity 0.8.23;
+pragma solidity 0.8.26;
 
 // external
 import { EnumerableSet } from "@openzeppelin/contracts/utils/structs/EnumerableSet.sol";

--- a/test/foundry/invariants/BaseInvariant.t.sol
+++ b/test/foundry/invariants/BaseInvariant.t.sol
@@ -1,6 +1,6 @@
 /* solhint-disable no-console */
 // SPDX-License-Identifier: BUSL-1.1
-pragma solidity 0.8.23;
+pragma solidity 0.8.26;
 
 // external
 import { BaseTest } from "../utils/BaseTest.t.sol";

--- a/test/foundry/invariants/DisputeModule.t.sol
+++ b/test/foundry/invariants/DisputeModule.t.sol
@@ -1,6 +1,6 @@
 /* solhint-disable no-console */
 // SPDX-License-Identifier: BUSL-1.1
-pragma solidity 0.8.23;
+pragma solidity 0.8.26;
 
 import { BaseTest } from "../utils/BaseTest.t.sol";
 import { Test } from "forge-std/Test.sol";

--- a/test/foundry/invariants/IPAccount.t.sol
+++ b/test/foundry/invariants/IPAccount.t.sol
@@ -1,6 +1,6 @@
 /* solhint-disable no-console */
 // SPDX-License-Identifier: BUSL-1.1
-pragma solidity 0.8.23;
+pragma solidity 0.8.26;
 
 // external
 import { BaseTest } from "../utils/BaseTest.t.sol";

--- a/test/foundry/invariants/IPAssetRegistry.t.sol
+++ b/test/foundry/invariants/IPAssetRegistry.t.sol
@@ -1,6 +1,6 @@
 /* solhint-disable no-console */
 // SPDX-License-Identifier: BUSL-1.1
-pragma solidity 0.8.23;
+pragma solidity 0.8.26;
 
 // external
 import { BaseTest } from "../utils/BaseTest.t.sol";

--- a/test/foundry/invariants/IpRoyaltyVault.t.sol
+++ b/test/foundry/invariants/IpRoyaltyVault.t.sol
@@ -1,6 +1,6 @@
 /* solhint-disable no-console */
 // SPDX-License-Identifier: BUSL-1.1
-pragma solidity 0.8.23;
+pragma solidity 0.8.26;
 
 import { BaseTest } from "../utils/BaseTest.t.sol";
 import { Test } from "forge-std/Test.sol";

--- a/test/foundry/invariants/LicenseToken.t.sol
+++ b/test/foundry/invariants/LicenseToken.t.sol
@@ -1,6 +1,6 @@
 /* solhint-disable no-console */
 // SPDX-License-Identifier: BUSL-1.1
-pragma solidity 0.8.23;
+pragma solidity 0.8.26;
 
 // external
 import { BaseTest } from "../utils/BaseTest.t.sol";

--- a/test/foundry/invariants/LicensingModule.t.sol
+++ b/test/foundry/invariants/LicensingModule.t.sol
@@ -1,6 +1,6 @@
 /* solhint-disable no-console */
 // SPDX-License-Identifier: BUSL-1.1
-pragma solidity 0.8.23;
+pragma solidity 0.8.26;
 
 // external
 import { Test } from "forge-std/Test.sol";

--- a/test/foundry/mocks/CustomModuleType.sol
+++ b/test/foundry/mocks/CustomModuleType.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: BUSL-1.1
-pragma solidity 0.8.23;
+pragma solidity 0.8.26;
 
 import { IModule } from "contracts/interfaces/modules/base/IModule.sol";
 import { IERC165 } from "@openzeppelin/contracts/utils/introspection/ERC165.sol";

--- a/test/foundry/mocks/MockIPGraph.sol
+++ b/test/foundry/mocks/MockIPGraph.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-pragma solidity 0.8.23;
+pragma solidity 0.8.26;
 
 import { EnumerableSet } from "@openzeppelin/contracts/utils/structs/EnumerableSet.sol";
 import { DoubleEndedQueue } from "@openzeppelin/contracts/utils/structs/DoubleEndedQueue.sol";

--- a/test/foundry/mocks/MockProtocolPausable.sol
+++ b/test/foundry/mocks/MockProtocolPausable.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: BUSL-1.1
-pragma solidity 0.8.23;
+pragma solidity 0.8.26;
 
 import { ProtocolPausableUpgradeable } from "contracts/pause/ProtocolPausableUpgradeable.sol";
 

--- a/test/foundry/mocks/MockTokenGatedHook.sol
+++ b/test/foundry/mocks/MockTokenGatedHook.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: BUSL-1.1
-pragma solidity 0.8.23;
+pragma solidity 0.8.26;
 
 import { IERC165 } from "@openzeppelin/contracts/utils/introspection/ERC165.sol";
 import { ERC165Checker } from "@openzeppelin/contracts/utils/introspection/ERC165Checker.sol";

--- a/test/foundry/mocks/grouping/MockEvenSplitGroupPool.sol
+++ b/test/foundry/mocks/grouping/MockEvenSplitGroupPool.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: BUSL-1.1
-pragma solidity 0.8.23;
+pragma solidity 0.8.26;
 
 import { IGroupRewardPool } from "contracts/interfaces/modules/grouping/IGroupRewardPool.sol";
 import { IERC20 } from "@openzeppelin/contracts/token/ERC20/IERC20.sol";

--- a/test/foundry/mocks/module/LicenseRegistryHarness.sol
+++ b/test/foundry/mocks/module/LicenseRegistryHarness.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: BUSL-1.1
-pragma solidity 0.8.23;
+pragma solidity 0.8.26;
 
 import { LicenseRegistry } from "../../../../contracts/registries/LicenseRegistry.sol";
 

--- a/test/foundry/mocks/module/MockAccessControlledModule.sol
+++ b/test/foundry/mocks/module/MockAccessControlledModule.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: BUSL-1.1
-pragma solidity 0.8.23;
+pragma solidity 0.8.26;
 
 import { IModule } from "../../../../contracts/interfaces/modules/base/IModule.sol";
 import { IIPAccountRegistry } from "../../../../contracts/interfaces/registries/IIPAccountRegistry.sol";

--- a/test/foundry/mocks/module/MockAccessControllerV2.sol
+++ b/test/foundry/mocks/module/MockAccessControllerV2.sol
@@ -1,7 +1,7 @@
 import { AccessController } from "contracts/access/AccessController.sol";
 
 // SPDX-License-Identifier: BUSL-1.1
-pragma solidity 0.8.23;
+pragma solidity 0.8.26;
 
 contract MockAccessControllerV2 is AccessController {
     /// @dev Storage structure for the AccessControllerV2

--- a/test/foundry/mocks/module/MockIpRoyaltyVaultV2.sol
+++ b/test/foundry/mocks/module/MockIpRoyaltyVaultV2.sol
@@ -1,7 +1,7 @@
 import { IpRoyaltyVault } from "contracts/modules/royalty/policies/IpRoyaltyVault.sol";
 
 // SPDX-License-Identifier: BUSL-1.1
-pragma solidity 0.8.23;
+pragma solidity 0.8.26;
 
 contract MockIpRoyaltyVaultV2 is IpRoyaltyVault {
     /// @dev Storage structure for the MockIPRoyaltyVaultV2

--- a/test/foundry/mocks/module/MockLicenseTemplate.sol
+++ b/test/foundry/mocks/module/MockLicenseTemplate.sol
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: BUSL-1.1
 
-pragma solidity 0.8.23;
+pragma solidity 0.8.26;
 
 import { BaseLicenseTemplateUpgradeable } from "contracts/modules/licensing/BaseLicenseTemplateUpgradeable.sol";
 

--- a/test/foundry/mocks/module/MockLicensingHook.sol
+++ b/test/foundry/mocks/module/MockLicensingHook.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: BUSL-1.1
-pragma solidity 0.8.23;
+pragma solidity 0.8.26;
 
 import { IERC165 } from "@openzeppelin/contracts/utils/introspection/ERC165.sol";
 

--- a/test/foundry/mocks/module/MockMetaTxModule.sol
+++ b/test/foundry/mocks/module/MockMetaTxModule.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: BUSL-1.1
-pragma solidity 0.8.23;
+pragma solidity 0.8.26;
 
 import { ERC165Checker } from "@openzeppelin/contracts/utils/introspection/ERC165Checker.sol";
 

--- a/test/foundry/mocks/module/MockModule.sol
+++ b/test/foundry/mocks/module/MockModule.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: BUSL-1.1
-pragma solidity 0.8.23;
+pragma solidity 0.8.26;
 
 import { ERC165Checker } from "@openzeppelin/contracts/utils/introspection/ERC165Checker.sol";
 

--- a/test/foundry/mocks/module/MockOrchestratorModule.sol
+++ b/test/foundry/mocks/module/MockOrchestratorModule.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: BUSL-1.1
-pragma solidity 0.8.23;
+pragma solidity 0.8.26;
 
 import { ERC165Checker } from "@openzeppelin/contracts/utils/introspection/ERC165Checker.sol";
 

--- a/test/foundry/mocks/policy/MockExternalRoyaltyPolicy1.sol
+++ b/test/foundry/mocks/policy/MockExternalRoyaltyPolicy1.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: BUSL-1.1
-pragma solidity 0.8.23;
+pragma solidity 0.8.26;
 
 // solhint-disable-next-line max-line-length
 import { IExternalRoyaltyPolicy } from "../../../../contracts/interfaces/modules/royalty/policies/IExternalRoyaltyPolicy.sol";

--- a/test/foundry/mocks/policy/MockExternalRoyaltyPolicy2.sol
+++ b/test/foundry/mocks/policy/MockExternalRoyaltyPolicy2.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: BUSL-1.1
-pragma solidity 0.8.23;
+pragma solidity 0.8.26;
 
 // solhint-disable-next-line max-line-length
 import { IExternalRoyaltyPolicy } from "../../../../contracts/interfaces/modules/royalty/policies/IExternalRoyaltyPolicy.sol";

--- a/test/foundry/mocks/policy/MockRoyaltyPolicyLAP.sol
+++ b/test/foundry/mocks/policy/MockRoyaltyPolicyLAP.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: BUSL-1.1
-pragma solidity 0.8.23;
+pragma solidity 0.8.26;
 
 import { IRoyaltyModule } from "../../../../contracts/interfaces/modules/royalty/IRoyaltyModule.sol";
 import { IDisputeModule } from "../../../../contracts/interfaces/modules/dispute/IDisputeModule.sol";

--- a/test/foundry/mocks/token/MockERC1155.sol
+++ b/test/foundry/mocks/token/MockERC1155.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: BUSDL-1.1
-pragma solidity 0.8.23;
+pragma solidity 0.8.26;
 
 import { ERC1155 } from "@openzeppelin/contracts/token/ERC1155/ERC1155.sol";
 

--- a/test/foundry/mocks/token/MockERC20.sol
+++ b/test/foundry/mocks/token/MockERC20.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: BUSL-1.1
-pragma solidity 0.8.23;
+pragma solidity 0.8.26;
 
 import { ERC20 } from "@openzeppelin/contracts/token/ERC20/ERC20.sol";
 

--- a/test/foundry/mocks/token/MockERC721.sol
+++ b/test/foundry/mocks/token/MockERC721.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: BUSDL-1.1
-pragma solidity 0.8.23;
+pragma solidity 0.8.26;
 
 import { ERC721 } from "@openzeppelin/contracts/token/ERC721/ERC721.sol";
 

--- a/test/foundry/mocks/token/MockERC721WithoutMetadata.sol
+++ b/test/foundry/mocks/token/MockERC721WithoutMetadata.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: BUSDL-1.1
-pragma solidity 0.8.23;
+pragma solidity 0.8.26;
 
 import { IERC721, IERC165 } from "@openzeppelin/contracts/token/ERC721/IERC721.sol";
 

--- a/test/foundry/modules/ModuleBase.t.sol
+++ b/test/foundry/modules/ModuleBase.t.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: BUSL-1.1
-pragma solidity 0.8.23;
+pragma solidity 0.8.26;
 
 import { IModule } from "contracts/interfaces/modules/base/IModule.sol";
 

--- a/test/foundry/modules/dispute/ArbitrationPolicySP.t.sol
+++ b/test/foundry/modules/dispute/ArbitrationPolicySP.t.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: BUSL-1.1
-pragma solidity 0.8.23;
+pragma solidity 0.8.26;
 
 // external
 import { IERC20 } from "@openzeppelin/contracts/token/ERC20/IERC20.sol";

--- a/test/foundry/modules/dispute/DisputeModule.t.sol
+++ b/test/foundry/modules/dispute/DisputeModule.t.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: BUSL-1.1
-pragma solidity 0.8.23;
+pragma solidity 0.8.26;
 
 // external
 import { IERC20 } from "@openzeppelin/contracts/token/ERC20/IERC20.sol";

--- a/test/foundry/modules/grouping/GroupingModule.t.sol
+++ b/test/foundry/modules/grouping/GroupingModule.t.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: BUSL-1.1
-pragma solidity 0.8.23;
+pragma solidity 0.8.26;
 
 // external
 import { Strings } from "@openzeppelin/contracts/utils/Strings.sol";

--- a/test/foundry/modules/licensing/LicensingModule.t.sol
+++ b/test/foundry/modules/licensing/LicensingModule.t.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: BUSL-1.1
-pragma solidity 0.8.23;
+pragma solidity 0.8.26;
 
 // external
 import { Strings } from "@openzeppelin/contracts/utils/Strings.sol";

--- a/test/foundry/modules/licensing/PILicenseTemplate.t.sol
+++ b/test/foundry/modules/licensing/PILicenseTemplate.t.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: BUSL-1.1
-pragma solidity 0.8.23;
+pragma solidity 0.8.26;
 
 // external
 import { Strings } from "@openzeppelin/contracts/utils/Strings.sol";

--- a/test/foundry/modules/royalty/IpRoyaltyVault.t.sol
+++ b/test/foundry/modules/royalty/IpRoyaltyVault.t.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: BUSL-1.1
-pragma solidity 0.8.23;
+pragma solidity 0.8.26;
 
 import { ERC20 } from "@openzeppelin/contracts/token/ERC20/ERC20.sol";
 import { IERC20 } from "@openzeppelin/contracts/token/ERC20/IERC20.sol";

--- a/test/foundry/modules/royalty/LAP/RoyaltyPolicyLAP.t.sol
+++ b/test/foundry/modules/royalty/LAP/RoyaltyPolicyLAP.t.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: BUSL-1.1
-pragma solidity 0.8.23;
+pragma solidity 0.8.26;
 
 import { IERC20 } from "@openzeppelin/contracts/token/ERC20/IERC20.sol";
 import { ERC6551AccountLib } from "erc6551/lib/ERC6551AccountLib.sol";

--- a/test/foundry/modules/royalty/LRP/RoyaltyPolicyLRP.t.sol
+++ b/test/foundry/modules/royalty/LRP/RoyaltyPolicyLRP.t.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: BUSL-1.1
-pragma solidity 0.8.23;
+pragma solidity 0.8.26;
 
 import { IERC20 } from "@openzeppelin/contracts/token/ERC20/IERC20.sol";
 

--- a/test/foundry/modules/royalty/RoyaltyModule.t.sol
+++ b/test/foundry/modules/royalty/RoyaltyModule.t.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: BUSL-1.1
-pragma solidity 0.8.23;
+pragma solidity 0.8.26;
 
 import { IERC20 } from "@openzeppelin/contracts/token/ERC20/IERC20.sol";
 import { ERC6551AccountLib } from "erc6551/lib/ERC6551AccountLib.sol";

--- a/test/foundry/modules/royalty/VaultController.t.sol
+++ b/test/foundry/modules/royalty/VaultController.t.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: BUSL-1.1
-pragma solidity 0.8.23;
+pragma solidity 0.8.26;
 
 import { UpgradeableBeacon } from "@openzeppelin/contracts/proxy/beacon/UpgradeableBeacon.sol";
 import { VaultController } from "../../../../contracts/modules/royalty/policies/VaultController.sol";

--- a/test/foundry/pause/ProtocolPauseAdmin.t.sol
+++ b/test/foundry/pause/ProtocolPauseAdmin.t.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: BUSL-1.1
-pragma solidity 0.8.23;
+pragma solidity 0.8.26;
 
 import { Errors } from "contracts/lib/Errors.sol";
 import { ProtocolAdmin } from "contracts/lib/ProtocolAdmin.sol";

--- a/test/foundry/registries/IPAccountRegistry.t.sol
+++ b/test/foundry/registries/IPAccountRegistry.t.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: BUSL-1.1
-pragma solidity 0.8.23;
+pragma solidity 0.8.26;
 
 import { IPAccountImpl } from "../../../contracts/IPAccountImpl.sol";
 import { IPAccountChecker } from "../../../contracts/lib/registries/IPAccountChecker.sol";

--- a/test/foundry/registries/IPAssetRegistry.t.sol
+++ b/test/foundry/registries/IPAssetRegistry.t.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: BUSL-1.1
-pragma solidity 0.8.23;
+pragma solidity 0.8.26;
 
 import { IIPAssetRegistry } from "contracts/interfaces/registries/IIPAssetRegistry.sol";
 import { IPAccountChecker } from "contracts/lib/registries/IPAccountChecker.sol";

--- a/test/foundry/registries/LicenseRegistry.t.sol
+++ b/test/foundry/registries/LicenseRegistry.t.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: BUSL-1.1
-pragma solidity 0.8.23;
+pragma solidity 0.8.26;
 
 // external
 import { Strings } from "@openzeppelin/contracts/utils/Strings.sol";

--- a/test/foundry/registries/ModuleRegistry.t.sol
+++ b/test/foundry/registries/ModuleRegistry.t.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: BUSL-1.1
-pragma solidity 0.8.23;
+pragma solidity 0.8.26;
 
 import { Errors } from "contracts/lib/Errors.sol";
 

--- a/test/foundry/upgrades/Upgrades.t.sol
+++ b/test/foundry/upgrades/Upgrades.t.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: BUSL-1.1
-pragma solidity 0.8.23;
+pragma solidity 0.8.26;
 
 import { ProtocolAdmin } from "contracts/lib/ProtocolAdmin.sol";
 import { VaultController } from "contracts/modules/royalty/policies/VaultController.sol";

--- a/test/foundry/utils/BaseTest.t.sol
+++ b/test/foundry/utils/BaseTest.t.sol
@@ -1,6 +1,6 @@
 /* solhint-disable no-console */
 // SPDX-License-Identifier: BUSL-1.1
-pragma solidity 0.8.23;
+pragma solidity 0.8.26;
 
 // external
 import { Test } from "forge-std/Test.sol";

--- a/test/foundry/utils/LicensingHelper.t.sol
+++ b/test/foundry/utils/LicensingHelper.t.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: BUSL-1.1
-pragma solidity 0.8.23;
+pragma solidity 0.8.26;
 
 import { IERC20 } from "@openzeppelin/contracts/token/ERC20/IERC20.sol";
 

--- a/test/foundry/utils/Users.t.sol
+++ b/test/foundry/utils/Users.t.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: BUSL-1.1
-pragma solidity 0.8.23;
+pragma solidity 0.8.26;
 
 import { Vm } from "forge-std/Vm.sol";
 


### PR DESCRIPTION
## Description

This PR updates the Solidity compiler version to the latest 0.8.26. This change ensures that the project benefits from the latest features, optimizations, and security improvements provided by the new compiler version.

## Key Changes

- **Solidity Version Update**: Updated the Solidity compiler version to 0.8.26 in all relevant files.

