### PR TITLE
Configure Non-Commercial Remix License as Default License in Deployment Script and Ensure Consistent API Behavior

### DIFF
--- a/contracts/registries/LicenseRegistry.sol
+++ b/contracts/registries/LicenseRegistry.sol
@@ -348,7 +348,7 @@ contract LicenseRegistry is ILicenseRegistry, AccessManagedUpgradeable, UUPSUpgr
         if (index < length) {
             licenseTemplate = $.licenseTemplates[ipId];
             licenseTermsId = $.attachedLicenseTerms[ipId].at(index);
-        // consider the default license terms is attached to IP as the last one
+            // consider the default license terms is attached to IP as the last one
         } else if (index == length && $.defaultLicenseTemplate != address(0)) {
             licenseTemplate = $.defaultLicenseTemplate;
             licenseTermsId = $.defaultLicenseTermsId;

--- a/contracts/registries/LicenseRegistry.sol
+++ b/contracts/registries/LicenseRegistry.sol
@@ -247,6 +247,7 @@ contract LicenseRegistry is ILicenseRegistry, AccessManagedUpgradeable, UUPSUpgr
             if (!isNewParent && !isNewTerms) {
                 revert Errors.LicenseRegistry__DuplicateLicense(parentIpIds[i], licenseTemplate, licenseTermsIds[i]);
             }
+            // link child IP to parent IP with license terms
             $.parentLicenseTerms[childIpId][parentIpIds[i]] = licenseTermsIds[i];
         }
 
@@ -334,7 +335,7 @@ contract LicenseRegistry is ILicenseRegistry, AccessManagedUpgradeable, UUPSUpgr
         return _hasIpAttachedLicenseTerms(ipId, licenseTemplate, licenseTermsId);
     }
 
-    /// @notice Gets the attached license terms of an IP by its index.
+    /// @notice Gets the attached license terms of an IP by its index. default license terms will be the last one.
     /// @param ipId The address of the IP.
     /// @param index The index of the attached license terms within the array of all attached license terms of the IP.
     /// @return licenseTemplate The address of the license template where the license terms are defined.
@@ -344,6 +345,7 @@ contract LicenseRegistry is ILicenseRegistry, AccessManagedUpgradeable, UUPSUpgr
         uint256 index
     ) external view returns (address licenseTemplate, uint256 licenseTermsId) {
         LicenseRegistryStorage storage $ = _getLicenseRegistryStorage();
+        // consider the default license terms is attached to IP as the last one
         uint256 length = $.attachedLicenseTerms[ipId].length();
         if (index < length) {
             licenseTemplate = $.licenseTemplates[ipId];
@@ -358,7 +360,7 @@ contract LicenseRegistry is ILicenseRegistry, AccessManagedUpgradeable, UUPSUpgr
         }
     }
 
-    /// @notice Gets the count of attached license terms of an IP.
+    /// @notice Gets the count of attached license terms of an IP. the default license terms will be counted.
     /// @param ipId The address of the IP.
     /// @return The count of attached license terms.
     function getAttachedLicenseTermsCount(address ipId) external view returns (uint256) {
@@ -505,6 +507,8 @@ contract LicenseRegistry is ILicenseRegistry, AccessManagedUpgradeable, UUPSUpgr
         }
     }
 
+    /// @dev return the license template attached an IP,
+    /// return the default license template if the IP has no license template attached
     function _getLicenseTemplate(address ipId) internal view returns (address licenseTemplate) {
         licenseTemplate = _getLicenseRegistryStorage().licenseTemplates[ipId];
         if (licenseTemplate == address(0)) {

--- a/script/foundry/utils/DeployHelper.sol
+++ b/script/foundry/utils/DeployHelper.sol
@@ -710,6 +710,10 @@ contract DeployHelper is Script, BroadcastManager, JsonDeploymentHandler, Storag
         // IPGraphACL
         ipGraphACL.whitelistAddress(address(licenseRegistry));
         ipGraphACL.whitelistAddress(address(royaltyPolicyLAP));
+
+        // set default license to non-commercial social remixing
+        uint256 licenseId = pilTemplate.registerLicenseTerms(PILFlavors.nonCommercialSocialRemixing());
+        licenseRegistry.setDefaultLicenseTerms(address(pilTemplate), licenseId);
     }
 
     function _configureRoles() private {

--- a/test/foundry/integration/big-bang/SingleNftCollection.t.sol
+++ b/test/foundry/integration/big-bang/SingleNftCollection.t.sol
@@ -93,6 +93,14 @@ contract BigBang_Integration_SingleNftCollection is BaseIntegration {
 
         vm.startPrank(u.alice);
         licensingModule.attachLicenseTerms(ipAcct[1], address(pilTemplate), commDerivTermsId);
+        vm.expectRevert(
+            abi.encodeWithSelector(
+                Errors.LicenseRegistry__LicenseTermsAlreadyAttached.selector,
+                ipAcct[100],
+                address(pilTemplate),
+                ncSocialRemixTermsId
+            )
+        );
         licensingModule.attachLicenseTerms(ipAcct[100], address(pilTemplate), ncSocialRemixTermsId);
 
         vm.startPrank(u.bob);
@@ -102,6 +110,14 @@ contract BigBang_Integration_SingleNftCollection is BaseIntegration {
         vm.startPrank(u.bob);
         // NOTE: the two calls below achieve the same functionality
         // licensingModule.attachLicenseTerms(ipAcct[3], address(pilTemplate), ncSocialRemixTermsId);
+        vm.expectRevert(
+            abi.encodeWithSelector(
+                Errors.LicenseRegistry__LicenseTermsAlreadyAttached.selector,
+                ipAcct[3],
+                address(pilTemplate),
+                ncSocialRemixTermsId
+            )
+        );
         IIPAccount(payable(ipAcct[3])).execute(
             address(licensingModule),
             0,

--- a/test/foundry/integration/flows/disputes/Disputes.t.sol
+++ b/test/foundry/integration/flows/disputes/Disputes.t.sol
@@ -33,6 +33,14 @@ contract Flows_Integration_Disputes is BaseIntegration {
         ipAcct[3] = registerIpAccount(mockNFT, 3, u.carl);
 
         vm.startPrank(u.alice);
+        vm.expectRevert(
+            abi.encodeWithSelector(
+                Errors.LicenseRegistry__LicenseTermsAlreadyAttached.selector,
+                ipAcct[1],
+                address(pilTemplate),
+                ncSocialRemixTermsId
+            )
+        );
         licensingModule.attachLicenseTerms(ipAcct[1], address(pilTemplate), ncSocialRemixTermsId);
         vm.stopPrank();
     }

--- a/test/foundry/integration/flows/licensing/LicensingIntegration.t.sol
+++ b/test/foundry/integration/flows/licensing/LicensingIntegration.t.sol
@@ -84,6 +84,14 @@ contract LicensingIntegrationTest is BaseIntegration {
 
         // attach licenses
         vm.startPrank(u.alice);
+        vm.expectRevert(
+            abi.encodeWithSelector(
+                Errors.LicenseRegistry__LicenseTermsAlreadyAttached.selector,
+                ipAcct[1],
+                address(pilTemplate),
+                1
+            )
+        );
         licensingModule.attachLicenseTerms(ipAcct[1], address(pilTemplate), 1);
 
         assertEq(licenseRegistry.hasIpAttachedLicenseTerms(ipAcct[1], address(pilTemplate), 1), true);
@@ -93,12 +101,17 @@ contract LicensingIntegrationTest is BaseIntegration {
         assertEq(attachedTemplate, address(pilTemplate));
         assertEq(attachedId, 1);
 
+
+        (address defaultLicenseTemplate, uint256 defaultLicenseTermsId) = licenseRegistry.getDefaultLicenseTerms();
+        assertEq(defaultLicenseTemplate, address(pilTemplate));
+        assertEq(defaultLicenseTermsId, 1);
+
         licensingModule.attachLicenseTerms(ipAcct[1], address(pilTemplate), 2);
 
         assertEq(licenseRegistry.hasIpAttachedLicenseTerms(ipAcct[1], address(pilTemplate), 2), true);
         assertEq(licenseRegistry.getAttachedLicenseTermsCount(ipAcct[1]), 2);
 
-        (attachedTemplate, attachedId) = licenseRegistry.getAttachedLicenseTerms(ipAcct[1], 1);
+        (attachedTemplate, attachedId) = licenseRegistry.getAttachedLicenseTerms(ipAcct[1], 0);
         assertEq(attachedTemplate, address(pilTemplate));
         assertEq(attachedId, 2);
         vm.stopPrank();
@@ -113,7 +126,7 @@ contract LicensingIntegrationTest is BaseIntegration {
         licensingModule.registerDerivative(ipAcct[2], parentIpIds, licenseTermsIds, address(pilTemplate), "");
 
         assertEq(licenseRegistry.hasIpAttachedLicenseTerms(ipAcct[2], address(pilTemplate), 1), true);
-        assertEq(licenseRegistry.getAttachedLicenseTermsCount(ipAcct[2]), 1);
+        assertEq(licenseRegistry.getAttachedLicenseTermsCount(ipAcct[2]), 2);
         assertEq(licenseRegistry.isDerivativeIp(ipAcct[2]), true);
         assertEq(licenseRegistry.hasDerivativeIps(ipAcct[2]), false);
         assertEq(licenseRegistry.hasDerivativeIps(ipAcct[1]), true);
@@ -148,7 +161,7 @@ contract LicensingIntegrationTest is BaseIntegration {
         licensingModule.registerDerivativeWithLicenseTokens(ipAcct[3], licenseTokens, "");
 
         assertEq(licenseRegistry.hasIpAttachedLicenseTerms(ipAcct[3], address(pilTemplate), 1), true);
-        assertEq(licenseRegistry.getAttachedLicenseTermsCount(ipAcct[3]), 1);
+        assertEq(licenseRegistry.getAttachedLicenseTermsCount(ipAcct[3]), 2);
         assertEq(licenseRegistry.isDerivativeIp(ipAcct[3]), true);
         assertEq(licenseRegistry.hasDerivativeIps(ipAcct[3]), false);
         assertEq(licenseRegistry.hasDerivativeIps(ipAcct[1]), true);
@@ -186,7 +199,7 @@ contract LicensingIntegrationTest is BaseIntegration {
         licensingModule.registerDerivativeWithLicenseTokens(ipAcct[6], licenseTokens, "");
 
         assertEq(licenseRegistry.hasIpAttachedLicenseTerms(ipAcct[6], address(pilTemplate), 2), true);
-        assertEq(licenseRegistry.getAttachedLicenseTermsCount(ipAcct[6]), 1);
+        assertEq(licenseRegistry.getAttachedLicenseTermsCount(ipAcct[6]), 2);
         assertEq(licenseRegistry.isDerivativeIp(ipAcct[6]), true);
         assertEq(licenseRegistry.hasDerivativeIps(ipAcct[6]), false);
         assertEq(licenseRegistry.hasDerivativeIps(ipAcct[1]), true);
@@ -216,7 +229,7 @@ contract LicensingIntegrationTest is BaseIntegration {
         licensingModule.registerDerivative(ipAcct[7], parentIpIds, licenseTermsIds, address(pilTemplate), "");
 
         assertEq(licenseRegistry.hasIpAttachedLicenseTerms(ipAcct[7], address(pilTemplate), 2), true);
-        assertEq(licenseRegistry.getAttachedLicenseTermsCount(ipAcct[7]), 1);
+        assertEq(licenseRegistry.getAttachedLicenseTermsCount(ipAcct[7]), 2);
         assertEq(licenseRegistry.isDerivativeIp(ipAcct[7]), true);
         assertEq(licenseRegistry.hasDerivativeIps(ipAcct[7]), false);
         assertEq(licenseRegistry.hasDerivativeIps(ipAcct[1]), true);
@@ -277,6 +290,14 @@ contract LicensingIntegrationTest is BaseIntegration {
         );
 
         vm.prank(u.alice);
+        vm.expectRevert(
+            abi.encodeWithSelector(
+                Errors.LicenseRegistry__LicenseTermsAlreadyAttached.selector,
+                ipAcct[1],
+                address(pilTemplate),
+                ncSocialRemixTermsId
+            )
+        );
         licensingModule.attachLicenseTerms(ipAcct[1], address(pilTemplate), ncSocialRemixTermsId);
 
         address[] memory parentIpIds = new address[](1);

--- a/test/foundry/integration/flows/licensing/LicensingIntegration.t.sol
+++ b/test/foundry/integration/flows/licensing/LicensingIntegration.t.sol
@@ -101,7 +101,6 @@ contract LicensingIntegrationTest is BaseIntegration {
         assertEq(attachedTemplate, address(pilTemplate));
         assertEq(attachedId, 1);
 
-
         (address defaultLicenseTemplate, uint256 defaultLicenseTermsId) = licenseRegistry.getDefaultLicenseTerms();
         assertEq(defaultLicenseTemplate, address(pilTemplate));
         assertEq(defaultLicenseTermsId, 1);

--- a/test/foundry/integration/flows/licensing/LicensingScenarios.t.sol
+++ b/test/foundry/integration/flows/licensing/LicensingScenarios.t.sol
@@ -8,6 +8,7 @@ import { IERC20 } from "@openzeppelin/contracts/token/ERC20/IERC20.sol";
 
 // contract
 import { PILFlavors } from "../../../../../contracts/lib/PILFlavors.sol";
+import { Errors } from "../../../../../contracts/lib/Errors.sol";
 
 // test
 import { BaseIntegration } from "../../BaseIntegration.t.sol";
@@ -111,6 +112,14 @@ contract Licensing_Scenarios is BaseIntegration {
         // Add policies to IP account
         vm.startPrank(u.alice);
         licensingModule.attachLicenseTerms(ipAcct[1], address(pilTemplate), commRemixTermsId);
+        vm.expectRevert(
+            abi.encodeWithSelector(
+                Errors.LicenseRegistry__LicenseTermsAlreadyAttached.selector,
+                ipAcct[1],
+                address(pilTemplate),
+                ncSocialRemixTermsId
+            )
+        );
         licensingModule.attachLicenseTerms(ipAcct[1], address(pilTemplate), ncSocialRemixTermsId);
         licensingModule.attachLicenseTerms(ipAcct[1], address(pilTemplate), commTermsId);
         vm.stopPrank();

--- a/test/foundry/invariants/LicensingModule.t.sol
+++ b/test/foundry/invariants/LicensingModule.t.sol
@@ -288,12 +288,13 @@ contract LicensingModuleBaseInvariant is BaseTest {
 
     /// @notice Invariant to check all IpIds are either not attached or attached to the known license templates
     function invariant_onlyAttachableToKnownLicenseTemplates() public {
+        (address defaultLicenseTemplate, ) = licenseRegistry.getDefaultLicenseTerms();
         for (uint256 i = 0; i < ipIds.length; i++) {
             (address licenseTemplate, ) = _getAttachedLicenseTerms(ipIds[i], 0);
             if (licenseTemplate != address(0)) {
                 bool found = false;
                 for (uint256 j = 0; j < pils.length; j++) {
-                    if (licenseTemplate == pils[j]) {
+                    if (licenseTemplate == pils[j] || licenseTemplate == defaultLicenseTemplate) {
                         found = true;
                         break;
                     }
@@ -339,7 +340,7 @@ contract LicensingModuleBaseInvariant is BaseTest {
     /// @notice Invariant to check that harness has no control over other ipIds
     function invariant_othersIpNotChanged() public {
         for (uint256 i = 0; i < othersIpIds.length; i++) {
-            (address licenseTemplate, uint256 licenseTermsId) = _getAttachedLicenseTerms(othersIpIds[i], 0);
+            (address licenseTemplate, uint256 licenseTermsId) = _getAttachedLicenseTerms(othersIpIds[i], 1);
             // shall be uninitialized
             assertEq(licenseTemplate, address(0), "LicensingModuleBaseInvariant: licenseTemplate not 0");
             assertEq(licenseTermsId, 0, "LicensingModuleBaseInvariant: licenseTermsId not 0");

--- a/test/foundry/modules/licensing/LicensingModule.t.sol
+++ b/test/foundry/modules/licensing/LicensingModule.t.sol
@@ -461,6 +461,14 @@ contract LicensingModuleTest is BaseTest {
     function test_LicensingModule_mintLicenseTokens_revert_licensorIpNotRegistered() public {
         uint256 termsId = pilTemplate.registerLicenseTerms(PILFlavors.defaultValuesLicenseTerms());
         vm.prank(ipOwner1);
+        vm.expectRevert(
+            abi.encodeWithSelector(
+                Errors.LicenseRegistry__LicenseTermsAlreadyAttached.selector,
+                ipId1,
+                address(pilTemplate),
+                termsId
+            )
+        );
         licensingModule.attachLicenseTerms(ipId1, address(pilTemplate), termsId);
 
         vm.expectRevert(abi.encodeWithSelector(Errors.LicensingModule__LicensorIpNotRegistered.selector));
@@ -477,6 +485,14 @@ contract LicensingModuleTest is BaseTest {
     function test_LicensingModule_mintLicenseTokens_revert_invalidInputs() public {
         uint256 termsId = pilTemplate.registerLicenseTerms(PILFlavors.defaultValuesLicenseTerms());
         vm.prank(ipOwner1);
+        vm.expectRevert(
+            abi.encodeWithSelector(
+                Errors.LicenseRegistry__LicenseTermsAlreadyAttached.selector,
+                ipId1,
+                address(pilTemplate),
+                termsId
+            )
+        );
         licensingModule.attachLicenseTerms(ipId1, address(pilTemplate), termsId);
 
         address receiver = address(0x111);
@@ -541,6 +557,14 @@ contract LicensingModuleTest is BaseTest {
     function test_LicensingModule_mintLicenseTokens_revert_paused() public {
         uint256 termsId = pilTemplate.registerLicenseTerms(PILFlavors.defaultValuesLicenseTerms());
         vm.prank(ipOwner1);
+        vm.expectRevert(
+            abi.encodeWithSelector(
+                Errors.LicenseRegistry__LicenseTermsAlreadyAttached.selector,
+                ipId1,
+                address(pilTemplate),
+                termsId
+            )
+        );
         licensingModule.attachLicenseTerms(ipId1, address(pilTemplate), termsId);
 
         vm.prank(u.admin);
@@ -584,6 +608,14 @@ contract LicensingModuleTest is BaseTest {
     function test_LicensingModule_registerDerivativeWithLicenseTokens_singleParent() public {
         uint256 termsId = pilTemplate.registerLicenseTerms(PILFlavors.nonCommercialSocialRemixing());
         vm.prank(ipOwner1);
+        vm.expectRevert(
+            abi.encodeWithSelector(
+                Errors.LicenseRegistry__LicenseTermsAlreadyAttached.selector,
+                ipId1,
+                address(pilTemplate),
+                termsId
+            )
+        );
         licensingModule.attachLicenseTerms(ipId1, address(pilTemplate), termsId);
 
         uint256 lcTokenId = licensingModule.mintLicenseTokens({
@@ -682,7 +714,14 @@ contract LicensingModuleTest is BaseTest {
     function test_LicensingModule_registerDerivativeWithLicenseTokens_revert_pause() public {
         uint256 termsId = pilTemplate.registerLicenseTerms(PILFlavors.nonCommercialSocialRemixing());
         vm.prank(ipOwner1);
-
+        vm.expectRevert(
+            abi.encodeWithSelector(
+                Errors.LicenseRegistry__LicenseTermsAlreadyAttached.selector,
+                ipId1,
+                address(pilTemplate),
+                termsId
+            )
+        );
         licensingModule.attachLicenseTerms(ipId1, address(pilTemplate), termsId);
 
         uint256 lcTokenId = licensingModule.mintLicenseTokens({
@@ -707,8 +746,24 @@ contract LicensingModuleTest is BaseTest {
     function test_LicensingModule_registerDerivativeWithLicenseTokens_twoParents() public {
         uint256 termsId = pilTemplate.registerLicenseTerms(PILFlavors.nonCommercialSocialRemixing());
         vm.prank(ipOwner1);
+        vm.expectRevert(
+            abi.encodeWithSelector(
+                Errors.LicenseRegistry__LicenseTermsAlreadyAttached.selector,
+                ipId1,
+                address(pilTemplate),
+                termsId
+            )
+        );
         licensingModule.attachLicenseTerms(ipId1, address(pilTemplate), termsId);
         vm.prank(ipOwner2);
+        vm.expectRevert(
+            abi.encodeWithSelector(
+                Errors.LicenseRegistry__LicenseTermsAlreadyAttached.selector,
+                ipId2,
+                address(pilTemplate),
+                termsId
+            )
+        );
         licensingModule.attachLicenseTerms(ipId2, address(pilTemplate), termsId);
 
         uint256 lcTokenId1 = licensingModule.mintLicenseTokens({
@@ -899,6 +954,14 @@ contract LicensingModuleTest is BaseTest {
     function test_LicensingModule_registerDerivativeWithLicenseTokens_revert_childAlreadyAttachedLicense() public {
         uint256 termsId = pilTemplate.registerLicenseTerms(PILFlavors.nonCommercialSocialRemixing());
         vm.prank(ipOwner1);
+        vm.expectRevert(
+            abi.encodeWithSelector(
+                Errors.LicenseRegistry__LicenseTermsAlreadyAttached.selector,
+                ipId1,
+                address(pilTemplate),
+                termsId
+            )
+        );
         licensingModule.attachLicenseTerms(ipId1, address(pilTemplate), termsId);
 
         uint256 lcTokenId = licensingModule.mintLicenseTokens({
@@ -921,8 +984,24 @@ contract LicensingModuleTest is BaseTest {
     function test_LicensingModule_registerDerivativeWithLicenseTokens_revert_DerivativeIpAlreadyHasChildIp() public {
         uint256 termsId = pilTemplate.registerLicenseTerms(PILFlavors.nonCommercialSocialRemixing());
         vm.prank(ipOwner1);
+        vm.expectRevert(
+            abi.encodeWithSelector(
+                Errors.LicenseRegistry__LicenseTermsAlreadyAttached.selector,
+                ipId1,
+                address(pilTemplate),
+                termsId
+            )
+        );
         licensingModule.attachLicenseTerms(ipId1, address(pilTemplate), termsId);
         vm.prank(ipOwner2);
+        vm.expectRevert(
+            abi.encodeWithSelector(
+                Errors.LicenseRegistry__LicenseTermsAlreadyAttached.selector,
+                ipId2,
+                address(pilTemplate),
+                termsId
+            )
+        );
         licensingModule.attachLicenseTerms(ipId2, address(pilTemplate), termsId);
 
         uint256 lcTokenId1 = licensingModule.mintLicenseTokens({
@@ -958,8 +1037,24 @@ contract LicensingModuleTest is BaseTest {
     function test_LicensingModule_registerDerivativeWithLicenseTokens_revert_AlreadyRegisteredAsDerivative() public {
         uint256 termsId = pilTemplate.registerLicenseTerms(PILFlavors.nonCommercialSocialRemixing());
         vm.prank(ipOwner1);
+        vm.expectRevert(
+            abi.encodeWithSelector(
+                Errors.LicenseRegistry__LicenseTermsAlreadyAttached.selector,
+                ipId1,
+                address(pilTemplate),
+                termsId
+            )
+        );
         licensingModule.attachLicenseTerms(ipId1, address(pilTemplate), termsId);
         vm.prank(ipOwner2);
+        vm.expectRevert(
+            abi.encodeWithSelector(
+                Errors.LicenseRegistry__LicenseTermsAlreadyAttached.selector,
+                ipId2,
+                address(pilTemplate),
+                termsId
+            )
+        );
         licensingModule.attachLicenseTerms(ipId2, address(pilTemplate), termsId);
 
         uint256 lcTokenId1 = licensingModule.mintLicenseTokens({
@@ -997,6 +1092,14 @@ contract LicensingModuleTest is BaseTest {
         accessController.setAllPermissions(ipId3, ipOwner2, AccessPermission.ALLOW);
         uint256 termsId = pilTemplate.registerLicenseTerms(PILFlavors.nonCommercialSocialRemixing());
         vm.prank(ipOwner1);
+        vm.expectRevert(
+            abi.encodeWithSelector(
+                Errors.LicenseRegistry__LicenseTermsAlreadyAttached.selector,
+                ipId1,
+                address(pilTemplate),
+                termsId
+            )
+        );
         licensingModule.attachLicenseTerms(ipId1, address(pilTemplate), termsId);
 
         uint256 lcTokenId = licensingModule.mintLicenseTokens({
@@ -1018,6 +1121,14 @@ contract LicensingModuleTest is BaseTest {
     function test_LicensingModule_registerDerivativeWithLicenseTokens_ownedByChildIp() public {
         uint256 termsId = pilTemplate.registerLicenseTerms(PILFlavors.nonCommercialSocialRemixing());
         vm.prank(ipOwner1);
+        vm.expectRevert(
+            abi.encodeWithSelector(
+                Errors.LicenseRegistry__LicenseTermsAlreadyAttached.selector,
+                ipId1,
+                address(pilTemplate),
+                termsId
+            )
+        );
         licensingModule.attachLicenseTerms(ipId1, address(pilTemplate), termsId);
 
         uint256 lcTokenId = licensingModule.mintLicenseTokens({
@@ -1039,6 +1150,14 @@ contract LicensingModuleTest is BaseTest {
     function test_LicensingModule_registerDerivativeWithLicenseTokens_revert_notLicensee() public {
         uint256 termsId = pilTemplate.registerLicenseTerms(PILFlavors.nonCommercialSocialRemixing());
         vm.prank(ipOwner1);
+        vm.expectRevert(
+            abi.encodeWithSelector(
+                Errors.LicenseRegistry__LicenseTermsAlreadyAttached.selector,
+                ipId1,
+                address(pilTemplate),
+                termsId
+            )
+        );
         licensingModule.attachLicenseTerms(ipId1, address(pilTemplate), termsId);
 
         uint256 lcTokenId = licensingModule.mintLicenseTokens({
@@ -1069,6 +1188,14 @@ contract LicensingModuleTest is BaseTest {
     function test_LicensingModule_singleTransfer_verifyOk() public {
         uint256 termsId = pilTemplate.registerLicenseTerms(PILFlavors.nonCommercialSocialRemixing());
         vm.prank(ipOwner1);
+        vm.expectRevert(
+            abi.encodeWithSelector(
+                Errors.LicenseRegistry__LicenseTermsAlreadyAttached.selector,
+                ipId1,
+                address(pilTemplate),
+                termsId
+            )
+        );
         licensingModule.attachLicenseTerms(ipId1, address(pilTemplate), termsId);
 
         uint256 lcTokenId = licensingModule.mintLicenseTokens({
@@ -1301,6 +1428,14 @@ contract LicensingModuleTest is BaseTest {
         );
 
         vm.prank(ipOwner1);
+        vm.expectRevert(
+            abi.encodeWithSelector(
+                Errors.LicenseRegistry__LicenseTermsAlreadyAttached.selector,
+                ipId1,
+                address(pilTemplate),
+                socialRemixTermsId
+            )
+        );
         licensingModule.attachLicenseTerms(ipId1, address(pilTemplate), socialRemixTermsId);
         vm.prank(ipOwner2);
         licensingModule.attachLicenseTerms(ipId2, address(pilTemplate), commUseTermsId);
@@ -1739,6 +1874,14 @@ contract LicensingModuleTest is BaseTest {
         vm.prank(ipOwner1);
         licensingModule.setLicensingConfig(ipId1, address(pilTemplate), termsId, licensingConfig);
         vm.prank(ipOwner1);
+        vm.expectRevert(
+            abi.encodeWithSelector(
+                Errors.LicenseRegistry__LicenseTermsAlreadyAttached.selector,
+                ipId1,
+                address(pilTemplate),
+                termsId
+            )
+        );
         licensingModule.attachLicenseTerms(ipId1, address(pilTemplate), termsId);
 
         address[] memory parentIpIds = new address[](1);

--- a/test/foundry/modules/licensing/LicensingModule.t.sol
+++ b/test/foundry/modules/licensing/LicensingModule.t.sol
@@ -137,11 +137,13 @@ contract LicensingModuleTest is BaseTest {
         assertFalse(licenseRegistry.isDerivativeIp(ipId1));
         assertTrue(licenseRegistry.exists(address(pilTemplate), termsId1));
 
-        uint256 termsId2 = pilTemplate.registerLicenseTerms(PILFlavors.commercialUse({
-            mintingFee: 0,
-            currencyToken: address(erc20),
-            royaltyPolicy: address(royaltyPolicyLAP)
-        }));
+        uint256 termsId2 = pilTemplate.registerLicenseTerms(
+            PILFlavors.commercialUse({
+                mintingFee: 0,
+                currencyToken: address(erc20),
+                royaltyPolicy: address(royaltyPolicyLAP)
+            })
+        );
         vm.expectEmit();
         emit ILicensingModule.LicenseTermsAttached(ipOwner1, ipId1, address(pilTemplate), termsId2);
         vm.prank(ipOwner1);
@@ -641,12 +643,14 @@ contract LicensingModuleTest is BaseTest {
     }
 
     function test_LicensingModule_registerDerivativeWithLicenseTokens_privateLicense() public {
-        uint256 termsId = pilTemplate.registerLicenseTerms(PILFlavors.commercialRemix({
-            mintingFee: 0,
-            commercialRevShare: 10,
-            currencyToken: address(erc20),
-            royaltyPolicy: address(royaltyPolicyLAP)
-        }));
+        uint256 termsId = pilTemplate.registerLicenseTerms(
+            PILFlavors.commercialRemix({
+                mintingFee: 0,
+                commercialRevShare: 10,
+                currencyToken: address(erc20),
+                royaltyPolicy: address(royaltyPolicyLAP)
+            })
+        );
 
         vm.prank(ipOwner1);
         uint256 lcTokenId = licensingModule.mintLicenseTokens({

--- a/test/foundry/modules/licensing/LicensingModule.t.sol
+++ b/test/foundry/modules/licensing/LicensingModule.t.sol
@@ -73,7 +73,7 @@ contract LicensingModuleTest is BaseTest {
         assertEq(licenseTemplate, address(pilTemplate));
         assertEq(licenseTermsId, termsId);
         assertTrue(licenseRegistry.hasIpAttachedLicenseTerms(ipId1, address(pilTemplate), termsId));
-        assertEq(licenseRegistry.getAttachedLicenseTermsCount(ipId1), 1);
+        assertEq(licenseRegistry.getAttachedLicenseTermsCount(ipId1), 2);
         assertEq(licenseRegistry.getDerivativeIpCount(ipId1), 0);
         assertEq(licenseRegistry.getParentIpCount(ipId1), 0);
         assertFalse(licenseRegistry.getLicensingConfig(ipId1, address(pilTemplate), termsId).isSet);
@@ -94,7 +94,7 @@ contract LicensingModuleTest is BaseTest {
         assertEq(licenseTemplate, address(pilTemplate));
         assertEq(licenseTermsId, termsId);
         assertTrue(licenseRegistry.hasIpAttachedLicenseTerms(ipId1, address(pilTemplate), termsId));
-        assertEq(licenseRegistry.getAttachedLicenseTermsCount(ipId1), 1);
+        assertEq(licenseRegistry.getAttachedLicenseTermsCount(ipId1), 2);
         assertEq(licenseRegistry.getDerivativeIpCount(ipId1), 0);
         assertEq(licenseRegistry.getParentIpCount(ipId1), 0);
         assertFalse(licenseRegistry.getLicensingConfig(ipId1, address(pilTemplate), termsId).isSet);
@@ -110,7 +110,7 @@ contract LicensingModuleTest is BaseTest {
         assertEq(licenseTemplate, address(pilTemplate));
         assertEq(licenseTermsId, termsId);
         assertTrue(licenseRegistry.hasIpAttachedLicenseTerms(ipId2, address(pilTemplate), termsId));
-        assertEq(licenseRegistry.getAttachedLicenseTermsCount(ipId2), 1);
+        assertEq(licenseRegistry.getAttachedLicenseTermsCount(ipId2), 2);
         assertEq(licenseRegistry.getDerivativeIpCount(ipId2), 0);
         assertEq(licenseRegistry.getParentIpCount(ipId2), 0);
         assertFalse(licenseRegistry.getLicensingConfig(ipId2, address(pilTemplate), termsId).isSet);
@@ -129,7 +129,7 @@ contract LicensingModuleTest is BaseTest {
         assertEq(licenseTemplate1, address(pilTemplate));
         assertEq(licenseTermsId1, termsId1);
         assertTrue(licenseRegistry.hasIpAttachedLicenseTerms(ipId1, address(pilTemplate), termsId1));
-        assertEq(licenseRegistry.getAttachedLicenseTermsCount(ipId1), 1);
+        assertEq(licenseRegistry.getAttachedLicenseTermsCount(ipId1), 2);
         assertEq(licenseRegistry.getDerivativeIpCount(ipId1), 0);
         assertEq(licenseRegistry.getParentIpCount(ipId1), 0);
         assertFalse(licenseRegistry.getLicensingConfig(ipId1, address(pilTemplate), termsId1).isSet);
@@ -137,7 +137,11 @@ contract LicensingModuleTest is BaseTest {
         assertFalse(licenseRegistry.isDerivativeIp(ipId1));
         assertTrue(licenseRegistry.exists(address(pilTemplate), termsId1));
 
-        uint256 termsId2 = pilTemplate.registerLicenseTerms(PILFlavors.nonCommercialSocialRemixing());
+        uint256 termsId2 = pilTemplate.registerLicenseTerms(PILFlavors.commercialUse({
+            mintingFee: 0,
+            currencyToken: address(erc20),
+            royaltyPolicy: address(royaltyPolicyLAP)
+        }));
         vm.expectEmit();
         emit ILicensingModule.LicenseTermsAttached(ipOwner1, ipId1, address(pilTemplate), termsId2);
         vm.prank(ipOwner1);
@@ -146,7 +150,7 @@ contract LicensingModuleTest is BaseTest {
         assertEq(licenseTemplate2, address(pilTemplate));
         assertEq(licenseTermsId2, termsId2);
         assertTrue(licenseRegistry.hasIpAttachedLicenseTerms(ipId1, address(pilTemplate), termsId2));
-        assertEq(licenseRegistry.getAttachedLicenseTermsCount(ipId1), 2);
+        assertEq(licenseRegistry.getAttachedLicenseTermsCount(ipId1), 3);
         assertEq(licenseRegistry.getDerivativeIpCount(ipId1), 0);
         assertEq(licenseRegistry.getParentIpCount(ipId1), 0);
         assertFalse(licenseRegistry.getLicensingConfig(ipId1, address(pilTemplate), termsId2).isSet);
@@ -219,7 +223,7 @@ contract LicensingModuleTest is BaseTest {
         licensingModule.registerDerivativeWithLicenseTokens(ipId2, licenseTokens, "");
 
         assertEq(licenseRegistry.hasIpAttachedLicenseTerms(ipId2, address(pilTemplate), termsId), true);
-        assertEq(licenseRegistry.getAttachedLicenseTermsCount(ipId2), 1);
+        assertEq(licenseRegistry.getAttachedLicenseTermsCount(ipId2), 2);
         assertEq(licenseRegistry.isDerivativeIp(ipId2), true);
         assertEq(licenseRegistry.hasDerivativeIps(ipId2), false);
         assertEq(licenseRegistry.hasDerivativeIps(ipId1), true);
@@ -461,14 +465,6 @@ contract LicensingModuleTest is BaseTest {
     function test_LicensingModule_mintLicenseTokens_revert_licensorIpNotRegistered() public {
         uint256 termsId = pilTemplate.registerLicenseTerms(PILFlavors.defaultValuesLicenseTerms());
         vm.prank(ipOwner1);
-        vm.expectRevert(
-            abi.encodeWithSelector(
-                Errors.LicenseRegistry__LicenseTermsAlreadyAttached.selector,
-                ipId1,
-                address(pilTemplate),
-                termsId
-            )
-        );
         licensingModule.attachLicenseTerms(ipId1, address(pilTemplate), termsId);
 
         vm.expectRevert(abi.encodeWithSelector(Errors.LicensingModule__LicensorIpNotRegistered.selector));
@@ -485,14 +481,6 @@ contract LicensingModuleTest is BaseTest {
     function test_LicensingModule_mintLicenseTokens_revert_invalidInputs() public {
         uint256 termsId = pilTemplate.registerLicenseTerms(PILFlavors.defaultValuesLicenseTerms());
         vm.prank(ipOwner1);
-        vm.expectRevert(
-            abi.encodeWithSelector(
-                Errors.LicenseRegistry__LicenseTermsAlreadyAttached.selector,
-                ipId1,
-                address(pilTemplate),
-                termsId
-            )
-        );
         licensingModule.attachLicenseTerms(ipId1, address(pilTemplate), termsId);
 
         address receiver = address(0x111);
@@ -557,14 +545,6 @@ contract LicensingModuleTest is BaseTest {
     function test_LicensingModule_mintLicenseTokens_revert_paused() public {
         uint256 termsId = pilTemplate.registerLicenseTerms(PILFlavors.defaultValuesLicenseTerms());
         vm.prank(ipOwner1);
-        vm.expectRevert(
-            abi.encodeWithSelector(
-                Errors.LicenseRegistry__LicenseTermsAlreadyAttached.selector,
-                ipId1,
-                address(pilTemplate),
-                termsId
-            )
-        );
         licensingModule.attachLicenseTerms(ipId1, address(pilTemplate), termsId);
 
         vm.prank(u.admin);
@@ -640,7 +620,7 @@ contract LicensingModuleTest is BaseTest {
         licensingModule.registerDerivativeWithLicenseTokens(ipId2, licenseTokens, "");
 
         assertEq(licenseRegistry.hasIpAttachedLicenseTerms(ipId2, address(pilTemplate), termsId), true);
-        assertEq(licenseRegistry.getAttachedLicenseTermsCount(ipId2), 1);
+        assertEq(licenseRegistry.getAttachedLicenseTermsCount(ipId2), 2);
         assertEq(licenseRegistry.isDerivativeIp(ipId2), true);
         assertEq(licenseRegistry.hasDerivativeIps(ipId2), false);
         assertEq(licenseRegistry.hasDerivativeIps(ipId1), true);
@@ -661,7 +641,12 @@ contract LicensingModuleTest is BaseTest {
     }
 
     function test_LicensingModule_registerDerivativeWithLicenseTokens_privateLicense() public {
-        uint256 termsId = pilTemplate.registerLicenseTerms(PILFlavors.nonCommercialSocialRemixing());
+        uint256 termsId = pilTemplate.registerLicenseTerms(PILFlavors.commercialRemix({
+            mintingFee: 0,
+            commercialRevShare: 10,
+            currencyToken: address(erc20),
+            royaltyPolicy: address(royaltyPolicyLAP)
+        }));
 
         vm.prank(ipOwner1);
         uint256 lcTokenId = licensingModule.mintLicenseTokens({
@@ -691,7 +676,7 @@ contract LicensingModuleTest is BaseTest {
         assertEq(licenseRegistry.hasIpAttachedLicenseTerms(ipId2, address(pilTemplate), termsId), true);
         assertEq(licenseRegistry.hasIpAttachedLicenseTerms(ipId1, address(pilTemplate), termsId), false);
 
-        assertEq(licenseRegistry.getAttachedLicenseTermsCount(ipId2), 1);
+        assertEq(licenseRegistry.getAttachedLicenseTermsCount(ipId2), 2);
         assertEq(licenseRegistry.isDerivativeIp(ipId2), true);
         assertEq(licenseRegistry.hasDerivativeIps(ipId2), false);
         assertEq(licenseRegistry.hasDerivativeIps(ipId1), true);
@@ -805,7 +790,7 @@ contract LicensingModuleTest is BaseTest {
         licensingModule.registerDerivativeWithLicenseTokens(ipId3, licenseTokens, "");
 
         assertEq(licenseRegistry.hasIpAttachedLicenseTerms(ipId3, address(pilTemplate), termsId), true);
-        assertEq(licenseRegistry.getAttachedLicenseTermsCount(ipId3), 1);
+        assertEq(licenseRegistry.getAttachedLicenseTermsCount(ipId3), 2);
         assertEq(licenseRegistry.isDerivativeIp(ipId3), true);
         assertEq(licenseRegistry.hasDerivativeIps(ipId3), false);
         assertEq(licenseRegistry.getDerivativeIpCount(ipId3), 0);
@@ -906,7 +891,7 @@ contract LicensingModuleTest is BaseTest {
         licensingModule.registerDerivativeWithLicenseTokens(ipId3, licenseTokens, "");
 
         assertEq(licenseRegistry.hasIpAttachedLicenseTerms(ipId3, address(pilTemplate), expiredTermsId), true);
-        assertEq(licenseRegistry.getAttachedLicenseTermsCount(ipId3), 1);
+        assertEq(licenseRegistry.getAttachedLicenseTermsCount(ipId3), 2);
         assertEq(licenseRegistry.isDerivativeIp(ipId3), true);
         assertEq(licenseRegistry.hasDerivativeIps(ipId3), false);
         assertEq(licenseRegistry.getDerivativeIpCount(ipId3), 0);
@@ -976,7 +961,7 @@ contract LicensingModuleTest is BaseTest {
         uint256[] memory licenseTokens = new uint256[](1);
         licenseTokens[0] = lcTokenId;
 
-        vm.expectRevert(abi.encodeWithSelector(Errors.LicenseRegistry__DerivativeIpAlreadyHasLicense.selector, ipId1));
+        vm.expectRevert(abi.encodeWithSelector(Errors.LicenseRegistry__DerivativeIsParent.selector, ipId1));
         vm.prank(ipOwner1);
         licensingModule.registerDerivativeWithLicenseTokens(ipId1, licenseTokens, "");
     }
@@ -1216,7 +1201,7 @@ contract LicensingModuleTest is BaseTest {
         licensingModule.registerDerivativeWithLicenseTokens(ipId3, licenseTokens, "");
 
         assertEq(licenseRegistry.hasIpAttachedLicenseTerms(ipId3, address(pilTemplate), termsId), true);
-        assertEq(licenseRegistry.getAttachedLicenseTermsCount(ipId3), 1);
+        assertEq(licenseRegistry.getAttachedLicenseTermsCount(ipId3), 2);
         assertEq(licenseRegistry.isDerivativeIp(ipId3), true);
         assertEq(licenseRegistry.hasDerivativeIps(ipId3), false);
         assertEq(licenseRegistry.hasDerivativeIps(ipId1), true);

--- a/test/foundry/modules/licensing/PILicenseTemplate.t.sol
+++ b/test/foundry/modules/licensing/PILicenseTemplate.t.sol
@@ -52,30 +52,30 @@ contract PILicenseTemplateTest is BaseTest {
     // this contract is for testing for each PILicenseTemplate's functions
     // register license terms with PILTerms struct
     function test_PILicenseTemplate_registerLicenseTerms() public {
-        uint256 defaultTermsId = pilTemplate.registerLicenseTerms(PILFlavors.defaultValuesLicenseTerms());
-        assertEq(defaultTermsId, 1);
-        (address royaltyPolicy, uint32 royaltyPercent, uint256 mintingFee, address currency) = pilTemplate
-            .getRoyaltyPolicy(defaultTermsId);
-        assertEq(royaltyPolicy, address(0), "royaltyPolicy should be address(0)");
-        assertEq(royaltyPercent, 0, "royaltyPercent should be empty");
-        assertEq(mintingFee, 0, "mintingFee should be 0");
-        assertEq(currency, address(0), "currency should be address(0)");
-        assertTrue(pilTemplate.isLicenseTransferable(defaultTermsId), "license should be transferable");
-        assertEq(pilTemplate.getLicenseTermsId(PILFlavors.defaultValuesLicenseTerms()), 1);
-        assertEq(pilTemplate.getExpireTime(defaultTermsId, block.timestamp), 0, "expire time should be 0");
-        assertTrue(pilTemplate.exists(defaultTermsId), "license terms should exist");
-
         uint256 socialRemixTermsId = pilTemplate.registerLicenseTerms(PILFlavors.nonCommercialSocialRemixing());
-        assertEq(socialRemixTermsId, 2);
-        (royaltyPolicy, royaltyPercent, mintingFee, currency) = pilTemplate.getRoyaltyPolicy(socialRemixTermsId);
+        assertEq(socialRemixTermsId, 1);
+        (address royaltyPolicy, uint32 royaltyPercent, uint256 mintingFee, address currency) = pilTemplate
+            .getRoyaltyPolicy(socialRemixTermsId);
         assertEq(royaltyPolicy, address(0));
         assertEq(royaltyPercent, 0);
         assertEq(mintingFee, 0);
         assertEq(currency, address(0));
         assertTrue(pilTemplate.isLicenseTransferable(socialRemixTermsId));
-        assertEq(pilTemplate.getLicenseTermsId(PILFlavors.nonCommercialSocialRemixing()), 2);
+        assertEq(pilTemplate.getLicenseTermsId(PILFlavors.nonCommercialSocialRemixing()), 1);
         assertEq(pilTemplate.getExpireTime(socialRemixTermsId, block.timestamp), 0, "expire time should be 0");
         assertTrue(pilTemplate.exists(socialRemixTermsId), "license terms should exist");
+
+        uint256 defaultTermsId = pilTemplate.registerLicenseTerms(PILFlavors.defaultValuesLicenseTerms());
+        assertEq(defaultTermsId, 2);
+        (royaltyPolicy, royaltyPercent, mintingFee, currency) = pilTemplate.getRoyaltyPolicy(defaultTermsId);
+        assertEq(royaltyPolicy, address(0), "royaltyPolicy should be address(0)");
+        assertEq(royaltyPercent, 0, "royaltyPercent should be empty");
+        assertEq(mintingFee, 0, "mintingFee should be 0");
+        assertEq(currency, address(0), "currency should be address(0)");
+        assertTrue(pilTemplate.isLicenseTransferable(defaultTermsId), "license should be transferable");
+        assertEq(pilTemplate.getLicenseTermsId(PILFlavors.defaultValuesLicenseTerms()), 2);
+        assertEq(pilTemplate.getExpireTime(defaultTermsId, block.timestamp), 0, "expire time should be 0");
+        assertTrue(pilTemplate.exists(defaultTermsId), "license terms should exist");
 
         uint256 commUseTermsId = pilTemplate.registerLicenseTerms(
             PILFlavors.commercialUse({
@@ -336,7 +336,14 @@ contract PILicenseTemplateTest is BaseTest {
         vm.prank(ipOwner[2]);
         licensingModule.registerDerivative(ipAcct[2], parentIpIds, licenseTermsIds, address(pilTemplate), "");
 
-        uint256 anotherTermsId = pilTemplate.registerLicenseTerms(PILFlavors.nonCommercialSocialRemixing());
+        uint256 anotherTermsId = pilTemplate.registerLicenseTerms(
+            PILFlavors.commercialRemix({
+                mintingFee: 0,
+                commercialRevShare: 10,
+                currencyToken: address(erc20),
+                royaltyPolicy: address(royaltyPolicyLAP)
+            })
+        );
 
         bool result = pilTemplate.verifyMintLicenseToken(anotherTermsId, ipOwner[3], ipAcct[2], 1);
         assertFalse(result);

--- a/test/foundry/registries/LicenseRegistry.t.sol
+++ b/test/foundry/registries/LicenseRegistry.t.sol
@@ -185,6 +185,14 @@ contract LicenseRegistryTest is BaseTest {
         uint256 socialRemixTermsId = pilTemplate.registerLicenseTerms(PILFlavors.nonCommercialSocialRemixing());
 
         vm.prank(ipOwner[1]);
+        vm.expectRevert(
+            abi.encodeWithSelector(
+                Errors.LicenseRegistry__LicenseTermsAlreadyAttached.selector,
+                ipAcct[1],
+                address(pilTemplate),
+                socialRemixTermsId
+            )
+        );
         licensingModule.attachLicenseTerms(ipAcct[1], address(pilTemplate), socialRemixTermsId);
         vm.expectRevert(abi.encodeWithSelector(Errors.LicenseRegistry__IndexOutOfBounds.selector, ipAcct[1], 1, 1));
         licenseRegistry.getAttachedLicenseTerms(ipAcct[1], 1);
@@ -226,8 +234,25 @@ contract LicenseRegistryTest is BaseTest {
     function test_LicenseRegistry_registerDerivativeIp() public {
         uint256 socialRemixTermsId = pilTemplate.registerLicenseTerms(PILFlavors.nonCommercialSocialRemixing());
         vm.prank(ipOwner[1]);
+        vm.expectRevert(
+            abi.encodeWithSelector(
+                Errors.LicenseRegistry__LicenseTermsAlreadyAttached.selector,
+                ipAcct[1],
+                address(pilTemplate),
+                socialRemixTermsId
+            )
+        );
         licensingModule.attachLicenseTerms(ipAcct[1], address(pilTemplate), socialRemixTermsId);
+
         vm.prank(ipOwner[2]);
+        vm.expectRevert(
+            abi.encodeWithSelector(
+                Errors.LicenseRegistry__LicenseTermsAlreadyAttached.selector,
+                ipAcct[2],
+                address(pilTemplate),
+                socialRemixTermsId
+            )
+        );
         licensingModule.attachLicenseTerms(ipAcct[2], address(pilTemplate), socialRemixTermsId);
 
         address[] memory parentIpIds = new address[](2);
@@ -258,8 +283,24 @@ contract LicenseRegistryTest is BaseTest {
     function test_LicenseRegistry_registerDerivativeIp_unattachedLicenseTerm_usingLicenseToken() public {
         uint256 socialRemixTermsId = pilTemplate.registerLicenseTerms(PILFlavors.nonCommercialSocialRemixing());
         vm.prank(ipOwner[1]);
+        vm.expectRevert(
+            abi.encodeWithSelector(
+                Errors.LicenseRegistry__LicenseTermsAlreadyAttached.selector,
+                ipAcct[1],
+                address(pilTemplate),
+                socialRemixTermsId
+            )
+        );
         licensingModule.attachLicenseTerms(ipAcct[1], address(pilTemplate), socialRemixTermsId);
         vm.prank(ipOwner[2]);
+        vm.expectRevert(
+            abi.encodeWithSelector(
+                Errors.LicenseRegistry__LicenseTermsAlreadyAttached.selector,
+                ipAcct[2],
+                address(pilTemplate),
+                socialRemixTermsId
+            )
+        );
         licensingModule.attachLicenseTerms(ipAcct[2], address(pilTemplate), socialRemixTermsId);
 
         uint256 commercialRemixTermsId = pilTemplate.registerLicenseTerms(
@@ -306,8 +347,24 @@ contract LicenseRegistryTest is BaseTest {
     function test_LicenseRegistry_registerDerivativeIp_unmatchLicenseTemplate_usingLicenseToken() public {
         uint256 socialRemixTermsId = pilTemplate.registerLicenseTerms(PILFlavors.nonCommercialSocialRemixing());
         vm.prank(ipOwner[1]);
+        vm.expectRevert(
+            abi.encodeWithSelector(
+                Errors.LicenseRegistry__LicenseTermsAlreadyAttached.selector,
+                ipAcct[1],
+                address(pilTemplate),
+                socialRemixTermsId
+            )
+        );
         licensingModule.attachLicenseTerms(ipAcct[1], address(pilTemplate), socialRemixTermsId);
         vm.prank(ipOwner[2]);
+        vm.expectRevert(
+            abi.encodeWithSelector(
+                Errors.LicenseRegistry__LicenseTermsAlreadyAttached.selector,
+                ipAcct[2],
+                address(pilTemplate),
+                socialRemixTermsId
+            )
+        );
         licensingModule.attachLicenseTerms(ipAcct[2], address(pilTemplate), socialRemixTermsId);
 
         MockLicenseTemplate pilTemplate2 = new MockLicenseTemplate();
@@ -343,6 +400,14 @@ contract LicenseRegistryTest is BaseTest {
     function test_LicenseRegistry_registerDerivativeIp_revert_DuplicateLicense() public {
         uint256 socialRemixTermsId = pilTemplate.registerLicenseTerms(PILFlavors.nonCommercialSocialRemixing());
         vm.prank(ipOwner[1]);
+        vm.expectRevert(
+            abi.encodeWithSelector(
+                Errors.LicenseRegistry__LicenseTermsAlreadyAttached.selector,
+                ipAcct[1],
+                address(pilTemplate),
+                socialRemixTermsId
+            )
+        );
         licensingModule.attachLicenseTerms(ipAcct[1], address(pilTemplate), socialRemixTermsId);
 
         address[] memory parentIpIds = new address[](2);
@@ -397,6 +462,14 @@ contract LicenseRegistryTest is BaseTest {
     function test_LicenseRegistry_registerDerivativeIp_revert_UnattachedLicenseTermsId() public {
         uint256 socialRemixTermsId = pilTemplate.registerLicenseTerms(PILFlavors.nonCommercialSocialRemixing());
         vm.prank(ipOwner[1]);
+        vm.expectRevert(
+            abi.encodeWithSelector(
+                Errors.LicenseRegistry__LicenseTermsAlreadyAttached.selector,
+                ipAcct[1],
+                address(pilTemplate),
+                socialRemixTermsId
+            )
+        );
         licensingModule.attachLicenseTerms(ipAcct[1], address(pilTemplate), socialRemixTermsId);
         uint256 commercialRemixTermsId = pilTemplate.registerLicenseTerms(
             PILFlavors.commercialRemix(100, 10, address(royaltyPolicyLAP), address(erc20))
@@ -508,13 +581,29 @@ contract LicenseRegistryTest is BaseTest {
         terms1.expiration = 0;
         uint256 termsId1 = pilTemplate.registerLicenseTerms(terms1);
         vm.prank(ipOwner[1]);
+        vm.expectRevert(
+            abi.encodeWithSelector(
+                Errors.LicenseRegistry__LicenseTermsAlreadyAttached.selector,
+                ipAcct[1],
+                address(pilTemplate),
+                termsId1
+            )
+        );
         licensingModule.attachLicenseTerms(ipAcct[1], address(pilTemplate), termsId1);
 
         PILTerms memory terms2 = PILFlavors.nonCommercialSocialRemixing();
         terms2.expiration = 400;
         uint256 termsId2 = pilTemplate.registerLicenseTerms(terms2);
         vm.prank(ipOwner[2]);
-        licensingModule.attachLicenseTerms(ipAcct[2], address(pilTemplate), termsId2);
+        vm.expectRevert(
+            abi.encodeWithSelector(
+                Errors.LicenseRegistry__LicenseTermsAlreadyAttached.selector,
+                ipAcct[2],
+                address(pilTemplate),
+                termsId1
+            )
+        );
+    licensingModule.attachLicenseTerms(ipAcct[2], address(pilTemplate), termsId2);
 
         address[] memory parentIpIds = new address[](2);
         uint256[] memory licenseTermsIds = new uint256[](2);

--- a/test/foundry/registries/LicenseRegistry.t.sol
+++ b/test/foundry/registries/LicenseRegistry.t.sol
@@ -435,18 +435,20 @@ contract LicenseRegistryTest is BaseTest {
     }
 
     function test_LicenseRegistry_registerDerivativeIp_revert_UnattachedLicenseTemplate() public {
-        uint256 socialRemixTermsId = pilTemplate.registerLicenseTerms(PILFlavors.nonCommercialSocialRemixing());
+        uint256 commercialRemix = pilTemplate.registerLicenseTerms(
+            PILFlavors.commercialRemix(100, 10, address(royaltyPolicyLAP), address(erc20))
+        );
 
         address[] memory parentIpIds = new address[](1);
         parentIpIds[0] = ipAcct[1];
         uint256[] memory licenseTermsIds = new uint256[](1);
-        licenseTermsIds[0] = socialRemixTermsId;
+        licenseTermsIds[0] = commercialRemix;
 
         vm.expectRevert(
             abi.encodeWithSelector(
-                Errors.LicenseRegistry__ParentIpUnmatchedLicenseTemplate.selector,
+                Errors.LicenseRegistry__ParentIpHasNoLicenseTerms.selector,
                 ipAcct[1],
-                address(pilTemplate)
+                commercialRemix
             )
         );
         vm.prank(address(licensingModule));
@@ -594,42 +596,45 @@ contract LicenseRegistryTest is BaseTest {
         PILTerms memory terms2 = PILFlavors.nonCommercialSocialRemixing();
         terms2.expiration = 400;
         uint256 termsId2 = pilTemplate.registerLicenseTerms(terms2);
-        vm.prank(ipOwner[2]);
-        vm.expectRevert(
-            abi.encodeWithSelector(
-                Errors.LicenseRegistry__LicenseTermsAlreadyAttached.selector,
-                ipAcct[2],
-                address(pilTemplate),
-                termsId1
-            )
-        );
-    licensingModule.attachLicenseTerms(ipAcct[2], address(pilTemplate), termsId2);
 
-        address[] memory parentIpIds = new address[](2);
-        uint256[] memory licenseTermsIds = new uint256[](2);
-        parentIpIds[0] = ipAcct[1];
-        parentIpIds[1] = ipAcct[2];
-        licenseTermsIds[0] = termsId1;
-        licenseTermsIds[1] = termsId2;
-        vm.prank(address(licensingModule));
-        licenseRegistry.registerDerivativeIp({
-            childIpId: ipAcct[3],
-            parentIpIds: parentIpIds,
-            licenseTemplate: address(pilTemplate),
-            licenseTermsIds: licenseTermsIds,
-            isUsingLicenseToken: false
-        });
-        assertEq(licenseRegistry.getExpireTime(ipAcct[1]), block.timestamp + 500, "ipAcct[1] expire time is incorrect");
-        assertEq(licenseRegistry.getExpireTime(ipAcct[2]), 0, "ipAcct[2] expire time is incorrect");
-        assertEq(licenseRegistry.getExpireTime(ipAcct[3]), block.timestamp + 400, "ipAcct[3] expire time is incorrect");
-        assertEq(licenseRegistry.getParentIp(ipAcct[3], 0), ipAcct[1]);
-        assertEq(licenseRegistry.getParentIp(ipAcct[3], 1), ipAcct[2]);
-        (address attachedTemplate1, uint256 attachedTermsId1) = licenseRegistry.getAttachedLicenseTerms(ipAcct[3], 0);
-        assertEq(attachedTemplate1, address(pilTemplate));
-        assertEq(attachedTermsId1, termsId1);
-        (address attachedTemplate2, uint256 attachedTermsId2) = licenseRegistry.getAttachedLicenseTerms(ipAcct[3], 1);
-        assertEq(attachedTemplate2, address(pilTemplate));
-        assertEq(attachedTermsId2, termsId2);
+        assertNotEq(termsId1, termsId2);
+
+        vm.prank(ipOwner[2]);
+//        vm.expectRevert(
+//            abi.encodeWithSelector(
+//                Errors.LicenseRegistry__LicenseTermsAlreadyAttached.selector,
+//                ipAcct[2],
+//                address(pilTemplate),
+//                termsId2
+//            )
+//        );
+        licensingModule.attachLicenseTerms(ipAcct[2], address(pilTemplate), termsId2);
+
+//        address[] memory parentIpIds = new address[](2);
+//        uint256[] memory licenseTermsIds = new uint256[](2);
+//        parentIpIds[0] = ipAcct[1];
+//        parentIpIds[1] = ipAcct[2];
+//        licenseTermsIds[0] = termsId1;
+//        licenseTermsIds[1] = termsId2;
+//        vm.prank(address(licensingModule));
+//        licenseRegistry.registerDerivativeIp({
+//            childIpId: ipAcct[3],
+//            parentIpIds: parentIpIds,
+//            licenseTemplate: address(pilTemplate),
+//            licenseTermsIds: licenseTermsIds,
+//            isUsingLicenseToken: false
+//        });
+//        assertEq(licenseRegistry.getExpireTime(ipAcct[1]), block.timestamp + 500, "ipAcct[1] expire time is incorrect");
+//        assertEq(licenseRegistry.getExpireTime(ipAcct[2]), 0, "ipAcct[2] expire time is incorrect");
+//        assertEq(licenseRegistry.getExpireTime(ipAcct[3]), block.timestamp + 400, "ipAcct[3] expire time is incorrect");
+//        assertEq(licenseRegistry.getParentIp(ipAcct[3], 0), ipAcct[1]);
+//        assertEq(licenseRegistry.getParentIp(ipAcct[3], 1), ipAcct[2]);
+//        (address attachedTemplate1, uint256 attachedTermsId1) = licenseRegistry.getAttachedLicenseTerms(ipAcct[3], 0);
+//        assertEq(attachedTemplate1, address(pilTemplate));
+//        assertEq(attachedTermsId1, termsId1);
+//        (address attachedTemplate2, uint256 attachedTermsId2) = licenseRegistry.getAttachedLicenseTerms(ipAcct[3], 1);
+//        assertEq(attachedTemplate2, address(pilTemplate));
+//        assertEq(attachedTermsId2, termsId2);
     }
 
     function onERC721Received(address, address, uint256, bytes memory) public pure returns (bytes4) {

--- a/test/foundry/registries/LicenseRegistry.t.sol
+++ b/test/foundry/registries/LicenseRegistry.t.sol
@@ -598,43 +598,34 @@ contract LicenseRegistryTest is BaseTest {
         uint256 termsId2 = pilTemplate.registerLicenseTerms(terms2);
 
         assertNotEq(termsId1, termsId2);
-
         vm.prank(ipOwner[2]);
-//        vm.expectRevert(
-//            abi.encodeWithSelector(
-//                Errors.LicenseRegistry__LicenseTermsAlreadyAttached.selector,
-//                ipAcct[2],
-//                address(pilTemplate),
-//                termsId2
-//            )
-//        );
         licensingModule.attachLicenseTerms(ipAcct[2], address(pilTemplate), termsId2);
 
-//        address[] memory parentIpIds = new address[](2);
-//        uint256[] memory licenseTermsIds = new uint256[](2);
-//        parentIpIds[0] = ipAcct[1];
-//        parentIpIds[1] = ipAcct[2];
-//        licenseTermsIds[0] = termsId1;
-//        licenseTermsIds[1] = termsId2;
-//        vm.prank(address(licensingModule));
-//        licenseRegistry.registerDerivativeIp({
-//            childIpId: ipAcct[3],
-//            parentIpIds: parentIpIds,
-//            licenseTemplate: address(pilTemplate),
-//            licenseTermsIds: licenseTermsIds,
-//            isUsingLicenseToken: false
-//        });
-//        assertEq(licenseRegistry.getExpireTime(ipAcct[1]), block.timestamp + 500, "ipAcct[1] expire time is incorrect");
-//        assertEq(licenseRegistry.getExpireTime(ipAcct[2]), 0, "ipAcct[2] expire time is incorrect");
-//        assertEq(licenseRegistry.getExpireTime(ipAcct[3]), block.timestamp + 400, "ipAcct[3] expire time is incorrect");
-//        assertEq(licenseRegistry.getParentIp(ipAcct[3], 0), ipAcct[1]);
-//        assertEq(licenseRegistry.getParentIp(ipAcct[3], 1), ipAcct[2]);
-//        (address attachedTemplate1, uint256 attachedTermsId1) = licenseRegistry.getAttachedLicenseTerms(ipAcct[3], 0);
-//        assertEq(attachedTemplate1, address(pilTemplate));
-//        assertEq(attachedTermsId1, termsId1);
-//        (address attachedTemplate2, uint256 attachedTermsId2) = licenseRegistry.getAttachedLicenseTerms(ipAcct[3], 1);
-//        assertEq(attachedTemplate2, address(pilTemplate));
-//        assertEq(attachedTermsId2, termsId2);
+        address[] memory parentIpIds = new address[](2);
+        uint256[] memory licenseTermsIds = new uint256[](2);
+        parentIpIds[0] = ipAcct[1];
+        parentIpIds[1] = ipAcct[2];
+        licenseTermsIds[0] = termsId1;
+        licenseTermsIds[1] = termsId2;
+        vm.prank(address(licensingModule));
+        licenseRegistry.registerDerivativeIp({
+            childIpId: ipAcct[3],
+            parentIpIds: parentIpIds,
+            licenseTemplate: address(pilTemplate),
+            licenseTermsIds: licenseTermsIds,
+            isUsingLicenseToken: false
+        });
+        assertEq(licenseRegistry.getExpireTime(ipAcct[1]), block.timestamp + 500, "ipAcct[1] expire time is incorrect");
+        assertEq(licenseRegistry.getExpireTime(ipAcct[2]), 0, "ipAcct[2] expire time is incorrect");
+        assertEq(licenseRegistry.getExpireTime(ipAcct[3]), block.timestamp + 400, "ipAcct[3] expire time is incorrect");
+        assertEq(licenseRegistry.getParentIp(ipAcct[3], 0), ipAcct[1]);
+        assertEq(licenseRegistry.getParentIp(ipAcct[3], 1), ipAcct[2]);
+        (address attachedTemplate1, uint256 attachedTermsId1) = licenseRegistry.getAttachedLicenseTerms(ipAcct[3], 0);
+        assertEq(attachedTemplate1, address(pilTemplate));
+        assertEq(attachedTermsId1, termsId1);
+        (address attachedTemplate2, uint256 attachedTermsId2) = licenseRegistry.getAttachedLicenseTerms(ipAcct[3], 1);
+        assertEq(attachedTemplate2, address(pilTemplate));
+        assertEq(attachedTermsId2, termsId2);
     }
 
     function onERC721Received(address, address, uint256, bytes memory) public pure returns (bytes4) {


### PR DESCRIPTION
## Description

This PR configures the non-commercial remix license as the default license in the deployment script as license terms ID 1, ensuring that the default license terms are set during the deployment of protocol contracts. Additionally, it updates the License Registry API to handle the default license terms consistently.

## Key Changes

- **Deployment Script Update**: Configured the non-commercial remixable license as the default license.
- **API Consistency**: Updated the License Registry API to handle the default license terms consistently:
  1. `getAttachedLicenseTerms()`: Default license terms will be the last one attached to the IP.
  2. `getAttachedLicenseTermsCount()`: Default license terms are also counted.
  3. `hasIpAttachedLicenseTerms()`: Default license terms are considered attached to the IP.

## Objectives

- **Set Default License**: Ensure the non-commercial remixable license is set as the default license during deployment.
- **Consistent API Behavior**: Make the License Registry API handle default license terms consistently.

