### PR TITLE
Fix error message of GroupNFT when caller is not GroupingModule

### DIFF
--- a/contracts/GroupNFT.sol
+++ b/contracts/GroupNFT.sol
@@ -36,7 +36,7 @@ contract GroupNFT is IGroupNFT, ERC721Upgradeable, AccessManagedUpgradeable, UUP
 
     modifier onlyGroupingModule() {
         if (msg.sender != address(GROUPING_MODULE)) {
-            revert Errors.GroupNFT__CallerNotIPAssetRegistry(msg.sender);
+            revert Errors.GroupNFT__CallerNotGroupingModule(msg.sender);
         }
         _;
     }

--- a/contracts/lib/Errors.sol
+++ b/contracts/lib/Errors.sol
@@ -731,7 +731,7 @@ library Errors {
     ////////////////////////////////////////////////////////////////////////////
 
     /// @notice Caller is not the IPA Asset Registry.
-    error GroupNFT__CallerNotIPAssetRegistry(address caller);
+    error GroupNFT__CallerNotGroupingModule(address caller);
 
     /// @notice Zero address provided for Access Manager.
     error GroupNFT__ZeroAccessManager();


### PR DESCRIPTION
## Description
Quick fix the error message in GroupNFT for checking caller is not GroupingModule.