### PR TITLE
Allow revenue token claiming to be done on behalf of the claimer

### DIFF
--- a/contracts/interfaces/modules/royalty/IRoyaltyModule.sol
+++ b/contracts/interfaces/modules/royalty/IRoyaltyModule.sol
@@ -189,6 +189,11 @@ interface IRoyaltyModule is IModule {
     /// @return isWhitelisted True if the royalty token is whitelisted
     function isWhitelistedRoyaltyToken(address token) external view returns (bool);
 
+    /// @notice Indicates if an address is a royalty vault
+    /// @param ipRoyaltyVault The address to check
+    /// @return isIpRoyaltyVault True if the address is a royalty vault
+    function isIpRoyaltyVault(address ipRoyaltyVault) external view returns (bool);
+
     /// @notice Indicates the royalty vault for a given IP asset
     /// @param ipId The ID of IP asset
     function ipRoyaltyVaults(address ipId) external view returns (address);

--- a/contracts/interfaces/modules/royalty/policies/IIpRoyaltyVault.sol
+++ b/contracts/interfaces/modules/royalty/policies/IIpRoyaltyVault.sol
@@ -53,17 +53,24 @@ interface IIpRoyaltyVault {
     /// @notice Allows token holders to claim revenue token based on the token balance at certain snapshot
     /// @param snapshotId The snapshot id
     /// @param tokenList The list of revenue tokens to claim
+    /// @param claimer The address of the claimer
     /// @return The amount of revenue tokens claimed for each token
-    function claimRevenueByTokenBatch(
+    function claimRevenueOnBehalfByTokenBatch(
         uint256 snapshotId,
-        address[] calldata tokenList
+        address[] calldata tokenList,
+        address claimer
     ) external returns (uint256[] memory);
 
     /// @notice Allows token holders to claim by a list of snapshot ids based on the token balance at certain snapshot
     /// @param snapshotIds The list of snapshot ids
     /// @param token The revenue token to claim
+    /// @param claimer The address of the claimer
     /// @return The amount of revenue tokens claimed
-    function claimRevenueBySnapshotBatch(uint256[] memory snapshotIds, address token) external returns (uint256);
+    function claimRevenueOnBehalfBySnapshotBatch(
+        uint256[] memory snapshotIds,
+        address token,
+        address claimer
+    ) external returns (uint256);
 
     /// @notice Allows to claim revenue tokens on behalf of the ip royalty vault
     /// @param snapshotId The snapshot id

--- a/contracts/lib/Errors.sol
+++ b/contracts/lib/Errors.sol
@@ -623,6 +623,9 @@ library Errors {
     /// @notice Zero amount provided.
     error IpRoyaltyVault__ZeroAmount();
 
+    /// @notice Vaults must claim as self.
+    error IpRoyaltyVault__VaultsMustClaimAsSelf();
+
     ////////////////////////////////////////////////////////////////////////////
     //                            Vault Controller                            //
     ////////////////////////////////////////////////////////////////////////////

--- a/contracts/modules/royalty/RoyaltyModule.sol
+++ b/contracts/modules/royalty/RoyaltyModule.sol
@@ -60,6 +60,7 @@ contract RoyaltyModule is IRoyaltyModule, VaultController, ReentrancyGuardUpgrad
     /// @param isWhitelistedRoyaltyToken Indicates if a royalty token is whitelisted
     /// @param isRegisteredExternalRoyaltyPolicy Indicates if an external royalty policy is registered
     /// @param ipRoyaltyVaults The royalty vault address for a given IP asset (if any)
+    /// @param isIpRoyaltyVault Indicates if an address is a royalty vault
     /// @param globalRoyaltyStack Sum of royalty stack from each whitelisted royalty policy for a given IP asset
     /// @param accumulatedRoyaltyPolicies The accumulated royalty policies for a given IP asset
     /// @param totalRevenueTokensReceived The total lifetime revenue tokens received for a given IP asset
@@ -74,6 +75,7 @@ contract RoyaltyModule is IRoyaltyModule, VaultController, ReentrancyGuardUpgrad
         mapping(address token => bool) isWhitelistedRoyaltyToken;
         mapping(address royaltyPolicy => bool) isRegisteredExternalRoyaltyPolicy;
         mapping(address ipId => address ipRoyaltyVault) ipRoyaltyVaults;
+        mapping(address ipRoyaltyVault => bool) isIpRoyaltyVault;
         mapping(address ipId => uint32) globalRoyaltyStack;
         mapping(address ipId => EnumerableSet.AddressSet) accumulatedRoyaltyPolicies;
         mapping(address ipId => mapping(address token => uint256)) totalRevenueTokensReceived;
@@ -421,6 +423,13 @@ contract RoyaltyModule is IRoyaltyModule, VaultController, ReentrancyGuardUpgrad
         return _getRoyaltyModuleStorage().isWhitelistedRoyaltyToken[token];
     }
 
+    /// @notice Indicates if an address is a royalty vault
+    /// @param ipRoyaltyVault The address to check
+    /// @return isIpRoyaltyVault True if the address is a royalty vault
+    function isIpRoyaltyVault(address ipRoyaltyVault) external view returns (bool) {
+        return _getRoyaltyModuleStorage().isIpRoyaltyVault[ipRoyaltyVault];
+    }
+
     /// @notice Indicates the royalty vault for a given IP asset
     /// @param ipId The ID of IP asset
     function ipRoyaltyVaults(address ipId) external view returns (address) {
@@ -461,6 +470,7 @@ contract RoyaltyModule is IRoyaltyModule, VaultController, ReentrancyGuardUpgrad
         address ipRoyaltyVault = address(new BeaconProxy(ipRoyaltyVaultBeacon(), ""));
         IIpRoyaltyVault(ipRoyaltyVault).initialize("Royalty Token", "RT", MAX_PERCENT, ipId, receiver);
         $.ipRoyaltyVaults[ipId] = ipRoyaltyVault;
+        $.isIpRoyaltyVault[ipRoyaltyVault] = true;
 
         return ipRoyaltyVault;
     }

--- a/test/foundry/integration/flows/royalty/Royalty.t.sol
+++ b/test/foundry/integration/flows/royalty/Royalty.t.sol
@@ -187,7 +187,7 @@ contract Flows_Integration_Disputes is BaseIntegration {
 
             uint256 aliceBalanceBefore = mockToken.balanceOf(ipAcct[1]);
 
-            IpRoyaltyVault(vault).claimRevenueBySnapshotBatch(snapshotIds, address(mockToken));
+            IpRoyaltyVault(vault).claimRevenueOnBehalfBySnapshotBatch(snapshotIds, address(mockToken), ipAcct[1]);
 
             uint256 aliceBalanceAfter = mockToken.balanceOf(ipAcct[1]);
 

--- a/test/foundry/invariants/IpRoyaltyVault.t.sol
+++ b/test/foundry/invariants/IpRoyaltyVault.t.sol
@@ -25,11 +25,11 @@ contract IpRoyaltyVaultHarness is Test {
     }
 
     function claimRevenueByTokenBatch(uint256 snapshotId, address[] calldata tokenList) public {
-        vault.claimRevenueByTokenBatch(snapshotId, tokenList);
+        vault.claimRevenueOnBehalfByTokenBatch(snapshotId, tokenList, address(this));
     }
 
     function claimRevenueBySnapshotBatch(uint256[] memory snapshotIds, address token) public {
-        vault.claimRevenueBySnapshotBatch(snapshotIds, token);
+        vault.claimRevenueOnBehalfBySnapshotBatch(snapshotIds, token, address(this));
     }
 
     function claimByTokenBatchAsSelf(uint256 snapshotId, address[] calldata tokenList, address targetIpId) public {

--- a/test/foundry/mocks/grouping/MockEvenSplitGroupPool.sol
+++ b/test/foundry/mocks/grouping/MockEvenSplitGroupPool.sol
@@ -136,7 +136,7 @@ contract MockEvenSplitGroupPool is IGroupRewardPool {
         if (address(vault) == address(0)) return;
         uint256[] memory snapshotsToClaim = new uint256[](1);
         snapshotsToClaim[0] = vault.snapshot();
-        uint256 royalties = vault.claimRevenueBySnapshotBatch(snapshotsToClaim, token);
+        uint256 royalties = vault.claimRevenueOnBehalfBySnapshotBatch(snapshotsToClaim, token, address(this));
         poolInfo[groupId][token].availableBalance += royalties;
         poolInfo[groupId][token].accBalance += royalties;
         groupTokens[groupId].add(token);

--- a/test/foundry/modules/royalty/RoyaltyModule.t.sol
+++ b/test/foundry/modules/royalty/RoyaltyModule.t.sol
@@ -439,6 +439,7 @@ contract TestRoyaltyModule is BaseTest {
 
         assertEq(ipIdRtBalAfter, royaltyModule.maxPercent());
         assertFalse(royaltyModule.ipRoyaltyVaults(licensor) == address(0));
+        assertEq(royaltyModule.isIpRoyaltyVault(newVault), true);
     }
 
     function test_RoyaltyModule_onLicenseMinting_NewVaultGroup() public {
@@ -459,6 +460,7 @@ contract TestRoyaltyModule is BaseTest {
 
         assertEq(groupPoolRtBalAfter, royaltyModule.maxPercent());
         assertFalse(royaltyModule.ipRoyaltyVaults(groupId) == address(0));
+        assertEq(royaltyModule.isIpRoyaltyVault(newVault), true);
     }
 
     function test_RoyaltyModule_onLicenseMinting_ExistingVault() public {
@@ -748,6 +750,7 @@ contract TestRoyaltyModule is BaseTest {
         uint256 ipId80IpIdRtBalAfter = IERC20(ipRoyaltyVault80).balanceOf(address(80));
 
         assertFalse(royaltyModule.ipRoyaltyVaults(address(80)) == address(0));
+        assertEq(royaltyModule.isIpRoyaltyVault(royaltyModule.ipRoyaltyVaults(address(80))), true);
         assertEq(ipId80RtLAPBalAfter, 0);
         assertEq(ipId80RtLRPBalAfter, 0);
         assertEq(ipId80RtLRPParentVaultBalAfter, 0);


### PR DESCRIPTION
## Description
This PR allows the revenue token claiming to be done on behalf of the claimer. Necessary, for example, for SPG to claim on behalf of royalty token holders.
