### PR TITLE
Disable fuzz test in GHA

### DIFF
--- a/.github/workflows/foundry_ci.yml
+++ b/.github/workflows/foundry_ci.yml
@@ -47,7 +47,7 @@ jobs:
 
       - name: Run Forge tests
         run: |
-          forge test -vvv
+          forge test -vvv --no-match-test "invariant*"
         id: forge-test
 
       - name: Run solhint


### PR DESCRIPTION
## Description
Not trigger the invariant tests for pre-commit test as it is too slow.