### PR TITLE
Deploy IPGraphACL to predefined address if not yet deployed

### DIFF
--- a/script/foundry/deployment/Main.s.sol
+++ b/script/foundry/deployment/Main.s.sol
@@ -10,7 +10,7 @@ import { DeployHelper } from "../utils/DeployHelper.sol";
 contract Main is DeployHelper {
     address internal ERC6551_REGISTRY = 0x000000006551c19487814612e58FE06813775758;
     address internal CREATE3_DEPLOYER = 0x384a891dFDE8180b054f04D66379f16B7a678Ad6;
-    uint256 internal CREATE3_DEFAULT_SEED = 0;
+    uint256 internal CREATE3_DEFAULT_SEED = 6;
     address internal IP_GRAPH_ACL = 0x680E66e4c7Df9133a7AFC1ed091089B32b89C4ae;
     // For arbitration policy
     uint256 internal constant ARBITRATION_PRICE = 1000 * 10 ** 6; // 1000 USDC

--- a/script/foundry/utils/DeployHelper.sol
+++ b/script/foundry/utils/DeployHelper.sol
@@ -142,8 +142,6 @@ contract DeployHelper is Script, BroadcastManager, JsonDeploymentHandler, Storag
         MAX_ROYALTY_APPROVAL = maxRoyaltyApproval_;
         TREASURY_ADDRESS = treasury_;
         ipGraphACL = IPGraphACL(ipGraphACL_);
-        if (address(ipGraphACL) == address(0))
-            newDeployedIpGraphACL = true;
 
         /// @dev USDC addresses are fetched from
         /// (mainnet) https://developers.circle.com/stablecoins/docs/usdc-on-main-networks
@@ -161,6 +159,17 @@ contract DeployHelper is Script, BroadcastManager, JsonDeploymentHandler, Storag
         create3SaltSeed = create3SaltSeed_;
         writeDeploys = writeDeploys_;
         version = version_;
+
+        // check if IPGraphACL is deployed
+        if (address(ipGraphACL) == address(0)) {
+            newDeployedIpGraphACL = true;
+        } else if (address(ipGraphACL).code.length == 0) {
+            newDeployedIpGraphACL = true;
+            require(
+                address(ipGraphACL) == _getDeployedAddress(type(IPGraphACL).name),
+                "Deploy: IPGraphACL Address Mismatch with seed."
+            );
+        }
 
         // This will run OZ storage layout check for all contracts. Requires --ffi flag.
         if (runStorageLayoutCheck) super.run();
@@ -662,8 +671,10 @@ contract DeployHelper is Script, BroadcastManager, JsonDeploymentHandler, Storag
                     abi.encodePacked(type(IPGraphACL).creationCode, abi.encode(address(protocolAccessManager)))
                 )
             );
-            _postdeploy("IPGraphACL", address(ipGraphACL));
+        } else {
+            console2.log("IPGraphACL already deployed");
         }
+        _postdeploy("IPGraphACL", address(ipGraphACL));
     }
 
     function _predeploy(string memory contractKey) private view {

--- a/test/foundry/mocks/token/SUSD.sol
+++ b/test/foundry/mocks/token/SUSD.sol
@@ -1,0 +1,16 @@
+// SPDX-License-Identifier: BUSL-1.1
+pragma solidity ^0.8.23;
+
+import { ERC20 } from "@openzeppelin/contracts/token/ERC20/ERC20.sol";
+
+contract SUSD is ERC20 {
+    constructor() ERC20("Story USD", "SUSD") {}
+
+    function mint(address to, uint256 amount) external {
+        _mint(to, amount);
+    }
+
+    function burn(address from, uint256 amount) external {
+        _burn(from, amount);
+    }
+}


### PR DESCRIPTION
## Description
This PR ensure deploy IPGraphACL to the predefined the address if IPGraphACL not yet deployed otherwise ignore deployment of IPGraphACL. 
Also set default CREATE3 seed to 6 which used to deployed the IPGraphACL