### PR TITLE
Refactor EvenSplitPool that Moving collectRoyalties  Function to GroupingModule 

### DIFF
--- a/contracts/interfaces/modules/grouping/IGroupRewardPool.sol
+++ b/contracts/interfaces/modules/grouping/IGroupRewardPool.sol
@@ -14,10 +14,11 @@ interface IGroupRewardPool {
         address[] calldata ipIds
     ) external returns (uint256[] memory rewards);
 
-    /// @notice Collects royalty revenue to the group pool through royalty module
+    /// @notice Deposits reward to the group pool directly
     /// @param groupId The group ID
     /// @param token The reward token
-    function collectRoyalties(address groupId, address token) external;
+    /// @param amount The amount of reward
+    function depositReward(address groupId, address token, uint256 amount) external;
 
     /// @notice Adds an IP to the group pool
     /// @param groupId The group ID

--- a/contracts/interfaces/modules/grouping/IGroupingModule.sol
+++ b/contracts/interfaces/modules/grouping/IGroupingModule.sol
@@ -30,6 +30,20 @@ interface IGroupingModule is IModule {
     /// @param amount The amount of reward.
     event ClaimedReward(address indexed groupId, address indexed token, address[] ipId, uint256[] amount);
 
+    /// @notice Emitted when collected royalties into the group pool.
+    /// @param groupId The address of the group.
+    /// @param token The address of the token.
+    /// @param pool The address of the pool.
+    /// @param amount The amount of reward.
+    /// @param snapshots The snapshot IDs of the royalty vault for the given group to collect royalties.
+    event CollectedRoyaltiesToGroupPool(
+        address indexed groupId,
+        address indexed token,
+        address indexed pool,
+        uint256 amount,
+        uint256[] snapshots
+    );
+
     /// @notice Registers a Group IPA.
     /// @param groupPool The address of the group pool.
     /// @return groupId The address of the newly registered Group IPA.
@@ -56,6 +70,16 @@ interface IGroupingModule is IModule {
     /// @param token The address of the token.
     /// @param ipIds The IP IDs.
     function claimReward(address groupId, address token, address[] calldata ipIds) external;
+
+    /// @notice Collects royalties into the pool, making them claimable by group member IPs.
+    /// @param groupId The address of the group.
+    /// @param token The address of the token.
+    /// @param snapshots The snapshot IDs of the royalty vault for the given group to collect royalties.
+    function collectRoyalties(
+        address groupId,
+        address token,
+        uint256[] calldata snapshots
+    ) external returns (uint256 royalties);
 
     /// @notice Returns the available reward for each IP in the group.
     /// @param groupId The address of the group.

--- a/contracts/interfaces/modules/grouping/IGroupingModule.sol
+++ b/contracts/interfaces/modules/grouping/IGroupingModule.sol
@@ -91,9 +91,4 @@ interface IGroupingModule is IModule {
         address token,
         address[] calldata ipIds
     ) external view returns (uint256[] memory);
-
-    /// @notice Checks whether a group reward pool is whitelisted
-    /// @param rewardPool The address of the group reward pool.
-    /// @return Whether the group reward pool is whitelisted.
-    function isWhitelistGroupRewardPool(address rewardPool) external view returns (bool);
 }

--- a/contracts/interfaces/modules/grouping/IGroupingModule.sol
+++ b/contracts/interfaces/modules/grouping/IGroupingModule.sol
@@ -74,11 +74,11 @@ interface IGroupingModule is IModule {
     /// @notice Collects royalties into the pool, making them claimable by group member IPs.
     /// @param groupId The address of the group.
     /// @param token The address of the token.
-    /// @param snapshots The snapshot IDs of the royalty vault for the given group to collect royalties.
+    /// @param snapshotIds The snapshot IDs of the royalty vault for the given group to collect royalties.
     function collectRoyalties(
         address groupId,
         address token,
-        uint256[] calldata snapshots
+        uint256[] calldata snapshotIds
     ) external returns (uint256 royalties);
 
     /// @notice Returns the available reward for each IP in the group.

--- a/contracts/interfaces/modules/grouping/IGroupingModule.sol
+++ b/contracts/interfaces/modules/grouping/IGroupingModule.sol
@@ -91,4 +91,9 @@ interface IGroupingModule is IModule {
         address token,
         address[] calldata ipIds
     ) external view returns (uint256[] memory);
+
+    /// @notice Checks whether a group reward pool is whitelisted
+    /// @param rewardPool The address of the group reward pool.
+    /// @return Whether the group reward pool is whitelisted.
+    function isWhitelistGroupRewardPool(address rewardPool) external view returns (bool);
 }

--- a/contracts/interfaces/registries/IGroupIPAssetRegistry.sol
+++ b/contracts/interfaces/registries/IGroupIPAssetRegistry.sol
@@ -35,6 +35,11 @@ interface IGroupIPAssetRegistry {
     /// @return groupPool The address of the group policy.
     function getGroupRewardPool(address groupId) external view returns (address);
 
+    /// @notice Checks whether a group reward pool is whitelisted
+    /// @param rewardPool The address of the group reward pool.
+    /// @return isWhitelisted Whether the group reward pool is whitelisted.
+    function isWhitelistedGroupRewardPool(address rewardPool) external view returns (bool isWhitelisted);
+
     /// @notice Retrieves the group members for a Group IPA
     /// @param groupId The address of the Group IPA.
     /// @param startIndex The start index of the group members to retrieve

--- a/contracts/lib/Errors.sol
+++ b/contracts/lib/Errors.sol
@@ -115,6 +115,9 @@ library Errors {
     /// @notice The IP has no attached the same license terms of Group IPA.
     error GroupingModule__IpHasNoGroupLicenseTerms(address groupId, address licenseTemplate, uint256 licenseTermsId);
 
+    /// @notice The Royalty Vault has not been created.
+    error GroupingModule__GroupRoyaltyVaultNotCreated(address groupId);
+
     /// @notice The Group IP's license terms should not have minting fee.
     error GroupingModule__GroupIPHasMintingFee(address groupId, address licenseTemplate, uint256 licenseTermsId);
 

--- a/contracts/modules/grouping/EvenSplitGroupPool.sol
+++ b/contracts/modules/grouping/EvenSplitGroupPool.sol
@@ -7,7 +7,6 @@ import { UUPSUpgradeable } from "@openzeppelin/contracts-upgradeable/proxy/utils
 
 import { IGroupRewardPool } from "../../interfaces/modules/grouping/IGroupRewardPool.sol";
 import { IRoyaltyModule } from "../../interfaces/modules/royalty/IRoyaltyModule.sol";
-import { IIpRoyaltyVault } from "../../interfaces/modules/royalty/policies/IIpRoyaltyVault.sol";
 import { IGroupingModule } from "../../interfaces/modules/grouping/IGroupingModule.sol";
 import { IGroupIPAssetRegistry } from "../../interfaces/registries/IGroupIPAssetRegistry.sol";
 import { ProtocolPausableUpgradeable } from "../../pause/ProtocolPausableUpgradeable.sol";
@@ -128,8 +127,6 @@ contract EvenSplitGroupPool is IGroupRewardPool, ProtocolPausableUpgradeable, UU
     ) external whenNotPaused returns (uint256[] memory rewards) {
         return _distributeRewards(groupId, token, ipIds);
     }
-
-
 
     function getTotalIps(address groupId) external view returns (uint256) {
         return _getEvenSplitGroupPoolStorage().totalMemberIps[groupId];

--- a/contracts/modules/grouping/EvenSplitGroupPool.sol
+++ b/contracts/modules/grouping/EvenSplitGroupPool.sol
@@ -128,20 +128,6 @@ contract EvenSplitGroupPool is IGroupRewardPool, ProtocolPausableUpgradeable, UU
         _collectRoyalties(groupId, token);
     }
 
-    /// @notice Deposits reward to the group pool directly
-    /// @param groupId The group ID
-    /// @param token The reward token
-    /// @param amount The amount of reward
-    function depositReward(address groupId, address token, uint256 amount) external whenNotPaused {
-        if (amount == 0) return;
-        if (!ROYALTY_MODULE.isWhitelistedRoyaltyToken(token))
-            revert Errors.EvenSplitGroupPool__UnregisteredCurrencyToken(token);
-        if (!GROUP_IP_ASSET_REGISTRY.isRegisteredGroup(groupId))
-            revert Errors.EvenSplitGroupPool__UnregisteredGroupIP(groupId);
-        IERC20(token).safeTransferFrom(msg.sender, address(this), amount);
-        _getEvenSplitGroupPoolStorage().poolBalance[groupId][token] += amount;
-    }
-
     function getTotalIps(address groupId) external view returns (uint256) {
         return _getEvenSplitGroupPoolStorage().totalMemberIps[groupId];
     }

--- a/contracts/modules/grouping/GroupingModule.sol
+++ b/contracts/modules/grouping/GroupingModule.sol
@@ -235,6 +235,13 @@ contract GroupingModule is
         return pool.getAvailableReward(groupId, token, ipIds);
     }
 
+    /// @notice Checks whether a group reward pool is whitelisted
+    /// @param rewardPool The address of the group reward pool.
+    /// @return Whether the group reward pool is whitelisted.
+    function isWhitelistGroupRewardPool(address rewardPool) external view returns (bool) {
+        return GROUP_IP_ASSET_REGISTRY.isWhitelistedGroupRewardPool(rewardPool);
+    }
+
     /// @dev The group members are locked if the group has derivative IPs or license tokens minted.
     function _checkIfGroupMembersLocked(address groupIpId) internal view {
         if (LICENSE_REGISTRY.hasDerivativeIps(groupIpId)) {

--- a/contracts/modules/grouping/GroupingModule.sol
+++ b/contracts/modules/grouping/GroupingModule.sol
@@ -235,12 +235,6 @@ contract GroupingModule is
         return pool.getAvailableReward(groupId, token, ipIds);
     }
 
-    /// @notice Checks whether a group reward pool is whitelisted
-    /// @param rewardPool The address of the group reward pool.
-    /// @return Whether the group reward pool is whitelisted.
-    function isWhitelistGroupRewardPool(address rewardPool) external view returns (bool) {
-        return GROUP_IP_ASSET_REGISTRY.isWhitelistedGroupRewardPool(rewardPool);
-    }
 
     /// @dev The group members are locked if the group has derivative IPs or license tokens minted.
     function _checkIfGroupMembersLocked(address groupIpId) internal view {

--- a/contracts/modules/grouping/GroupingModule.sol
+++ b/contracts/modules/grouping/GroupingModule.sol
@@ -21,6 +21,8 @@ import { IGroupRewardPool } from "../../interfaces/modules/grouping/IGroupReward
 import { GROUPING_MODULE_KEY } from "../../lib/modules/Module.sol";
 import { IPILicenseTemplate, PILTerms } from "../../interfaces/modules/licensing/IPILicenseTemplate.sol";
 import { ILicenseToken } from "../../interfaces/ILicenseToken.sol";
+import { IRoyaltyModule } from "../../interfaces/modules/royalty/IRoyaltyModule.sol";
+import { IIpRoyaltyVault } from "../../interfaces/modules/royalty/policies/IIpRoyaltyVault.sol";
 
 /// @title Grouping Module
 /// @notice Grouping module is the main entry point for the IPA grouping. It is responsible for:
@@ -39,6 +41,10 @@ contract GroupingModule is
     using ERC165Checker for address;
     using Strings for *;
     using IPAccountStorageOps for IIPAccount;
+
+    /// @notice Returns the canonical protocol-wide RoyaltyModule
+    /// @custom:oz-upgrades-unsafe-allow state-variable-immutable
+    IRoyaltyModule public immutable ROYALTY_MODULE;
 
     /// @notice Returns the canonical protocol-wide LicenseToken
     /// @custom:oz-upgrades-unsafe-allow state-variable-immutable
@@ -72,16 +78,19 @@ contract GroupingModule is
         address ipAssetRegistry,
         address licenseRegistry,
         address licenseToken,
-        address groupNFT
+        address groupNFT,
+        address royaltyModule
     ) AccessControlled(accessController, ipAssetRegistry) {
         if (licenseToken == address(0)) revert Errors.GroupingModule__ZeroLicenseToken();
         if (licenseRegistry == address(0)) revert Errors.GroupingModule__ZeroLicenseRegistry();
         if (groupNFT == address(0)) revert Errors.GroupingModule__ZeroGroupNFT();
         if (ipAssetRegistry == address(0)) revert Errors.GroupingModule__ZeroIpAssetRegistry();
+        if (royaltyModule == address(0)) revert Errors.GroupingModule__ZeroRoyaltyModule();
 
         LICENSE_TOKEN = ILicenseToken(licenseToken);
         GROUP_IP_ASSET_REGISTRY = IGroupIPAssetRegistry(ipAssetRegistry);
         LICENSE_REGISTRY = ILicenseRegistry(licenseRegistry);
+        ROYALTY_MODULE = IRoyaltyModule(royaltyModule);
 
         if (!groupNFT.supportsInterface(type(IGroupNFT).interfaceId)) {
             revert Errors.GroupingModule__InvalidGroupNFT(groupNFT);
@@ -183,11 +192,28 @@ contract GroupingModule is
     /// @param ipIds The IP IDs.
     function claimReward(address groupId, address token, address[] calldata ipIds) external whenNotPaused {
         IGroupRewardPool pool = IGroupRewardPool(GROUP_IP_ASSET_REGISTRY.getGroupRewardPool(groupId));
-        // claim reward from group IPA's RoyaltyVault to group pool
-        pool.collectRoyalties(groupId, token);
         // trigger group pool to distribute rewards to group members vault
         uint256[] memory rewards = pool.distributeRewards(groupId, token, ipIds);
         emit ClaimedReward(groupId, token, ipIds, rewards);
+    }
+
+    /// @notice Collects royalties into the pool, making them claimable by group member IPs.
+    /// @param groupId The address of the group.
+    /// @param token The address of the token.
+    /// @param snapshots The snapshot IDs of the royalty vault for the given group to collect royalties.
+    function collectRoyalties(
+        address groupId,
+        address token,
+        uint256[] calldata snapshots
+    ) external whenNotPaused returns (uint256 royalties) {
+        IGroupRewardPool pool = IGroupRewardPool(GROUP_IP_ASSET_REGISTRY.getGroupRewardPool(groupId));
+        IIpRoyaltyVault vault = IIpRoyaltyVault(ROYALTY_MODULE.ipRoyaltyVaults(groupId));
+
+        if (address(vault) == address(0)) revert Errors.GroupingModule__GroupRoyaltyVaultNotCreated(groupId);
+
+        royalties = vault.claimRevenueOnBehalfBySnapshotBatch(snapshots, token, address(pool));
+        pool.depositReward(groupId, token, royalties);
+        emit CollectedRoyaltiesToGroupPool(groupId, token, address(pool), royalties, snapshots);
     }
 
     function name() external pure override returns (string memory) {

--- a/contracts/modules/grouping/GroupingModule.sol
+++ b/contracts/modules/grouping/GroupingModule.sol
@@ -200,20 +200,20 @@ contract GroupingModule is
     /// @notice Collects royalties into the pool, making them claimable by group member IPs.
     /// @param groupId The address of the group.
     /// @param token The address of the token.
-    /// @param snapshots The snapshot IDs of the royalty vault for the given group to collect royalties.
+    /// @param snapshotIds The snapshot IDs of the royalty vault for the given group to collect royalties.
     function collectRoyalties(
         address groupId,
         address token,
-        uint256[] calldata snapshots
+        uint256[] calldata snapshotIds
     ) external whenNotPaused returns (uint256 royalties) {
         IGroupRewardPool pool = IGroupRewardPool(GROUP_IP_ASSET_REGISTRY.getGroupRewardPool(groupId));
         IIpRoyaltyVault vault = IIpRoyaltyVault(ROYALTY_MODULE.ipRoyaltyVaults(groupId));
 
         if (address(vault) == address(0)) revert Errors.GroupingModule__GroupRoyaltyVaultNotCreated(groupId);
 
-        royalties = vault.claimRevenueOnBehalfBySnapshotBatch(snapshots, token, address(pool));
+        royalties = vault.claimRevenueOnBehalfBySnapshotBatch(snapshotIds, token, address(pool));
         pool.depositReward(groupId, token, royalties);
-        emit CollectedRoyaltiesToGroupPool(groupId, token, address(pool), royalties, snapshots);
+        emit CollectedRoyaltiesToGroupPool(groupId, token, address(pool), royalties, snapshotIds);
     }
 
     function name() external pure override returns (string memory) {

--- a/contracts/registries/GroupIPAssetRegistry.sol
+++ b/contracts/registries/GroupIPAssetRegistry.sol
@@ -118,6 +118,13 @@ abstract contract GroupIPAssetRegistry is IGroupIPAssetRegistry, ProtocolPausabl
         return _getGroupIPAssetRegistryStorage().rewardPools[groupId];
     }
 
+    /// @notice Checks whether a group reward pool is whitelisted
+    /// @param rewardPool The address of the group reward pool.
+    /// @return isWhitelisted Whether the group reward pool is whitelisted.
+    function isWhitelistedGroupRewardPool(address rewardPool) external view returns (bool isWhitelisted) {
+        return _getGroupIPAssetRegistryStorage().whitelistedGroupRewardPools[rewardPool];
+    }
+
     /// @notice Retrieves the group members for a Group IPA
     /// @param groupId The address of the Group IPA.
     /// @param startIndex The start index of the group members to retrieve

--- a/script/foundry/utils/DeployHelper.sol
+++ b/script/foundry/utils/DeployHelper.sol
@@ -432,7 +432,8 @@ contract DeployHelper is Script, BroadcastManager, JsonDeploymentHandler, Storag
                 address(ipAssetRegistry),
                 address(licenseRegistry),
                 _getDeployedAddress(type(LicenseToken).name),
-                address(groupNft)
+                address(groupNft),
+                address(royaltyModule)
             )
         );
         groupingModule = GroupingModule(

--- a/test/foundry/modules/grouping/EvenSplitGroupPool.t.sol
+++ b/test/foundry/modules/grouping/EvenSplitGroupPool.t.sol
@@ -186,12 +186,7 @@ contract EvenSplitGroupPoolTest is BaseTest {
         erc20.mint(address(this), 100);
         erc20.approve(address(royaltyModule), 100);
         royaltyModule.payRoyaltyOnBehalf(ipId2, address(this), address(erc20), 100);
-        royaltyPolicyLAP.transferToVault(
-            ipId2,
-            group1,
-            address(erc20),
-            10
-        );
+        royaltyPolicyLAP.transferToVault(ipId2, group1, address(erc20), 10);
 
         vm.warp(vm.getBlockTimestamp() + 7 days);
         rewardPool.collectRoyalties(group1, address(erc20));
@@ -201,7 +196,6 @@ contract EvenSplitGroupPoolTest is BaseTest {
 
         address[] memory ipIds = new address[](1);
         ipIds[0] = ipId1;
-
 
         uint256[] memory rewards = rewardPool.getAvailableReward(group1, address(erc20), ipIds);
         assertEq(rewards[0], 10);

--- a/test/foundry/modules/grouping/EvenSplitGroupPool.t.sol
+++ b/test/foundry/modules/grouping/EvenSplitGroupPool.t.sol
@@ -171,25 +171,15 @@ contract EvenSplitGroupPoolTest is BaseTest {
         vm.prank(ipOwner1);
         licensingModule.attachLicenseTerms(ipId1, address(pilTemplate), commRemixTermsId);
         licensingModule.mintLicenseTokens(ipId1, address(pilTemplate), commRemixTermsId, 1, address(this), "");
-        licensingModule.attachLicenseTerms(group1, address(pilTemplate), commRemixTermsId);
 
         vm.prank(address(groupingModule));
         rewardPool.addIp(group1, ipId1);
 
-        address[] memory parentIpIds = new address[](1);
-        parentIpIds[0] = group1;
-        uint256[] memory licenseIds = new uint256[](1);
-        licenseIds[0] = commRemixTermsId;
-        vm.prank(ipOwner2);
-        licensingModule.registerDerivative(ipId2, parentIpIds, licenseIds, address(pilTemplate), "");
-
-        erc20.mint(address(this), 100);
-        erc20.approve(address(royaltyModule), 100);
-        royaltyModule.payRoyaltyOnBehalf(ipId2, address(this), address(erc20), 100);
-        royaltyPolicyLAP.transferToVault(ipId2, group1, address(erc20), 10);
-
-        vm.warp(vm.getBlockTimestamp() + 7 days);
-        rewardPool.collectRoyalties(group1, address(erc20));
+        vm.startPrank(address(groupingModule));
+        erc20.mint(address(rewardPool), 100);
+        rewardPool.depositReward(group1, address(erc20), 100);
+        assertEq(erc20.balanceOf(address(rewardPool)), 100);
+        vm.stopPrank();
 
         uint256 rewardDebt = rewardPool.getIpRewardDebt(group1, address(erc20), ipId1);
         assertEq(rewardDebt, 0);
@@ -198,15 +188,15 @@ contract EvenSplitGroupPoolTest is BaseTest {
         ipIds[0] = ipId1;
 
         uint256[] memory rewards = rewardPool.getAvailableReward(group1, address(erc20), ipIds);
-        assertEq(rewards[0], 10);
+        assertEq(rewards[0], 100);
 
         rewards = rewardPool.distributeRewards(group1, address(erc20), ipIds);
-        assertEq(rewards[0], 10);
+        assertEq(rewards[0], 100);
 
         assertEq(erc20.balanceOf(address(rewardPool)), 0);
 
         rewardDebt = rewardPool.getIpRewardDebt(group1, address(erc20), ipId1);
-        assertEq(rewardDebt, 10);
+        assertEq(rewardDebt, 100);
 
         vm.stopPrank();
     }

--- a/test/foundry/modules/grouping/GroupingModule.t.sol
+++ b/test/foundry/modules/grouping/GroupingModule.t.sol
@@ -81,6 +81,15 @@ contract GroupingModuleTest is BaseTest {
         assertEq(ipAssetRegistry.totalMembers(groupId), 0);
     }
 
+
+    function test_GroupingModule_whitelistRewardPool() public {
+        vm.prank(admin);
+        groupingModule.whitelistGroupRewardPool(address(rewardPool));
+        assertEq(ipAssetRegistry.isWhitelistedGroupRewardPool(address(rewardPool)), true);
+
+        assertEq(ipAssetRegistry.isWhitelistedGroupRewardPool(address(0x123)), false);
+    }
+
     function test_GroupingModule_addIp() public {
         vm.warp(100);
         vm.prank(alice);

--- a/test/foundry/modules/grouping/GroupingModule.t.sol
+++ b/test/foundry/modules/grouping/GroupingModule.t.sol
@@ -81,7 +81,6 @@ contract GroupingModuleTest is BaseTest {
         assertEq(ipAssetRegistry.totalMembers(groupId), 0);
     }
 
-
     function test_GroupingModule_whitelistRewardPool() public {
         vm.prank(admin);
         groupingModule.whitelistGroupRewardPool(address(rewardPool));

--- a/test/foundry/modules/grouping/GroupingModule.t.sol
+++ b/test/foundry/modules/grouping/GroupingModule.t.sol
@@ -12,6 +12,7 @@ import { PILFlavors } from "../../../../contracts/lib/PILFlavors.sol";
 import { EvenSplitGroupPool } from "../../../../contracts/modules/grouping/EvenSplitGroupPool.sol";
 import { MockERC721 } from "../../mocks/token/MockERC721.sol";
 import { BaseTest } from "../../utils/BaseTest.t.sol";
+import { IIpRoyaltyVault } from "../../../../contracts/interfaces/modules/royalty/policies/IIpRoyaltyVault.sol";
 
 contract GroupingModuleTest is BaseTest {
     // test register group
@@ -189,6 +190,20 @@ contract GroupingModuleTest is BaseTest {
         vm.stopPrank();
         royaltyPolicyLAP.transferToVault(ipId3, groupId, address(erc20), 100);
         vm.warp(vm.getBlockTimestamp() + 7 days);
+
+        uint256 snapshotId = IIpRoyaltyVault(royaltyModule.ipRoyaltyVaults(groupId)).snapshot();
+        uint256[] memory snapshotIds = new uint256[](1);
+        snapshotIds[0] = snapshotId;
+
+        vm.expectEmit();
+        emit IGroupingModule.CollectedRoyaltiesToGroupPool(
+            groupId,
+            address(erc20),
+            address(rewardPool),
+            100,
+            snapshotIds
+        );
+        groupingModule.collectRoyalties(groupId, address(erc20), snapshotIds);
 
         address[] memory claimIpIds = new address[](1);
         claimIpIds[0] = ipId1;

--- a/test/foundry/modules/grouping/GroupingModule.t.sol
+++ b/test/foundry/modules/grouping/GroupingModule.t.sol
@@ -187,12 +187,7 @@ contract GroupingModuleTest is BaseTest {
         erc20.approve(address(royaltyModule), 1000);
         royaltyModule.payRoyaltyOnBehalf(ipId3, ipOwner3, address(erc20), 1000);
         vm.stopPrank();
-        royaltyPolicyLAP.transferToVault(
-            ipId3,
-            groupId,
-            address(erc20),
-            100
-        );
+        royaltyPolicyLAP.transferToVault(ipId3, groupId, address(erc20), 100);
         vm.warp(vm.getBlockTimestamp() + 7 days);
 
         address[] memory claimIpIds = new address[](1);


### PR DESCRIPTION
## Description
Per off line discussion, we decide to move collectRoyalties to groupingModule from the EvenSplitPool and allow pass snapshots, so that group pool has an unified entry point of grouping operations. Also added a new function for check whether an address is whitelisted group reward pool.

