### PR TITLE
Restrict distributeRewards Function to Grouping Module in EvenSplitGroupPool

### DIFF
--- a/contracts/modules/grouping/EvenSplitGroupPool.sol
+++ b/contracts/modules/grouping/EvenSplitGroupPool.sol
@@ -124,7 +124,7 @@ contract EvenSplitGroupPool is IGroupRewardPool, ProtocolPausableUpgradeable, UU
         address groupId,
         address token,
         address[] calldata ipIds
-    ) external whenNotPaused returns (uint256[] memory rewards) {
+    ) external whenNotPaused onlyGroupingModule returns (uint256[] memory rewards) {
         rewards = _getAvailableReward(groupId, token, ipIds);
         uint256 totalRewards = 0;
         for (uint256 i = 0; i < ipIds.length; i++) {

--- a/test/foundry/modules/grouping/EvenSplitGroupPool.t.sol
+++ b/test/foundry/modules/grouping/EvenSplitGroupPool.t.sol
@@ -203,15 +203,20 @@ contract EvenSplitGroupPoolTest is BaseTest {
 
     function test_EvenSplitGroupPool_revert_Only_GroupingModule() public {
         vm.startPrank(address(0x123));
-        vm.expectRevert(abi.encodeWithSelector(Errors.EvenSplitGroupPool__CallerIsNotGroupingModule.selector, address(0x123)));
+        vm.expectRevert(
+            abi.encodeWithSelector(Errors.EvenSplitGroupPool__CallerIsNotGroupingModule.selector, address(0x123))
+        );
         rewardPool.removeIp(group1, ipId1);
 
-        vm.expectRevert(abi.encodeWithSelector(Errors.EvenSplitGroupPool__CallerIsNotGroupingModule.selector, address(0x123)));
+        vm.expectRevert(
+            abi.encodeWithSelector(Errors.EvenSplitGroupPool__CallerIsNotGroupingModule.selector, address(0x123))
+        );
         rewardPool.addIp(group1, ipId1);
 
-        vm.expectRevert(abi.encodeWithSelector(Errors.EvenSplitGroupPool__CallerIsNotGroupingModule.selector, address(0x123)));
+        vm.expectRevert(
+            abi.encodeWithSelector(Errors.EvenSplitGroupPool__CallerIsNotGroupingModule.selector, address(0x123))
+        );
         rewardPool.distributeRewards(group1, address(erc20), new address[](0));
-
 
         vm.stopPrank();
     }

--- a/test/foundry/modules/grouping/EvenSplitGroupPool.t.sol
+++ b/test/foundry/modules/grouping/EvenSplitGroupPool.t.sol
@@ -10,6 +10,7 @@ import { PILFlavors } from "../../../../contracts/lib/PILFlavors.sol";
 import { EvenSplitGroupPool } from "../../../../contracts/modules/grouping/EvenSplitGroupPool.sol";
 import { MockERC721 } from "../../mocks/token/MockERC721.sol";
 import { BaseTest } from "../../utils/BaseTest.t.sol";
+import { Errors } from "../../../../contracts/lib/Errors.sol";
 
 contract EvenSplitGroupPoolTest is BaseTest {
     using Strings for *;
@@ -188,6 +189,7 @@ contract EvenSplitGroupPoolTest is BaseTest {
         uint256[] memory rewards = rewardPool.getAvailableReward(group1, address(erc20), ipIds);
         assertEq(rewards[0], 100);
 
+        vm.prank(address(groupingModule));
         rewards = rewardPool.distributeRewards(group1, address(erc20), ipIds);
         assertEq(rewards[0], 100);
 
@@ -195,6 +197,21 @@ contract EvenSplitGroupPoolTest is BaseTest {
 
         rewardDebt = rewardPool.getIpRewardDebt(group1, address(erc20), ipId1);
         assertEq(rewardDebt, 100);
+
+        vm.stopPrank();
+    }
+
+    function test_EvenSplitGroupPool_revert_Only_GroupingModule() public {
+        vm.startPrank(address(0x123));
+        vm.expectRevert(abi.encodeWithSelector(Errors.EvenSplitGroupPool__CallerIsNotGroupingModule.selector, address(0x123)));
+        rewardPool.removeIp(group1, ipId1);
+
+        vm.expectRevert(abi.encodeWithSelector(Errors.EvenSplitGroupPool__CallerIsNotGroupingModule.selector, address(0x123)));
+        rewardPool.addIp(group1, ipId1);
+
+        vm.expectRevert(abi.encodeWithSelector(Errors.EvenSplitGroupPool__CallerIsNotGroupingModule.selector, address(0x123)));
+        rewardPool.distributeRewards(group1, address(erc20), new address[](0));
+
 
         vm.stopPrank();
     }


### PR DESCRIPTION
This PR updates the `distributeRewards` function in the `EvenSplitGroupPool` contract to add a restriction that only allows the Grouping Module to call this function. This ensures that only authorized modules can distribute rewards, enhancing the security and integrity of the reward distribution process.

## Key Changes

- **Function Restriction**: Added a restriction to the `distributeRewards` function to ensure it can only be called by the Grouping Module.
