### PR TITLE
Allow IP Owner to Customize and Override Royalty Percentage in License Terms

### DIFF
--- a/contracts/interfaces/modules/licensing/ILicenseTemplate.sol
+++ b/contracts/interfaces/modules/licensing/ILicenseTemplate.sol
@@ -138,5 +138,10 @@ interface ILicenseTemplate is IERC165 {
         address childIpOwner
     ) external returns (bool);
 
+    /// @notice Verifies if the royalty percentage defined in the licenseTermsId can be overridden with
+    /// the given newRoyaltyPercent.
+    /// @param licenseTermsId The ID of the license terms.
+    /// @param newRoyaltyPercent The new royalty percentage.
+    /// @return True if the royalty percentage can be overridden, false otherwise.
     function canOverrideRoyaltyPercent(uint256 licenseTermsId, uint32 newRoyaltyPercent) external view returns (bool);
 }

--- a/contracts/interfaces/modules/licensing/ILicenseTemplate.sol
+++ b/contracts/interfaces/modules/licensing/ILicenseTemplate.sol
@@ -137,4 +137,6 @@ interface ILicenseTemplate is IERC165 {
         uint256[] calldata licenseTermsIds,
         address childIpOwner
     ) external returns (bool);
+
+    function canOverrideRoyaltyPercent(uint256 licenseTermsId, uint32 newRoyaltyPercent) external view returns (bool);
 }

--- a/contracts/interfaces/registries/ILicenseRegistry.sol
+++ b/contracts/interfaces/registries/ILicenseRegistry.sol
@@ -16,7 +16,8 @@ interface ILicenseRegistry {
     event LicensingConfigSetForLicense(
         address indexed ipId,
         address indexed licenseTemplate,
-        uint256 indexed licenseTermsId
+        uint256 indexed licenseTermsId,
+        Licensing.LicensingConfig licensingConfig
     );
 
     /// @notice Emitted when set new default license terms.

--- a/contracts/lib/Errors.sol
+++ b/contracts/lib/Errors.sol
@@ -252,8 +252,11 @@ library Errors {
     /// @notice Zero address provided for IP Graph ACL.
     error LicenseRegistry__ZeroIPGraphACL();
 
+    /// @notice When Set LicenseConfig the license template cannot be Zero address if royalty percentage is not Zero.
     error LicensingModule__LicenseTemplateCannotZeroAddressForOverrideRoyaltyPercent();
-    error LicensingModule__CannotOverrideRoyaltyPercent(
+
+    /// @notice Current License does not allow to override royalty percentage.
+    error LicensingModule__CurrentLicenseNotAllowOverrideRoyaltyPercent(
         address licenseTemplate,
         uint256 licenseTermsId,
         uint32 newRoyaltyPercent

--- a/contracts/lib/Errors.sol
+++ b/contracts/lib/Errors.sol
@@ -253,7 +253,7 @@ library Errors {
     error LicenseRegistry__ZeroIPGraphACL();
 
     /// @notice When Set LicenseConfig the license template cannot be Zero address if royalty percentage is not Zero.
-    error LicensingModule__LicenseTemplateCannotZeroAddressForOverrideRoyaltyPercent();
+    error LicensingModule__LicenseTemplateCannotBeZeroAddressToOverrideRoyaltyPercent();
 
     /// @notice Current License does not allow to override royalty percentage.
     error LicensingModule__CurrentLicenseNotAllowOverrideRoyaltyPercent(

--- a/contracts/lib/Errors.sol
+++ b/contracts/lib/Errors.sol
@@ -252,6 +252,12 @@ library Errors {
     /// @notice Zero address provided for IP Graph ACL.
     error LicenseRegistry__ZeroIPGraphACL();
 
+    error LicensingModule__LicenseTemplateCannotZeroAddressForOverrideRoyaltyPercent();
+    error LicensingModule__CannotOverrideRoyaltyPercent(
+        address licenseTemplate,
+        uint256 licenseTermsId,
+        uint32 newRoyaltyPercent
+    );
     ////////////////////////////////////////////////////////////////////////////
     //                             License Token                              //
     ////////////////////////////////////////////////////////////////////////////

--- a/contracts/lib/Licensing.sol
+++ b/contracts/lib/Licensing.sol
@@ -20,5 +20,6 @@ library Licensing {
         uint256 mintingFee;
         address licensingHook;
         bytes hookData;
+        uint32 commercialRevShare;
     }
 }

--- a/contracts/lib/Licensing.sol
+++ b/contracts/lib/Licensing.sol
@@ -15,6 +15,7 @@ library Licensing {
     /// @param mintingFee The minting fee to be paid when minting license tokens.
     /// @param licensingHook  The hook contract address for the licensing module, or address(0) if none
     /// @param hookData The data to be used by the licensing hook.
+    /// @param commercialRevShare The commercial revenue share percentage.
     struct LicensingConfig {
         bool isSet;
         uint256 mintingFee;

--- a/contracts/modules/licensing/LicensingModule.sol
+++ b/contracts/modules/licensing/LicensingModule.sol
@@ -331,7 +331,7 @@ contract LicensingModule is
         uint32[] memory rPercents = new uint32[](parentIpIds.length);
         for (uint256 i = 0; i < parentIpIds.length; i++) {
             (address royaltyPolicy, uint32 royaltyPercent, , ) = lct.getRoyaltyPolicy(licenseTermsIds[i]);
-            Licensing.LicensingConfig lsc = LICENSE_REGISTRY.getLicensingConfig(
+            Licensing.LicensingConfig memory lsc = LICENSE_REGISTRY.getLicensingConfig(
                 parentIpIds[i],
                 licenseTemplate,
                 licenseTermsIds[i]

--- a/contracts/modules/licensing/LicensingModule.sol
+++ b/contracts/modules/licensing/LicensingModule.sol
@@ -377,11 +377,12 @@ contract LicensingModule is
         if (licenseTemplate == address(0) && licensingConfig.commercialRevShare != 0) {
             revert Errors.LicensingModule__LicenseTemplateCannotZeroAddressForOverrideRoyaltyPercent();
         }
-        ILicenseTemplate lct = ILicenseTemplate(licenseTemplate);
-        if (!LICENSE_REGISTRY.isRegisteredLicenseTemplate(licenseTemplate)) {
-            revert Errors.LicenseRegistry__UnregisteredLicenseTemplate(licenseTemplate);
-        }
+
         if (licensingConfig.commercialRevShare != 0) {
+            ILicenseTemplate lct = ILicenseTemplate(licenseTemplate);
+            if (!LICENSE_REGISTRY.isRegisteredLicenseTemplate(licenseTemplate)) {
+                revert Errors.LicenseRegistry__UnregisteredLicenseTemplate(licenseTemplate);
+            }
             if (!lct.canOverrideRoyaltyPercent(licenseTermsId, licensingConfig.commercialRevShare)) {
                 revert Errors.LicensingModule__CannotOverrideRoyaltyPercent(
                     licenseTemplate,

--- a/contracts/modules/licensing/LicensingModule.sol
+++ b/contracts/modules/licensing/LicensingModule.sol
@@ -384,7 +384,7 @@ contract LicensingModule is
                 revert Errors.LicenseRegistry__UnregisteredLicenseTemplate(licenseTemplate);
             }
             if (!lct.canOverrideRoyaltyPercent(licenseTermsId, licensingConfig.commercialRevShare)) {
-                revert Errors.LicensingModule__CannotOverrideRoyaltyPercent(
+                revert Errors.LicensingModule__CurrentLicenseNotAllowOverrideRoyaltyPercent(
                     licenseTemplate,
                     licenseTermsId,
                     licensingConfig.commercialRevShare

--- a/contracts/modules/licensing/LicensingModule.sol
+++ b/contracts/modules/licensing/LicensingModule.sol
@@ -331,7 +331,7 @@ contract LicensingModule is
         uint32[] memory rPercents = new uint32[](parentIpIds.length);
         for (uint256 i = 0; i < parentIpIds.length; i++) {
             (address royaltyPolicy, uint32 royaltyPercent, , ) = lct.getRoyaltyPolicy(licenseTermsIds[i]);
-            Licensing.LicensingConfig memory lsc = LICENSE_REGISTRY.getLicensingConfig(
+            Licensing.LicensingConfig lsc = LICENSE_REGISTRY.getLicensingConfig(
                 parentIpIds[i],
                 licenseTemplate,
                 licenseTermsIds[i]
@@ -378,13 +378,8 @@ contract LicensingModule is
             revert Errors.LicensingModule__LicenseTemplateCannotZeroAddressForOverrideRoyaltyPercent();
         }
         ILicenseTemplate lct = ILicenseTemplate(licenseTemplate);
-        if (licenseTemplate != address(0)) {
-            if (!lct.supportsInterface(type(ILicenseTemplate).interfaceId)) {
-                revert Errors.LicenseRegistry__NotLicenseTemplate(licenseTemplate);
-            }
-            if (!LICENSE_REGISTRY.isRegisteredLicenseTemplate(licenseTemplate)) {
-                revert Errors.LicenseRegistry__UnregisteredLicenseTemplate(licenseTemplate);
-            }
+        if (!LICENSE_REGISTRY.isRegisteredLicenseTemplate(licenseTemplate)) {
+            revert Errors.LicenseRegistry__UnregisteredLicenseTemplate(licenseTemplate);
         }
         if (licensingConfig.commercialRevShare != 0) {
             if (!lct.canOverrideRoyaltyPercent(licenseTermsId, licensingConfig.commercialRevShare)) {

--- a/contracts/modules/licensing/LicensingModule.sol
+++ b/contracts/modules/licensing/LicensingModule.sol
@@ -375,7 +375,7 @@ contract LicensingModule is
         Licensing.LicensingConfig memory licensingConfig
     ) external verifyPermission(ipId) whenNotPaused {
         if (licenseTemplate == address(0) && licensingConfig.commercialRevShare != 0) {
-            revert Errors.LicensingModule__LicenseTemplateCannotZeroAddressForOverrideRoyaltyPercent();
+            revert Errors.LicensingModule__LicenseTemplateCannotBeZeroAddressToOverrideRoyaltyPercent();
         }
 
         if (licensingConfig.commercialRevShare != 0) {

--- a/contracts/modules/licensing/PILicenseTemplate.sol
+++ b/contracts/modules/licensing/PILicenseTemplate.sol
@@ -302,10 +302,7 @@ contract PILicenseTemplate is
     function canOverrideRoyaltyPercent(uint256 licenseTermsId, uint32 newRoyaltyPercent) external view returns (bool) {
         if (licenseTermsId == 0 || newRoyaltyPercent == 0) return false;
         PILTerms memory terms = _getPILicenseTemplateStorage().licenseTerms[licenseTermsId];
-        if (terms.commercialUse) {
-            return terms.commercialRevCeiling == 0 || newRoyaltyPercent <= terms.commercialRevCeiling;
-        }
-        return false;
+        return terms.commercialUse;
     }
 
     /// @notice checks the contract whether supports the given interface.

--- a/contracts/modules/licensing/PILicenseTemplate.sol
+++ b/contracts/modules/licensing/PILicenseTemplate.sol
@@ -294,6 +294,11 @@ contract PILicenseTemplate is
         return _getPILicenseTemplateStorage().licenseTermsCounter;
     }
 
+    /// @notice Verifies if the royalty percentage defined in the licenseTermsId can be overridden with
+    /// the given newRoyaltyPercent.
+    /// @param licenseTermsId The ID of the license terms.
+    /// @param newRoyaltyPercent The new royalty percentage.
+    /// @return True if the royalty percentage can be overridden, false otherwise.
     function canOverrideRoyaltyPercent(uint256 licenseTermsId, uint32 newRoyaltyPercent) external view returns (bool) {
         if (licenseTermsId == 0 || newRoyaltyPercent == 0) return false;
         PILTerms memory terms = _getPILicenseTemplateStorage().licenseTerms[licenseTermsId];

--- a/contracts/modules/licensing/PILicenseTemplate.sol
+++ b/contracts/modules/licensing/PILicenseTemplate.sol
@@ -294,6 +294,15 @@ contract PILicenseTemplate is
         return _getPILicenseTemplateStorage().licenseTermsCounter;
     }
 
+    function canOverrideRoyaltyPercent(uint256 licenseTermsId, uint32 newRoyaltyPercent) external view returns (bool) {
+        if (licenseTermsId == 0 || newRoyaltyPercent == 0) return false;
+        PILTerms memory terms = _getPILicenseTemplateStorage().licenseTerms[licenseTermsId];
+        if (terms.commercialUse) {
+            return terms.commercialRevCeiling == 0 || newRoyaltyPercent <= terms.commercialRevCeiling;
+        }
+        return false;
+    }
+
     /// @notice checks the contract whether supports the given interface.
     function supportsInterface(
         bytes4 interfaceId

--- a/contracts/registries/LicenseRegistry.sol
+++ b/contracts/registries/LicenseRegistry.sol
@@ -147,10 +147,11 @@ contract LicenseRegistry is ILicenseRegistry, AccessManagedUpgradeable, UUPSUpgr
             isSet: licensingConfig.isSet,
             mintingFee: licensingConfig.mintingFee,
             licensingHook: licensingConfig.licensingHook,
-            hookData: licensingConfig.hookData
+            hookData: licensingConfig.hookData,
+            commercialRevShare: licensingConfig.commercialRevShare
         });
 
-        emit LicensingConfigSetForLicense(ipId, licenseTemplate, licenseTermsId);
+        emit LicensingConfigSetForLicense(ipId, licenseTemplate, licenseTermsId, licensingConfig);
     }
 
     /// @notice Sets the LicensingConfig for an IP and applies it to all licenses attached to the IP.
@@ -167,7 +168,8 @@ contract LicenseRegistry is ILicenseRegistry, AccessManagedUpgradeable, UUPSUpgr
             isSet: licensingConfig.isSet,
             mintingFee: licensingConfig.mintingFee,
             licensingHook: licensingConfig.licensingHook,
-            hookData: licensingConfig.hookData
+            hookData: licensingConfig.hookData,
+            commercialRevShare: licensingConfig.commercialRevShare
         });
         emit LicensingConfigSetForIP(ipId, licensingConfig);
     }

--- a/test/foundry/mocks/module/MockLicenseTemplate.sol
+++ b/test/foundry/mocks/module/MockLicenseTemplate.sol
@@ -149,4 +149,8 @@ contract MockLicenseTemplate is BaseLicenseTemplateUpgradeable {
     function getLicenseTermsURI(uint256 licenseTermsId) external view returns (string memory) {
         return "";
     }
+
+    function canOverrideRoyaltyPercent(uint256 licenseTermsId, uint32 newRoyaltyPercent) external view returns (bool) {
+        return true;
+    }
 }

--- a/test/foundry/modules/licensing/LicensingModule.t.sol
+++ b/test/foundry/modules/licensing/LicensingModule.t.sol
@@ -1710,7 +1710,7 @@ contract LicensingModuleTest is BaseTest {
         vm.prank(ipOwner1);
         licensingModule.setLicensingConfig(ipId1, address(0x123), 1, licensingConfig);
 
-        vm.expectRevert(Errors.LicensingModule__LicenseTemplateCannotZeroAddressForOverrideRoyaltyPercent.selector);
+        vm.expectRevert(Errors.LicensingModule__LicenseTemplateCannotBeZeroAddressToOverrideRoyaltyPercent.selector);
         vm.prank(ipOwner1);
         licensingModule.setLicensingConfig(ipId1, address(0), socialRemixTermsId, licensingConfig);
 

--- a/test/foundry/modules/licensing/LicensingModule.t.sol
+++ b/test/foundry/modules/licensing/LicensingModule.t.sol
@@ -1484,7 +1484,8 @@ contract LicensingModuleTest is BaseTest {
             isSet: true,
             mintingFee: 100,
             licensingHook: address(licensingHook),
-            hookData: abi.encode(address(0x123))
+            hookData: abi.encode(address(0x123)),
+            commercialRevShare: 0
         });
         vm.prank(ipOwner1);
         licensingModule.setLicensingConfig(ipId1, address(pilTemplate), socialRemixTermsId, licensingConfig);
@@ -1522,7 +1523,8 @@ contract LicensingModuleTest is BaseTest {
             isSet: true,
             mintingFee: 100,
             licensingHook: address(licensingHook),
-            hookData: abi.encode(address(0x123))
+            hookData: abi.encode(address(0x123)),
+            commercialRevShare: 0
         });
         vm.prank(ipOwner1);
         licensingModule.setLicensingConfig(ipId1, address(pilTemplate), socialRemixTermsId, licensingConfig);
@@ -1571,7 +1573,8 @@ contract LicensingModuleTest is BaseTest {
             isSet: true,
             mintingFee: 100,
             licensingHook: address(licensingHook),
-            hookData: abi.encode(address(0x123))
+            hookData: abi.encode(address(0x123)),
+            commercialRevShare: 0
         });
         vm.expectRevert(
             abi.encodeWithSelector(Errors.LicensingModule__InvalidLicenseTermsId.selector, address(pilTemplate), 0)
@@ -1598,7 +1601,8 @@ contract LicensingModuleTest is BaseTest {
             isSet: true,
             mintingFee: 100,
             licensingHook: address(licensingHook),
-            hookData: abi.encode(address(0x123))
+            hookData: abi.encode(address(0x123)),
+            commercialRevShare: 0
         });
         vm.expectRevert(
             abi.encodeWithSelector(Errors.LicensingModule__InvalidLicensingHook.selector, address(licensingHook))
@@ -1615,7 +1619,8 @@ contract LicensingModuleTest is BaseTest {
             isSet: true,
             mintingFee: 100,
             licensingHook: address(tokenGatedHook),
-            hookData: abi.encode(address(0x123))
+            hookData: abi.encode(address(0x123)),
+            commercialRevShare: 0
         });
         vm.expectRevert(
             abi.encodeWithSelector(Errors.LicensingModule__InvalidLicensingHook.selector, address(tokenGatedHook))
@@ -1636,7 +1641,8 @@ contract LicensingModuleTest is BaseTest {
             isSet: true,
             mintingFee: 100,
             licensingHook: address(licensingHook),
-            hookData: abi.encode(address(0x123))
+            hookData: abi.encode(address(0x123)),
+            commercialRevShare: 0
         });
         vm.expectRevert(abi.encodeWithSelector(PausableUpgradeable.EnforcedPause.selector));
         vm.prank(ipOwner1);
@@ -1652,7 +1658,8 @@ contract LicensingModuleTest is BaseTest {
             isSet: true,
             mintingFee: 100,
             licensingHook: address(licensingHook),
-            hookData: abi.encode(address(0x123))
+            hookData: abi.encode(address(0x123)),
+            commercialRevShare: 0
         });
         vm.prank(ipOwner1);
         licensingModule.setLicensingConfig(ipId1, address(pilTemplate), termsId, licensingConfig);
@@ -1688,7 +1695,8 @@ contract LicensingModuleTest is BaseTest {
             isSet: true,
             mintingFee: 999999,
             licensingHook: address(licensingHook),
-            hookData: abi.encode(address(0x123))
+            hookData: abi.encode(address(0x123)),
+            commercialRevShare: 0
         });
         vm.prank(ipOwner1);
         licensingModule.setLicensingConfig(ipId1, address(pilTemplate), termsId, licensingConfig);
@@ -1745,7 +1753,8 @@ contract LicensingModuleTest is BaseTest {
             isSet: true,
             mintingFee: 1000,
             licensingHook: address(0),
-            hookData: abi.encode(address(0x123))
+            hookData: abi.encode(address(0x123)),
+            commercialRevShare: 0
         });
         vm.prank(ipOwner1);
         licensingModule.setLicensingConfig(ipId1, address(pilTemplate), termsId, licensingConfig);
@@ -1853,7 +1862,8 @@ contract LicensingModuleTest is BaseTest {
             isSet: true,
             mintingFee: 999999,
             licensingHook: address(licensingHook),
-            hookData: abi.encode(address(0x123))
+            hookData: abi.encode(address(0x123)),
+            commercialRevShare: 0
         });
         vm.prank(ipOwner1);
         licensingModule.setLicensingConfig(ipId1, address(pilTemplate), termsId, licensingConfig);
@@ -1903,7 +1913,8 @@ contract LicensingModuleTest is BaseTest {
             isSet: true,
             mintingFee: 999999,
             licensingHook: address(licensingHook),
-            hookData: abi.encode(address(0x123))
+            hookData: abi.encode(address(0x123)),
+            commercialRevShare: 0
         });
         vm.prank(ipOwner1);
         licensingModule.setLicensingConfig(ipId1, address(pilTemplate), termsId, licensingConfig);
@@ -1955,7 +1966,8 @@ contract LicensingModuleTest is BaseTest {
             isSet: true,
             mintingFee: 999999,
             licensingHook: address(licensingHook),
-            hookData: abi.encode(address(0x123))
+            hookData: abi.encode(address(0x123)),
+            commercialRevShare: 0
         });
         vm.prank(ipOwner1);
         licensingModule.setLicensingConfig(ipId1, address(pilTemplate), termsId, licensingConfig);
@@ -1994,7 +2006,8 @@ contract LicensingModuleTest is BaseTest {
             isSet: false,
             mintingFee: 0,
             licensingHook: address(0),
-            hookData: abi.encode(address(0))
+            hookData: abi.encode(address(0)),
+            commercialRevShare: 0
         });
         vm.prank(ipOwner1);
         licensingModule.setLicensingConfig(ipId1, address(pilTemplate), termsId, licensingConfig2);
@@ -2023,7 +2036,8 @@ contract LicensingModuleTest is BaseTest {
             isSet: true,
             mintingFee: 100,
             licensingHook: address(licensingHook),
-            hookData: abi.encode(address(ipOwner2))
+            hookData: abi.encode(address(ipOwner2)),
+            commercialRevShare: 0
         });
         vm.prank(ipOwner1);
         licensingModule.setLicensingConfig(ipId1, address(pilTemplate), termsId, licensingConfig);

--- a/test/foundry/modules/licensing/LicensingModule.t.sol
+++ b/test/foundry/modules/licensing/LicensingModule.t.sol
@@ -1716,7 +1716,7 @@ contract LicensingModuleTest is BaseTest {
 
         vm.expectRevert(
             abi.encodeWithSelector(
-                Errors.LicensingModule__CannotOverrideRoyaltyPercent.selector,
+                Errors.LicensingModule__CurrentLicenseNotAllowOverrideRoyaltyPercent.selector,
                 address(pilTemplate),
                 socialRemixTermsId,
                 1000

--- a/test/foundry/registries/LicenseRegistry.t.sol
+++ b/test/foundry/registries/LicenseRegistry.t.sol
@@ -102,7 +102,8 @@ contract LicenseRegistryTest is BaseTest {
             isSet: true,
             mintingFee: 100,
             licensingHook: address(0),
-            hookData: ""
+            hookData: "",
+            commercialRevShare: 0
         });
 
         vm.prank(address(licensingModule));
@@ -129,7 +130,8 @@ contract LicenseRegistryTest is BaseTest {
             isSet: true,
             mintingFee: 100,
             licensingHook: address(0),
-            hookData: ""
+            hookData: "",
+            commercialRevShare: 0
         });
 
         vm.expectRevert(
@@ -145,7 +147,8 @@ contract LicenseRegistryTest is BaseTest {
             isSet: true,
             mintingFee: 100,
             licensingHook: address(0),
-            hookData: ""
+            hookData: "",
+            commercialRevShare: 0
         });
 
         vm.prank(address(licensingModule));


### PR DESCRIPTION
## Description

This PR introduces a new configuration item, `commercialRevShare`, in the `LicenseConfig` to allow IP owners to customize and override the royalty percentage defined in the license terms. This enhancement enables derivative IPs to customize or change the royalty percentage for their further children/descendants.

## Key Changes

- **New Configuration Item**: Added `commercialRevShare` to the `LicenseConfig`.
- **Override Mechanism**: Implemented logic to override the `commercialRevShare` read from the license terms with the customized value set in the `LicenseConfig`.

## Objectives

- **Customization**: Allow IP owners to set a custom royalty percentage for each license.
- **Override Default**: Enable the custom `commercialRevShare` to override the default value from the license terms when a child IP registers a derivative to the IP.

## Implementation Steps

1. **Update LicenseConfig**: Add the `commercialRevShare` field to the `LicenseConfig`.
2. **Override Logic**: Implement the logic to use the custom `commercialRevShare` from the `LicenseConfig` if set, instead of the default value from the license terms.

