### PR TITLE
Grouping & Royalty integration refactor

### DIFF
--- a/contracts/lib/Errors.sol
+++ b/contracts/lib/Errors.sol
@@ -583,6 +583,12 @@ library Errors {
     /// @notice Zero address provided for Royalty Module.
     error IpRoyaltyVault__ZeroRoyaltyModule();
 
+    /// @notice Zero address provided for IP Asset Registry.
+    error IpRoyaltyVault__ZeroIpAssetRegistry();
+
+    /// @notice Zero address provided for Grouping Module.
+    error IpRoyaltyVault__ZeroGroupingModule();
+
     /// @notice Caller is not Royalty Module.
     error IpRoyaltyVault__NotAllowedToAddTokenToVault();
 
@@ -612,6 +618,9 @@ library Errors {
 
     /// @notice Vaults must claim as self.
     error IpRoyaltyVault__VaultsMustClaimAsSelf();
+
+    /// @notice Group reward pool must claim via GroupingModule.
+    error IpRoyaltyVault__GroupPoolMustClaimViaGroupingModule();
 
     ////////////////////////////////////////////////////////////////////////////
     //                            Vault Controller                            //

--- a/script/foundry/utils/DeployHelper.sol
+++ b/script/foundry/utils/DeployHelper.sol
@@ -594,7 +594,7 @@ contract DeployHelper is Script, BroadcastManager, JsonDeploymentHandler, Storag
                 _getSalt(type(IpRoyaltyVault).name),
                 abi.encodePacked(
                     type(IpRoyaltyVault).creationCode,
-                    abi.encode(address(disputeModule), address(royaltyModule))
+                    abi.encode(address(disputeModule), address(royaltyModule), address(ipAssetRegistry), address(groupingModule))
                 )
             )
         );

--- a/test/foundry/mocks/module/MockIpRoyaltyVaultV2.sol
+++ b/test/foundry/mocks/module/MockIpRoyaltyVaultV2.sol
@@ -15,7 +15,12 @@ contract MockIpRoyaltyVaultV2 is IpRoyaltyVault {
         0x2942176f94974e015a9b06f79a3a2280d18f1872591c134ba237fa184e378300;
 
     /// @custom:oz-upgrades-unsafe-allow constructor
-    constructor(address royaltyPolicyLAP, address disputeModule) IpRoyaltyVault(royaltyPolicyLAP, disputeModule) {
+    constructor(
+        address royaltyPolicyLAP,
+        address disputeModule,
+        address licenseRegistry,
+        address groupingModule
+    ) IpRoyaltyVault(royaltyPolicyLAP, disputeModule, licenseRegistry, groupingModule) {
         _disableInitializers();
     }
 

--- a/test/foundry/modules/royalty/VaultController.t.sol
+++ b/test/foundry/modules/royalty/VaultController.t.sol
@@ -35,7 +35,7 @@ contract TestRoyaltyModule is BaseTest {
     }
 
     function test_VaultController_upgradeVaults() public {
-        address newVault = address(new IpRoyaltyVault(address(1), address(2)));
+        address newVault = address(new IpRoyaltyVault(address(1), address(2), address(3), address(4)));
 
         (bytes32 operationId, uint32 nonce) = protocolAccessManager.schedule(
             address(royaltyModule),

--- a/test/foundry/upgrades/Upgrades.t.sol
+++ b/test/foundry/upgrades/Upgrades.t.sol
@@ -21,7 +21,14 @@ contract UpgradesTest is BaseTest {
     }
 
     function test_upgradeVaults() public {
-        address newVault = address(new MockIpRoyaltyVaultV2(address(royaltyPolicyLAP), address(disputeModule)));
+        address newVault = address(
+            new MockIpRoyaltyVaultV2(
+                address(royaltyPolicyLAP),
+                address(disputeModule),
+                address(licenseRegistry),
+                address(groupingModule)
+            )
+        );
         (bool immediate, uint32 delay) = protocolAccessManager.canCall(
             u.bob,
             address(royaltyModule),


### PR DESCRIPTION
## Description
A restriction is added on the ip royalty vault in which only the grouping module can claim on behalf of group pools to prevent accounting errors in the grouping module / group pools.