### PR TITLE
Support Unwhitelisting a Group Reward Pool

### DIFF
--- a/contracts/interfaces/modules/grouping/IGroupingModule.sol
+++ b/contracts/interfaces/modules/grouping/IGroupingModule.sol
@@ -51,7 +51,8 @@ interface IGroupingModule is IModule {
 
     /// @notice Whitelists a group reward pool.
     /// @param rewardPool The address of the group reward pool.
-    function whitelistGroupRewardPool(address rewardPool) external;
+    /// @param allowed Whether the group reward pool is whitelisted.
+    function whitelistGroupRewardPool(address rewardPool, bool allowed) external;
 
     /// @notice Adds IP to group.
     /// the function must be called by the Group IP owner or an authorized operator.

--- a/contracts/interfaces/registries/IGroupIPAssetRegistry.sol
+++ b/contracts/interfaces/registries/IGroupIPAssetRegistry.sol
@@ -13,7 +13,8 @@ interface IGroupIPAssetRegistry {
 
     /// @notice Whitelists a group reward pool
     /// @param rewardPool The address of the group reward pool
-    function whitelistGroupRewardPool(address rewardPool) external;
+    /// @param allowed Whether the group reward pool is whitelisted
+    function whitelistGroupRewardPool(address rewardPool, bool allowed) external;
 
     /// @notice Adds a member to a Group IPA
     /// @param groupId The address of the Group IPA.

--- a/contracts/modules/grouping/GroupingModule.sol
+++ b/contracts/modules/grouping/GroupingModule.sol
@@ -123,12 +123,13 @@ contract GroupingModule is
 
     /// @notice Whitelists a group reward pool.
     /// @param rewardPool The address of the group reward pool.
-    function whitelistGroupRewardPool(address rewardPool) external restricted {
+    /// @param allowed Whether the group reward pool is whitelisted.
+    function whitelistGroupRewardPool(address rewardPool, bool allowed) external restricted {
         if (rewardPool == address(0)) {
             revert Errors.GroupingModule__ZeroGroupRewardPool();
         }
 
-        GROUP_IP_ASSET_REGISTRY.whitelistGroupRewardPool(rewardPool);
+        GROUP_IP_ASSET_REGISTRY.whitelistGroupRewardPool(rewardPool, allowed);
     }
 
     /// @notice Adds IP to group.

--- a/contracts/registries/GroupIPAssetRegistry.sol
+++ b/contracts/registries/GroupIPAssetRegistry.sol
@@ -67,11 +67,12 @@ abstract contract GroupIPAssetRegistry is IGroupIPAssetRegistry, ProtocolPausabl
 
     /// @notice Whitelists a group reward pool
     /// @param rewardPool The address of the group reward pool
-    function whitelistGroupRewardPool(address rewardPool) external onlyGroupingModule whenNotPaused {
+    /// @param allowed Whether the group reward pool is whitelisted
+    function whitelistGroupRewardPool(address rewardPool, bool allowed) external onlyGroupingModule whenNotPaused {
         if (rewardPool == address(0)) {
             revert Errors.GroupIPAssetRegistry__InvalidGroupRewardPool(rewardPool);
         }
-        _getGroupIPAssetRegistryStorage().whitelistedGroupRewardPools[rewardPool] = true;
+        _getGroupIPAssetRegistryStorage().whitelistedGroupRewardPools[rewardPool] = allowed;
     }
 
     /// @notice Adds a member to a Group IPA

--- a/script/foundry/utils/DeployHelper.sol
+++ b/script/foundry/utils/DeployHelper.sol
@@ -743,7 +743,7 @@ contract DeployHelper is Script, BroadcastManager, JsonDeploymentHandler, Storag
         licenseRegistry.setDefaultLicenseTerms(address(pilTemplate), licenseId);
 
         // add evenSplitGroupPool to whitelist of group pools
-        groupingModule.whitelistGroupRewardPool(address(evenSplitGroupPool));
+        groupingModule.whitelistGroupRewardPool(address(evenSplitGroupPool), true);
     }
 
     function _configureRoles() private {

--- a/test/foundry/modules/grouping/GroupingModule.t.sol
+++ b/test/foundry/modules/grouping/GroupingModule.t.sol
@@ -81,10 +81,14 @@ contract GroupingModuleTest is BaseTest {
 
     function test_GroupingModule_whitelistRewardPool() public {
         vm.prank(admin);
-        groupingModule.whitelistGroupRewardPool(address(rewardPool));
+        groupingModule.whitelistGroupRewardPool(address(rewardPool), true);
         assertEq(ipAssetRegistry.isWhitelistedGroupRewardPool(address(rewardPool)), true);
 
         assertEq(ipAssetRegistry.isWhitelistedGroupRewardPool(address(0x123)), false);
+
+        vm.prank(admin);
+        groupingModule.whitelistGroupRewardPool(address(rewardPool), false);
+        assertEq(ipAssetRegistry.isWhitelistedGroupRewardPool(address(rewardPool)), false);
     }
 
     function test_GroupingModule_addIp() public {


### PR DESCRIPTION
## Description

This PR introduces functionality to support unwhitelisting a group reward pool. This allows the protocol to remove a previously whitelisted group reward pool.

