### PR TITLE
Introduce Max Minting Fee for License Token Minting and Derivative Registration

### DIFF
--- a/contracts/interfaces/modules/licensing/ILicensingModule.sol
+++ b/contracts/interfaces/modules/licensing/ILicensingModule.sol
@@ -82,6 +82,7 @@ interface ILicensingModule is IModule {
     /// @param amount The amount of license tokens to mint.
     /// @param receiver The address of the receiver.
     /// @param royaltyContext The context of the royalty.
+    /// @param maxMintingFee The maximum minting fee that the caller is willing to pay. if set to 0 then no limit.
     /// @return startLicenseTokenId The start ID of the minted license tokens.
     function mintLicenseTokens(
         address licensorIpId,
@@ -89,7 +90,8 @@ interface ILicensingModule is IModule {
         uint256 licenseTermsId,
         uint256 amount,
         address receiver,
-        bytes calldata royaltyContext
+        bytes calldata royaltyContext,
+        uint256 maxMintingFee
     ) external returns (uint256 startLicenseTokenId);
 
     /// @notice Registers a derivative directly with parent IP's license terms, without needing license tokens,
@@ -102,12 +104,14 @@ interface ILicensingModule is IModule {
     /// @param licenseTermsIds The IDs of the license terms that the parent IP supports.
     /// @param licenseTemplate The address of the license template of the license terms Ids.
     /// @param royaltyContext The context of the royalty.
+    /// @param maxMintingFee The maximum minting fee that the caller is willing to pay. if set to 0 then no limit.
     function registerDerivative(
         address childIpId,
         address[] calldata parentIpIds,
         uint256[] calldata licenseTermsIds,
         address licenseTemplate,
-        bytes calldata royaltyContext
+        bytes calldata royaltyContext,
+        uint256 maxMintingFee
     ) external;
 
     /// @notice Registers a derivative with license tokens.

--- a/contracts/lib/Errors.sol
+++ b/contracts/lib/Errors.sol
@@ -365,6 +365,9 @@ library Errors {
     /// @notice Grouping Module is zero address.
     error LicensingModule__ZeroGroupingModule();
 
+    /// @notice licensing minting fee is above the maximum minting fee.
+    error LicensingModule__MintingFeeExceedMaxMintingFee(uint256 mintingFee, uint256 maxMintingFee);
+
     ////////////////////////////////////////////////////////////////////////////
     //                             Dispute Module                             //
     ////////////////////////////////////////////////////////////////////////////

--- a/test/foundry/integration/big-bang/SingleNftCollection.t.sol
+++ b/test/foundry/integration/big-bang/SingleNftCollection.t.sol
@@ -153,7 +153,8 @@ contract BigBang_Integration_SingleNftCollection is BaseIntegration {
                 licenseTermsId: commDerivTermsId,
                 amount: 1,
                 receiver: u.carl,
-                royaltyContext: ""
+                royaltyContext: "",
+                maxMintingFee: 0
             });
 
             ipAcct[6] = registerIpAccount(mockNFT, 6, u.carl);
@@ -178,7 +179,8 @@ contract BigBang_Integration_SingleNftCollection is BaseIntegration {
                 licenseTermsId: ncSocialRemixTermsId,
                 amount: 1,
                 receiver: u.carl,
-                royaltyContext: ""
+                royaltyContext: "",
+                maxMintingFee: 0
             });
 
             ipAcct[tokenId] = registerIpAccount(address(mockNFT), tokenId, u.carl);
@@ -207,7 +209,8 @@ contract BigBang_Integration_SingleNftCollection is BaseIntegration {
                 licenseTermsId: commDerivTermsId,
                 amount: 2,
                 receiver: u.alice,
-                royaltyContext: ""
+                royaltyContext: "",
+                maxMintingFee: 0
             }); // ID 0 (first license)
 
             ipAcct[2] = registerIpAccount(mockNFT, 2, u.alice);
@@ -243,7 +246,8 @@ contract BigBang_Integration_SingleNftCollection is BaseIntegration {
                 licenseTermsId: commDerivTermsId,
                 amount: license0_mintAmount,
                 receiver: u.carl,
-                royaltyContext: ""
+                royaltyContext: "",
+                maxMintingFee: 0
             });
 
             // NC Social Remix license
@@ -253,7 +257,8 @@ contract BigBang_Integration_SingleNftCollection is BaseIntegration {
                 licenseTermsId: ncSocialRemixTermsId, // ipAcct[3] has this policy attached
                 amount: 1,
                 receiver: u.carl,
-                royaltyContext: ""
+                royaltyContext: "",
+                maxMintingFee: 0
             });
 
             ipAcct[tokenId] = registerIpAccount(address(mockNFT), tokenId, u.carl);
@@ -278,7 +283,8 @@ contract BigBang_Integration_SingleNftCollection is BaseIntegration {
                 licenseTermsId: commDerivTermsId,
                 amount: license1_mintAmount,
                 receiver: u.carl,
-                royaltyContext: ""
+                royaltyContext: "",
+                maxMintingFee: 0
             });
             carl_licenses[1] = carl_licenses[1] + license1_mintAmount - 1; // use last license ID minted from above
 

--- a/test/foundry/integration/flows/disputes/Disputes.t.sol
+++ b/test/foundry/integration/flows/disputes/Disputes.t.sol
@@ -55,7 +55,8 @@ contract Flows_Integration_Disputes is BaseIntegration {
             licenseTermsId: ncSocialRemixTermsId,
             amount: 1,
             receiver: u.carl,
-            royaltyContext: ""
+            royaltyContext: "",
+            maxMintingFee: 0
         });
         assertEq(licenseToken.balanceOf(u.carl), 1);
 
@@ -69,7 +70,8 @@ contract Flows_Integration_Disputes is BaseIntegration {
             licenseTermsId: ncSocialRemixTermsId,
             amount: 1,
             receiver: u.carl,
-            royaltyContext: ""
+            royaltyContext: "",
+            maxMintingFee: 0
         });
     }
 
@@ -83,7 +85,8 @@ contract Flows_Integration_Disputes is BaseIntegration {
             licenseTermsId: ncSocialRemixTermsId,
             amount: 1,
             receiver: u.carl,
-            royaltyContext: ""
+            royaltyContext: "",
+            maxMintingFee: 0
         });
         assertEq(licenseToken.balanceOf(u.carl), 1);
 
@@ -113,7 +116,8 @@ contract Flows_Integration_Disputes is BaseIntegration {
             parentIpIds: parentIpIds,
             licenseTermsIds: licenseTermsIds,
             licenseTemplate: address(pilTemplate),
-            royaltyContext: ""
+            royaltyContext: "",
+            maxMintingFee: 0
         });
     }
 
@@ -127,7 +131,8 @@ contract Flows_Integration_Disputes is BaseIntegration {
             licenseTermsId: ncSocialRemixTermsId,
             amount: 1,
             receiver: u.carl,
-            royaltyContext: ""
+            royaltyContext: "",
+            maxMintingFee: 0
         });
         assertEq(licenseToken.balanceOf(u.carl), 1);
 
@@ -154,7 +159,8 @@ contract Flows_Integration_Disputes is BaseIntegration {
             licenseTermsId: ncSocialRemixTermsId,
             amount: 1,
             receiver: u.carl,
-            royaltyContext: ""
+            royaltyContext: "",
+            maxMintingFee: 0
         });
         assertEq(licenseToken.balanceOf(u.carl), 1);
     }

--- a/test/foundry/integration/flows/grouping/Grouping.t.sol
+++ b/test/foundry/integration/flows/grouping/Grouping.t.sol
@@ -80,8 +80,8 @@ contract Flows_Integration_Grouping is BaseIntegration {
             vm.stopPrank();
         }
 
-        licensingModule.mintLicenseTokens(ipAcct[1], address(pilTemplate), commRemixTermsId, 1, address(this), "");
-        licensingModule.mintLicenseTokens(ipAcct[2], address(pilTemplate), commRemixTermsId, 1, address(this), "");
+        licensingModule.mintLicenseTokens(ipAcct[1], address(pilTemplate), commRemixTermsId, 1, address(this), "", 0);
+        licensingModule.mintLicenseTokens(ipAcct[2], address(pilTemplate), commRemixTermsId, 1, address(this), "", 0);
         {
             address[] memory ipIds = new address[](2);
             ipIds[0] = ipAcct[1];
@@ -98,7 +98,7 @@ contract Flows_Integration_Grouping is BaseIntegration {
             parentIpIds[0] = groupId;
             uint256[] memory licenseIds = new uint256[](1);
             licenseIds[0] = commRemixTermsId;
-            licensingModule.registerDerivative(ipAcct[3], parentIpIds, licenseIds, address(pilTemplate), "");
+            licensingModule.registerDerivative(ipAcct[3], parentIpIds, licenseIds, address(pilTemplate), "", 0);
             vm.stopPrank();
         }
 

--- a/test/foundry/integration/flows/licensing/LicensingIntegration.t.sol
+++ b/test/foundry/integration/flows/licensing/LicensingIntegration.t.sol
@@ -122,7 +122,7 @@ contract LicensingIntegrationTest is BaseIntegration {
         parentIpIds[0] = ipAcct[1];
         licenseTermsIds[0] = 1;
 
-        licensingModule.registerDerivative(ipAcct[2], parentIpIds, licenseTermsIds, address(pilTemplate), "");
+        licensingModule.registerDerivative(ipAcct[2], parentIpIds, licenseTermsIds, address(pilTemplate), "", 0);
 
         assertEq(licenseRegistry.hasIpAttachedLicenseTerms(ipAcct[2], address(pilTemplate), 1), true);
         assertEq(licenseRegistry.getAttachedLicenseTermsCount(ipAcct[2]), 2);
@@ -145,7 +145,8 @@ contract LicensingIntegrationTest is BaseIntegration {
             1,
             1,
             address(u.carl),
-            ""
+            "",
+            0
         );
         assertEq(licenseToken.ownerOf(lcTokenId), u.carl);
         assertEq(licenseToken.getLicenseTermsId(lcTokenId), 1);
@@ -182,7 +183,7 @@ contract LicensingIntegrationTest is BaseIntegration {
         erc20.mint(u.dan, 1000);
         erc20.approve(address(royaltyModule), 100);
 
-        lcTokenId = licensingModule.mintLicenseTokens(ipAcct[1], address(pilTemplate), 2, 1, address(u.dan), "");
+        lcTokenId = licensingModule.mintLicenseTokens(ipAcct[1], address(pilTemplate), 2, 1, address(u.dan), "", 0);
 
         assertEq(licenseToken.ownerOf(lcTokenId), u.dan);
         assertEq(licenseToken.getLicenseTermsId(lcTokenId), 2);
@@ -225,7 +226,7 @@ contract LicensingIntegrationTest is BaseIntegration {
         parentIpIds[0] = ipAcct[1];
         licenseTermsIds[0] = 2;
 
-        licensingModule.registerDerivative(ipAcct[7], parentIpIds, licenseTermsIds, address(pilTemplate), "");
+        licensingModule.registerDerivative(ipAcct[7], parentIpIds, licenseTermsIds, address(pilTemplate), "", 0);
 
         assertEq(licenseRegistry.hasIpAttachedLicenseTerms(ipAcct[7], address(pilTemplate), 2), true);
         assertEq(licenseRegistry.getAttachedLicenseTermsCount(ipAcct[7]), 2);
@@ -272,7 +273,8 @@ contract LicensingIntegrationTest is BaseIntegration {
             parentIpIds: parentIpIds,
             licenseTermsIds: licenseTermsIds,
             licenseTemplate: address(anotherPILTemplate),
-            royaltyContext: ""
+            royaltyContext: "",
+            maxMintingFee: 0
         });
     }
 
@@ -318,7 +320,8 @@ contract LicensingIntegrationTest is BaseIntegration {
             parentIpIds: parentIpIds,
             licenseTermsIds: licenseTermsIds,
             licenseTemplate: address(pilTemplate),
-            royaltyContext: ""
+            royaltyContext: "",
+            maxMintingFee: 0
         });
     }
 }

--- a/test/foundry/integration/flows/licensing/LicensingScenarios.t.sol
+++ b/test/foundry/integration/flows/licensing/LicensingScenarios.t.sol
@@ -138,7 +138,8 @@ contract Licensing_Scenarios is BaseIntegration {
             licenseTermsId: ncSocialRemixTermsId,
             amount: 1,
             receiver: u.bob,
-            royaltyContext: ""
+            royaltyContext: "",
+            maxMintingFee: 0
         });
         licensingModule.registerDerivativeWithLicenseTokens(ipAcct[2], licenseIds, "");
 
@@ -150,7 +151,8 @@ contract Licensing_Scenarios is BaseIntegration {
             licenseTermsId: commTermsId,
             amount: 1,
             receiver: u.bob,
-            royaltyContext: ""
+            royaltyContext: "",
+            maxMintingFee: 0
         });
         licensingModule.registerDerivativeWithLicenseTokens(ipAcct[3], licenseIds, "");
 
@@ -162,7 +164,8 @@ contract Licensing_Scenarios is BaseIntegration {
             licenseTermsId: commRemixTermsId,
             amount: 1,
             receiver: u.bob,
-            royaltyContext: ""
+            royaltyContext: "",
+            maxMintingFee: 0
         });
         licensingModule.registerDerivativeWithLicenseTokens(ipAcct[4], licenseIds, "");
 

--- a/test/foundry/integration/flows/royalty/Royalty.t.sol
+++ b/test/foundry/integration/flows/royalty/Royalty.t.sol
@@ -80,7 +80,8 @@ contract Flows_Integration_Disputes is BaseIntegration {
                 licenseTermsId: commRemixTermsId,
                 amount: mintAmount,
                 receiver: u.bob,
-                royaltyContext: ""
+                royaltyContext: "",
+                maxMintingFee: 0
             }); // first license minted
             licenseIds[1] = licenseIds[0] + 1; // second license minted
             licenseIds[2] = licenseIds[0] + 2; // third license minted
@@ -131,7 +132,8 @@ contract Flows_Integration_Disputes is BaseIntegration {
                 licenseTermsId: commRemixTermsId,
                 amount: mintAmount,
                 receiver: u.carl,
-                royaltyContext: ""
+                royaltyContext: "",
+                maxMintingFee: 0
             });
 
             vm.expectEmit(address(royaltyModule));
@@ -148,7 +150,8 @@ contract Flows_Integration_Disputes is BaseIntegration {
                 licenseTermsId: commRemixTermsId,
                 amount: mintAmount,
                 receiver: u.carl,
-                royaltyContext: ""
+                royaltyContext: "",
+                maxMintingFee: 0
             });
 
             ipAcct[3] = registerIpAccount(address(mockNFT), 3, u.carl);
@@ -247,7 +250,8 @@ contract Flows_Integration_Disputes is BaseIntegration {
                 licenseTermsId: commRemixExternalTermsId,
                 amount: 1,
                 receiver: u.alice,
-                royaltyContext: ""
+                royaltyContext: "",
+                maxMintingFee: 0
             });
 
             mockNFT.mintId(u.alice, 5);

--- a/test/foundry/invariants/DisputeModule.t.sol
+++ b/test/foundry/invariants/DisputeModule.t.sol
@@ -180,7 +180,8 @@ contract DisputeInvariants is BaseTest {
             parentIpIds: parentIpIds,
             licenseTermsIds: licenseTermsIds,
             licenseTemplate: address(pilTemplate),
-            royaltyContext: ""
+            royaltyContext: "",
+            maxMintingFee: 0
         });
 
         /*         targetContract(address(harness));

--- a/test/foundry/invariants/LicensingModule.t.sol
+++ b/test/foundry/invariants/LicensingModule.t.sol
@@ -75,7 +75,8 @@ contract LicensingModuleHarness is Test {
             licenseTermsId,
             amount,
             receiver,
-            royaltyContext
+            royaltyContext,
+            0
         );
 
         mintedOrRegisterDerivative = true;
@@ -102,7 +103,7 @@ contract LicensingModuleHarness is Test {
             require(parentIpIdsNth[i] < availableIpIds.length, "LicensingModuleHarness: invalid parentIpIdsNth");
             parentIpIds[i] = availableIpIds[parentIpIdsNth[i]];
         }
-        licensingModule.registerDerivative(childIpId, parentIpIds, licenseTermsIds, licenseTemplate, royaltyContext);
+        licensingModule.registerDerivative(childIpId, parentIpIds, licenseTermsIds, licenseTemplate, royaltyContext, 0);
 
         mintedOrRegisterDerivative = true;
     }

--- a/test/foundry/modules/dispute/DisputeModule.t.sol
+++ b/test/foundry/modules/dispute/DisputeModule.t.sol
@@ -97,7 +97,8 @@ contract DisputeModuleTest is BaseTest {
             licenseTermsId: getSelectedPILicenseTermsId("cheap_flexible"),
             amount: mintAmount,
             receiver: u.bob,
-            royaltyContext: ""
+            royaltyContext: "",
+            maxMintingFee: 0
         }); // first license minted
 
         ipAddr2 = ipAssetRegistry.register(block.chainid, address(mockNFT), 1);

--- a/test/foundry/modules/grouping/EvenSplitGroupPool.t.sol
+++ b/test/foundry/modules/grouping/EvenSplitGroupPool.t.sol
@@ -169,7 +169,7 @@ contract EvenSplitGroupPoolTest is BaseTest {
 
         vm.prank(ipOwner1);
         licensingModule.attachLicenseTerms(ipId1, address(pilTemplate), commRemixTermsId);
-        licensingModule.mintLicenseTokens(ipId1, address(pilTemplate), commRemixTermsId, 1, address(this), "");
+        licensingModule.mintLicenseTokens(ipId1, address(pilTemplate), commRemixTermsId, 1, address(this), "", 0);
 
         vm.prank(address(groupingModule));
         rewardPool.addIp(group1, ipId1);

--- a/test/foundry/modules/grouping/GroupingModule.t.sol
+++ b/test/foundry/modules/grouping/GroupingModule.t.sol
@@ -167,10 +167,10 @@ contract GroupingModuleTest is BaseTest {
 
         vm.prank(ipOwner1);
         licensingModule.attachLicenseTerms(ipId1, address(pilTemplate), termsId);
-        licensingModule.mintLicenseTokens(ipId1, address(pilTemplate), termsId, 1, address(this), "");
+        licensingModule.mintLicenseTokens(ipId1, address(pilTemplate), termsId, 1, address(this), "", 0);
         vm.prank(ipOwner2);
         licensingModule.attachLicenseTerms(ipId2, address(pilTemplate), termsId);
-        licensingModule.mintLicenseTokens(ipId2, address(pilTemplate), termsId, 1, address(this), "");
+        licensingModule.mintLicenseTokens(ipId2, address(pilTemplate), termsId, 1, address(this), "", 0);
 
         vm.startPrank(alice);
         licensingModule.attachLicenseTerms(groupId, address(pilTemplate), termsId);
@@ -187,7 +187,7 @@ contract GroupingModuleTest is BaseTest {
         uint256[] memory licenseTermsIds = new uint256[](1);
         licenseTermsIds[0] = termsId;
         vm.prank(ipOwner3);
-        licensingModule.registerDerivative(ipId3, parentIpIds, licenseTermsIds, address(pilTemplate), "");
+        licensingModule.registerDerivative(ipId3, parentIpIds, licenseTermsIds, address(pilTemplate), "", 0);
 
         erc20.mint(ipOwner3, 1000);
         vm.startPrank(ipOwner3);
@@ -280,7 +280,7 @@ contract GroupingModuleTest is BaseTest {
         parentIpIds[0] = groupId;
         licenseTermsIds[0] = termsId;
 
-        licensingModule.registerDerivative(ipId3, parentIpIds, licenseTermsIds, address(pilTemplate), "");
+        licensingModule.registerDerivative(ipId3, parentIpIds, licenseTermsIds, address(pilTemplate), "", 0);
         vm.stopPrank();
 
         address[] memory ipIds = new address[](2);
@@ -333,7 +333,7 @@ contract GroupingModuleTest is BaseTest {
         parentIpIds[0] = groupId;
         licenseTermsIds[0] = termsId;
 
-        licensingModule.registerDerivative(ipId3, parentIpIds, licenseTermsIds, address(pilTemplate), "");
+        licensingModule.registerDerivative(ipId3, parentIpIds, licenseTermsIds, address(pilTemplate), "", 0);
         vm.stopPrank();
 
         address[] memory removeIpIds = new address[](1);

--- a/test/foundry/modules/licensing/PILicenseTemplate.t.sol
+++ b/test/foundry/modules/licensing/PILicenseTemplate.t.sol
@@ -334,7 +334,7 @@ contract PILicenseTemplateTest is BaseTest {
         uint256[] memory licenseTermsIds = new uint256[](1);
         licenseTermsIds[0] = commUseTermsId;
         vm.prank(ipOwner[2]);
-        licensingModule.registerDerivative(ipAcct[2], parentIpIds, licenseTermsIds, address(pilTemplate), "");
+        licensingModule.registerDerivative(ipAcct[2], parentIpIds, licenseTermsIds, address(pilTemplate), "", 0);
 
         uint256 anotherTermsId = pilTemplate.registerLicenseTerms(
             PILFlavors.commercialRemix({
@@ -365,7 +365,7 @@ contract PILicenseTemplateTest is BaseTest {
         uint256[] memory licenseTermsIds = new uint256[](1);
         licenseTermsIds[0] = commUseTermsId;
         vm.prank(ipOwner[2]);
-        licensingModule.registerDerivative(ipAcct[2], parentIpIds, licenseTermsIds, address(pilTemplate), "");
+        licensingModule.registerDerivative(ipAcct[2], parentIpIds, licenseTermsIds, address(pilTemplate), "", 0);
 
         bool result = pilTemplate.verifyMintLicenseToken(commUseTermsId, ipOwner[3], ipAcct[2], 1);
         assertFalse(result);
@@ -412,7 +412,7 @@ contract PILicenseTemplateTest is BaseTest {
         uint256[] memory licenseTermsIds = new uint256[](1);
         licenseTermsIds[0] = socialRemixTermsId;
         vm.prank(ipOwner[2]);
-        licensingModule.registerDerivative(ipAcct[2], parentIpIds, licenseTermsIds, address(pilTemplate), "");
+        licensingModule.registerDerivative(ipAcct[2], parentIpIds, licenseTermsIds, address(pilTemplate), "", 0);
 
         // checking register derivative of derivative, expect false
         bool result = pilTemplate.verifyRegisterDerivative(ipAcct[3], ipAcct[2], socialRemixTermsId, ipOwner[3]);

--- a/test/foundry/registries/LicenseRegistry.t.sol
+++ b/test/foundry/registries/LicenseRegistry.t.sol
@@ -175,7 +175,7 @@ contract LicenseRegistryTest is BaseTest {
         uint256[] memory licenseTermsIds = new uint256[](1);
         licenseTermsIds[0] = socialRemixTermsId;
         vm.prank(ipOwner[2]);
-        licensingModule.registerDerivative(ipAcct[2], parentIpIds, licenseTermsIds, address(pilTemplate), "");
+        licensingModule.registerDerivative(ipAcct[2], parentIpIds, licenseTermsIds, address(pilTemplate), "", 0);
 
         uint256 defaultTermsId = pilTemplate.registerLicenseTerms(PILFlavors.defaultValuesLicenseTerms());
         vm.expectRevert(Errors.LicensingModule__DerivativesCannotAddLicenseTerms.selector);
@@ -212,7 +212,7 @@ contract LicenseRegistryTest is BaseTest {
         uint256[] memory licenseTermsIds = new uint256[](1);
         licenseTermsIds[0] = socialRemixTermsId;
         vm.prank(ipOwner[2]);
-        licensingModule.registerDerivative(ipAcct[2], parentIpIds, licenseTermsIds, address(pilTemplate), "");
+        licensingModule.registerDerivative(ipAcct[2], parentIpIds, licenseTermsIds, address(pilTemplate), "", 0);
 
         vm.expectRevert(abi.encodeWithSelector(Errors.LicenseRegistry__IndexOutOfBounds.selector, ipAcct[1], 1, 1));
         licenseRegistry.getDerivativeIp(ipAcct[1], 1);
@@ -228,7 +228,7 @@ contract LicenseRegistryTest is BaseTest {
         uint256[] memory licenseTermsIds = new uint256[](1);
         licenseTermsIds[0] = socialRemixTermsId;
         vm.prank(ipOwner[2]);
-        licensingModule.registerDerivative(ipAcct[2], parentIpIds, licenseTermsIds, address(pilTemplate), "");
+        licensingModule.registerDerivative(ipAcct[2], parentIpIds, licenseTermsIds, address(pilTemplate), "", 0);
 
         vm.expectRevert(abi.encodeWithSelector(Errors.LicenseRegistry__IndexOutOfBounds.selector, ipAcct[2], 1, 1));
         licenseRegistry.getParentIp(ipAcct[2], 1);


### PR DESCRIPTION
## Description

This PR introduces a `maxMintingFee` parameter for minting license tokens and registering derivatives. This allows the caller to set the maximum minting fee they are willing to pay, providing better control over the costs associated with these operations.

## Key Changes

- **Max Minting Fee Parameter**: Added a `maxMintingFee` parameter to the functions for minting license tokens and registering derivatives.
- **Fee Validation**: Implemented logic to validate that the minting fee does not exceed the specified `maxMintingFee`.

## Objectives

- **Cost Control**: Allow callers to set a maximum minting fee they are willing to pay.
- **Fee Validation**: Ensure that the minting fee does not exceed the specified maximum.

## Implementation Steps

1. **Add Max Minting Fee Parameter**: Update the functions for minting license tokens and registering derivatives to include a `maxMintingFee` parameter.
2. **Implement Fee Validation**: Add logic to validate that the minting fee does not exceed the specified `maxMintingFee`.
3. **Testing**: Update and add tests to verify the correct functionality of the new parameter and validation logic.

