### PR TITLE
Add Missing Pausable Config in Deployment Script

### DIFF
--- a/script/foundry/utils/DeployHelper.sol
+++ b/script/foundry/utils/DeployHelper.sol
@@ -704,6 +704,7 @@ contract DeployHelper is Script, BroadcastManager, JsonDeploymentHandler, Storag
         protocolPauser.addPausable(address(royaltyPolicyLRP));
         protocolPauser.addPausable(address(ipAssetRegistry));
         protocolPauser.addPausable(address(groupingModule));
+        protocolPauser.addPausable(address(evenSplitGroupPool));
 
         // Module Registry
         moduleRegistry.registerModule(DISPUTE_MODULE_KEY, address(disputeModule));


### PR DESCRIPTION
Add `EvenSplitGroupPool` to `ProtocolPauser` in deployment script to allow `EvenSplitGroupPool` to be paused by `ProtocolPauseAdmin`