### PR TITLE
fix(royalty-policy): make `transferToVault` pausable

### DIFF
--- a/contracts/modules/royalty/policies/LAP/RoyaltyPolicyLAP.sol
+++ b/contracts/modules/royalty/policies/LAP/RoyaltyPolicyLAP.sol
@@ -125,7 +125,7 @@ contract RoyaltyPolicyLAP is
     /// @param ancestorIpId The ancestor ipId of the IP asset
     /// @param token The token address to transfer
     /// @param amount The amount of tokens to transfer
-    function transferToVault(address ipId, address ancestorIpId, address token, uint256 amount) external {
+    function transferToVault(address ipId, address ancestorIpId, address token, uint256 amount) external whenNotPaused {
         RoyaltyPolicyLAPStorage storage $ = _getRoyaltyPolicyLAPStorage();
 
         if (amount == 0) revert Errors.RoyaltyPolicyLAP__ZeroAmount();

--- a/contracts/modules/royalty/policies/LRP/RoyaltyPolicyLRP.sol
+++ b/contracts/modules/royalty/policies/LRP/RoyaltyPolicyLRP.sol
@@ -146,7 +146,7 @@ contract RoyaltyPolicyLRP is
     /// @param ancestorIpId The ancestor ipId of the IP asset
     /// @param token The token address to transfer
     /// @param amount The amount of tokens to transfer
-    function transferToVault(address ipId, address ancestorIpId, address token, uint256 amount) external {
+    function transferToVault(address ipId, address ancestorIpId, address token, uint256 amount) external whenNotPaused {
         RoyaltyPolicyLRPStorage storage $ = _getRoyaltyPolicyLRPStorage();
 
         if (amount == 0) revert Errors.RoyaltyPolicyLRP__ZeroAmount();


### PR DESCRIPTION
This PR makes the `transferToVault` functions in `RoyaltyPolicyLAP` and `RoyaltyPolicyLRP` pausable.