### PR TITLE
Add set arbitration policy cooldown

### DIFF
--- a/contracts/interfaces/modules/dispute/IDisputeModule.sol
+++ b/contracts/interfaces/modules/dispute/IDisputeModule.sol
@@ -41,10 +41,15 @@ interface IDisputeModule {
     /// @param arbitrationPolicy The address of the arbitration policy
     event DefaultArbitrationPolicyUpdated(address arbitrationPolicy);
 
+    /// @notice Event emitted when the arbitration policy cooldown is updated
+    /// @param cooldown The cooldown in seconds
+    event ArbitrationPolicyCooldownUpdated(uint256 cooldown);
+
     /// @notice Event emitted when an arbitration policy is set for an ipId
     /// @param ipId The ipId address
     /// @param arbitrationPolicy The address of the arbitration policy
-    event ArbitrationPolicySet(address ipId, address arbitrationPolicy);
+    /// @param nextArbitrationUpdateTimestamp The timestamp of the next arbitration update
+    event ArbitrationPolicySet(address ipId, address arbitrationPolicy, uint256 nextArbitrationUpdateTimestamp);
 
     /// @notice Event emitted when a dispute is raised
     /// @param disputeId The dispute id
@@ -165,6 +170,10 @@ interface IDisputeModule {
     /// @param arbitrationPolicy The address of the arbitration policy
     function setBaseArbitrationPolicy(address arbitrationPolicy) external;
 
+    /// @notice Sets the arbitration policy cooldown
+    /// @param cooldown The cooldown in seconds
+    function setArbitrationPolicyCooldown(uint256 cooldown) external;
+
     /// @notice Sets the arbitration policy for an ipId
     /// @param ipId The ipId
     /// @param arbitrationPolicy The address of the arbitration policy
@@ -208,6 +217,11 @@ interface IDisputeModule {
     /// @param disputeId The dispute
     /// @param data The data to resolve the dispute
     function resolveDispute(uint256 disputeId, bytes calldata data) external;
+
+    /// @notice Updates the active arbitration policy for a given ipId
+    /// @param ipId The ipId
+    /// @return arbitrationPolicy The address of the arbitration policy
+    function updateActiveArbitrationPolicy(address ipId) external returns (address arbitrationPolicy);
 
     /// @notice Returns true if the ipId is tagged with any tag (meaning at least one dispute went through)
     /// @param ipId The ipId

--- a/contracts/lib/Errors.sol
+++ b/contracts/lib/Errors.sol
@@ -432,6 +432,9 @@ library Errors {
     /// @notice Provided parent dispute has not been resolved.
     error DisputeModule__ParentDisputeNotResolved();
 
+    /// @notice Zero arbitration policy cooldown provided.
+    error DisputeModule__ZeroArbitrationPolicyCooldown();
+
     ////////////////////////////////////////////////////////////////////////////
     //                            Royalty Module                              //
     ////////////////////////////////////////////////////////////////////////////

--- a/contracts/modules/dispute/DisputeModule.sol
+++ b/contracts/modules/dispute/DisputeModule.sol
@@ -32,6 +32,7 @@ contract DisputeModule is
 
     /// @dev Storage for DisputeModule
     /// @param disputeCounter The dispute ID counter
+    /// @param arbitrationPolicyCooldown The cooldown for updating the arbitration policy
     /// @param baseArbitrationPolicy The address of the base arbitration policy
     /// @param disputes Returns the dispute information for a given dispute id
     /// @param isWhitelistedDisputeTag Indicates if a dispute tag is whitelisted
@@ -39,16 +40,21 @@ contract DisputeModule is
     /// @param isWhitelistedArbitrationRelayer Indicates if an arbitration relayer
     /// is whitelisted for a given arbitration policy
     /// @param arbitrationPolicies Arbitration policy for a given ipId
+    /// @param nextArbitrationPolicies Next arbitration policy for a given ipId
+    /// @param arbitrationUpdateTimestamps Timestamp of when the arbitration policy will be updated for a given ipId
     /// @param successfulDisputesPerIp Counter of successful disputes per ipId
     /// @custom:storage-location erc7201:story-protocol.DisputeModule
     struct DisputeModuleStorage {
         uint256 disputeCounter;
+        uint256 arbitrationPolicyCooldown;
         address baseArbitrationPolicy;
         mapping(uint256 => Dispute) disputes;
         mapping(bytes32 => bool) isWhitelistedDisputeTag;
         mapping(address => bool) isWhitelistedArbitrationPolicy;
         mapping(address => mapping(address => bool)) isWhitelistedArbitrationRelayer;
         mapping(address => address) arbitrationPolicies;
+        mapping(address => address) nextArbitrationPolicies;
+        mapping(address => uint256) nextArbitrationUpdateTimestamps;
         mapping(address => uint256) successfulDisputesPerIp;
     }
 
@@ -155,17 +161,30 @@ contract DisputeModule is
         emit DefaultArbitrationPolicyUpdated(arbitrationPolicy);
     }
 
+    /// @notice Sets the arbitration policy cooldown
+    /// @param cooldown The cooldown in seconds
+    function setArbitrationPolicyCooldown(uint256 cooldown) external restricted {
+        if (cooldown == 0) revert Errors.DisputeModule__ZeroArbitrationPolicyCooldown();
+        DisputeModuleStorage storage $ = _getDisputeModuleStorage();
+        $.arbitrationPolicyCooldown = cooldown;
+
+        emit ArbitrationPolicyCooldownUpdated(cooldown);
+    }
+
     /// @notice Sets the arbitration policy for an ipId
     /// @param ipId The ipId
-    /// @param arbitrationPolicy The address of the arbitration policy
-    function setArbitrationPolicy(address ipId, address arbitrationPolicy) external verifyPermission(ipId) {
+    /// @param nextArbitrationPolicy The address of the arbitration policy
+    function setArbitrationPolicy(address ipId, address nextArbitrationPolicy) external verifyPermission(ipId) {
         DisputeModuleStorage storage $ = _getDisputeModuleStorage();
-        if (!$.isWhitelistedArbitrationPolicy[arbitrationPolicy])
+        if (!$.isWhitelistedArbitrationPolicy[nextArbitrationPolicy])
             revert Errors.DisputeModule__NotWhitelistedArbitrationPolicy();
 
-        $.arbitrationPolicies[ipId] = arbitrationPolicy;
+        $.nextArbitrationPolicies[ipId] = nextArbitrationPolicy;
 
-        emit ArbitrationPolicySet(ipId, arbitrationPolicy);
+        uint256 nextArbitrationUpdateTimestamp = block.timestamp + $.arbitrationPolicyCooldown;
+        $.nextArbitrationUpdateTimestamps[ipId] = nextArbitrationUpdateTimestamp;
+
+        emit ArbitrationPolicySet(ipId, nextArbitrationPolicy, nextArbitrationUpdateTimestamp);
     }
 
     /// @notice Raises a dispute on a given ipId
@@ -185,9 +204,7 @@ contract DisputeModule is
         if (!$.isWhitelistedDisputeTag[targetTag]) revert Errors.DisputeModule__NotWhitelistedDisputeTag();
         if (disputeEvidenceHash == bytes32(0)) revert Errors.DisputeModule__ZeroDisputeEvidenceHash();
 
-        address arbitrationPolicy = $.arbitrationPolicies[targetIpId];
-        if (!$.isWhitelistedArbitrationPolicy[arbitrationPolicy]) arbitrationPolicy = $.baseArbitrationPolicy;
-
+        address arbitrationPolicy = _updateActiveArbitrationPolicy(targetIpId);
         uint256 disputeId = ++$.disputeCounter;
 
         $.disputes[disputeId] = Dispute({
@@ -327,6 +344,13 @@ contract DisputeModule is
         emit DisputeResolved(disputeId);
     }
 
+    /// @notice Updates the active arbitration policy for a given ipId
+    /// @param ipId The ipId
+    /// @return arbitrationPolicy The address of the arbitration policy
+    function updateActiveArbitrationPolicy(address ipId) external returns (address arbitrationPolicy) {
+        return _updateActiveArbitrationPolicy(ipId);
+    }
+
     /// @notice Returns true if the ipId is tagged with any tag (meaning at least one dispute went through)
     /// @param ipId The ipId
     /// @return isTagged True if the ipId is tagged
@@ -339,6 +363,12 @@ contract DisputeModule is
     function disputeCounter() external view returns (uint256) {
         DisputeModuleStorage storage $ = _getDisputeModuleStorage();
         return $.disputeCounter;
+    }
+
+    /// @notice Returns the arbitration policy cooldown
+    function arbitrationPolicyCooldown() external view returns (uint256) {
+        DisputeModuleStorage storage $ = _getDisputeModuleStorage();
+        return $.arbitrationPolicyCooldown;
     }
 
     /// @notice The address of the base arbitration policy
@@ -385,7 +415,6 @@ contract DisputeModule is
 
     /// @notice Indicates if a dispute tag is whitelisted
     /// @param tag The dispute tag
-    /// @return allowed Indicates if the dispute tag is whitelisted
     function isWhitelistedDisputeTag(bytes32 tag) external view returns (bool allowed) {
         DisputeModuleStorage storage $ = _getDisputeModuleStorage();
         return $.isWhitelistedDisputeTag[tag];
@@ -393,7 +422,6 @@ contract DisputeModule is
 
     /// @notice Indicates if an arbitration policy is whitelisted
     /// @param arbitrationPolicy The address of the arbitration policy
-    /// @return allowed Indicates if the arbitration policy is whitelisted
     function isWhitelistedArbitrationPolicy(address arbitrationPolicy) external view returns (bool allowed) {
         DisputeModuleStorage storage $ = _getDisputeModuleStorage();
         return $.isWhitelistedArbitrationPolicy[arbitrationPolicy];
@@ -402,7 +430,6 @@ contract DisputeModule is
     /// @notice Indicates if an arbitration relayer is whitelisted for a given arbitration policy
     /// @param arbitrationPolicy The address of the arbitration policy
     /// @param arbitrationRelayer The address of the arbitration relayer
-    /// @return allowed Indicates if the arbitration relayer is whitelisted
     function isWhitelistedArbitrationRelayer(
         address arbitrationPolicy,
         address arbitrationRelayer
@@ -411,12 +438,51 @@ contract DisputeModule is
         return $.isWhitelistedArbitrationRelayer[arbitrationPolicy][arbitrationRelayer];
     }
 
-    /// @notice Arbitration policy for a given ipId
+    /// @notice Returns the arbitration policy for a given ipId
     /// @param ipId The ipId
-    /// @return policy The address of the arbitration policy
     function arbitrationPolicies(address ipId) external view returns (address policy) {
         DisputeModuleStorage storage $ = _getDisputeModuleStorage();
         return $.arbitrationPolicies[ipId];
+    }
+
+    /// @notice Returns the next arbitration policy for a given ipId
+    /// @param ipId The ipId
+    function nextArbitrationPolicies(address ipId) external view returns (address policy) {
+        DisputeModuleStorage storage $ = _getDisputeModuleStorage();
+        return $.nextArbitrationPolicies[ipId];
+    }
+
+    /// @notice Returns the next arbitration update timestamp for a given ipId
+    /// @param ipId The ipId
+    function nextArbitrationUpdateTimestamps(address ipId) external view returns (uint256 timestamp) {
+        DisputeModuleStorage storage $ = _getDisputeModuleStorage();
+        return $.nextArbitrationUpdateTimestamps[ipId];
+    }
+
+    /// @notice Updates the active arbitration policy for a given ipId
+    /// @param ipId The ipId
+    /// @return arbitrationPolicy The address of the arbitration policy
+    function _updateActiveArbitrationPolicy(address ipId) internal returns (address arbitrationPolicy) {
+        DisputeModuleStorage storage $ = _getDisputeModuleStorage();
+
+        // in normal conditions the active arbitration policy is in arbitrationPolicies
+        arbitrationPolicy = $.arbitrationPolicies[ipId];
+
+        // if the next arbitration policy is set and the cooldown has passed
+        // then the active arbitration policy is updated
+        uint256 nextArbitrationUpdateTimestamp = $.nextArbitrationUpdateTimestamps[ipId];
+        if (nextArbitrationUpdateTimestamp > 0 && nextArbitrationUpdateTimestamp < block.timestamp) {
+            address nextArbitrationPolicy = $.nextArbitrationPolicies[ipId];
+            $.arbitrationPolicies[ipId] = nextArbitrationPolicy;
+            arbitrationPolicy = nextArbitrationPolicy;
+
+            delete $.nextArbitrationUpdateTimestamps[ipId];
+            delete $.nextArbitrationPolicies[ipId];
+        }
+
+        // if the resulting arbitration policy is not whitelisted or has been blacklisted
+        // then the active arbitration policy is the base arbitration policy
+        if (!$.isWhitelistedArbitrationPolicy[arbitrationPolicy]) arbitrationPolicy = $.baseArbitrationPolicy;
     }
 
     /// @dev Hook to authorize the upgrade according to UUPSUpgradeable

--- a/contracts/modules/dispute/DisputeModule.sol
+++ b/contracts/modules/dispute/DisputeModule.sol
@@ -416,15 +416,13 @@ contract DisputeModule is
     /// @notice Indicates if a dispute tag is whitelisted
     /// @param tag The dispute tag
     function isWhitelistedDisputeTag(bytes32 tag) external view returns (bool allowed) {
-        DisputeModuleStorage storage $ = _getDisputeModuleStorage();
-        return $.isWhitelistedDisputeTag[tag];
+        return _getDisputeModuleStorage().isWhitelistedDisputeTag[tag];
     }
 
     /// @notice Indicates if an arbitration policy is whitelisted
     /// @param arbitrationPolicy The address of the arbitration policy
     function isWhitelistedArbitrationPolicy(address arbitrationPolicy) external view returns (bool allowed) {
-        DisputeModuleStorage storage $ = _getDisputeModuleStorage();
-        return $.isWhitelistedArbitrationPolicy[arbitrationPolicy];
+        return _getDisputeModuleStorage().isWhitelistedArbitrationPolicy[arbitrationPolicy];
     }
 
     /// @notice Indicates if an arbitration relayer is whitelisted for a given arbitration policy
@@ -434,29 +432,25 @@ contract DisputeModule is
         address arbitrationPolicy,
         address arbitrationRelayer
     ) external view returns (bool allowed) {
-        DisputeModuleStorage storage $ = _getDisputeModuleStorage();
-        return $.isWhitelistedArbitrationRelayer[arbitrationPolicy][arbitrationRelayer];
+        return _getDisputeModuleStorage().isWhitelistedArbitrationRelayer[arbitrationPolicy][arbitrationRelayer];
     }
 
     /// @notice Returns the arbitration policy for a given ipId
     /// @param ipId The ipId
     function arbitrationPolicies(address ipId) external view returns (address policy) {
-        DisputeModuleStorage storage $ = _getDisputeModuleStorage();
-        return $.arbitrationPolicies[ipId];
+        return _getDisputeModuleStorage().arbitrationPolicies[ipId];
     }
 
     /// @notice Returns the next arbitration policy for a given ipId
     /// @param ipId The ipId
     function nextArbitrationPolicies(address ipId) external view returns (address policy) {
-        DisputeModuleStorage storage $ = _getDisputeModuleStorage();
-        return $.nextArbitrationPolicies[ipId];
+        return _getDisputeModuleStorage().nextArbitrationPolicies[ipId];
     }
 
     /// @notice Returns the next arbitration update timestamp for a given ipId
     /// @param ipId The ipId
     function nextArbitrationUpdateTimestamps(address ipId) external view returns (uint256 timestamp) {
-        DisputeModuleStorage storage $ = _getDisputeModuleStorage();
-        return $.nextArbitrationUpdateTimestamps[ipId];
+        return _getDisputeModuleStorage().nextArbitrationUpdateTimestamps[ipId];
     }
 
     /// @notice Updates the active arbitration policy for a given ipId

--- a/contracts/modules/dispute/DisputeModule.sol
+++ b/contracts/modules/dispute/DisputeModule.sol
@@ -355,26 +355,22 @@ contract DisputeModule is
     /// @param ipId The ipId
     /// @return isTagged True if the ipId is tagged
     function isIpTagged(address ipId) external view returns (bool) {
-        DisputeModuleStorage storage $ = _getDisputeModuleStorage();
-        return $.successfulDisputesPerIp[ipId] > 0;
+        return _getDisputeModuleStorage().successfulDisputesPerIp[ipId] > 0;
     }
 
     /// @notice Dispute ID counter
     function disputeCounter() external view returns (uint256) {
-        DisputeModuleStorage storage $ = _getDisputeModuleStorage();
-        return $.disputeCounter;
+        return _getDisputeModuleStorage().disputeCounter;
     }
 
     /// @notice Returns the arbitration policy cooldown
     function arbitrationPolicyCooldown() external view returns (uint256) {
-        DisputeModuleStorage storage $ = _getDisputeModuleStorage();
-        return $.arbitrationPolicyCooldown;
+        return _getDisputeModuleStorage().arbitrationPolicyCooldown;
     }
 
     /// @notice The address of the base arbitration policy
     function baseArbitrationPolicy() external view returns (address) {
-        DisputeModuleStorage storage $ = _getDisputeModuleStorage();
-        return $.baseArbitrationPolicy;
+        return _getDisputeModuleStorage().baseArbitrationPolicy;
     }
 
     /// @notice Returns the dispute information for a given dispute id

--- a/script/foundry/utils/DeployHelper.sol
+++ b/script/foundry/utils/DeployHelper.sol
@@ -724,6 +724,7 @@ contract DeployHelper is Script, BroadcastManager, JsonDeploymentHandler, Storag
 
         // Dispute Module and SP Dispute Policy
         disputeModule.whitelistDisputeTag("PLAGIARISM", true);
+        disputeModule.setArbitrationPolicyCooldown(7 days);
 
         // Core Metadata Module
         coreMetadataViewModule.updateCoreMetadataModule();

--- a/test/foundry/modules/dispute/DisputeModule.t.sol
+++ b/test/foundry/modules/dispute/DisputeModule.t.sol
@@ -30,7 +30,6 @@ contract DisputeModuleTest is BaseTest {
     event DisputeCancelled(uint256 disputeId, bytes data);
     event DisputeResolved(uint256 disputeId);
     event DefaultArbitrationPolicyUpdated(address arbitrationPolicy);
-    event ArbitrationPolicySet(address ipId, address arbitrationPolicy);
 
     address internal ipAccount1 = address(0x111000aaa);
     address internal ipAccount2 = address(0x111000bbb);
@@ -54,7 +53,7 @@ contract DisputeModuleTest is BaseTest {
 
         vm.startPrank(u.admin);
         disputeModule.whitelistArbitrationPolicy(address(mockArbitrationPolicy2), true);
-        disputeModule.setBaseArbitrationPolicy(address(mockArbitrationPolicy2));
+        disputeModule.setBaseArbitrationPolicy(address(mockArbitrationPolicy));
         vm.stopPrank();
 
         registerSelectedPILicenseTerms_Commercial({
@@ -194,6 +193,21 @@ contract DisputeModuleTest is BaseTest {
         assertEq(disputeModule.baseArbitrationPolicy(), address(mockArbitrationPolicy2));
     }
 
+    function test_DisputeModule_setArbitrationPolicyCooldown_revert_ZeroCooldown() public {
+        vm.startPrank(u.admin);
+        vm.expectRevert(Errors.DisputeModule__ZeroArbitrationPolicyCooldown.selector);
+        disputeModule.setArbitrationPolicyCooldown(0);
+    }
+
+    function test_DisputeModule_setArbitrationPolicyCooldown() public {
+        vm.startPrank(u.admin);
+        vm.expectEmit(true, true, true, true, address(disputeModule));
+        emit IDisputeModule.ArbitrationPolicyCooldownUpdated(100);
+
+        disputeModule.setArbitrationPolicyCooldown(100);
+        assertEq(disputeModule.arbitrationPolicyCooldown(), 100);
+    }
+
     function test_DisputeModule_setArbitrationPolicy_revert_UnauthorizedAccess() public {
         vm.expectRevert(
             abi.encodeWithSelector(
@@ -225,10 +239,13 @@ contract DisputeModuleTest is BaseTest {
         vm.startPrank(ipAddr);
 
         vm.expectEmit(true, true, true, true, address(disputeModule));
-        emit ArbitrationPolicySet(ipAddr, address(mockArbitrationPolicy2));
+        emit IDisputeModule.ArbitrationPolicySet(ipAddr, address(mockArbitrationPolicy2), block.timestamp + 7 days);
 
         disputeModule.setArbitrationPolicy(ipAddr, address(mockArbitrationPolicy2));
-        assertEq(disputeModule.arbitrationPolicies(ipAddr), address(mockArbitrationPolicy2));
+
+        assertEq(disputeModule.arbitrationPolicies(ipAddr), address(0));
+        assertEq(disputeModule.nextArbitrationPolicies(ipAddr), address(mockArbitrationPolicy2));
+        assertEq(disputeModule.nextArbitrationUpdateTimestamps(ipAddr), block.timestamp + 7 days);
     }
 
     function test_DisputeModule_raiseDispute_revert_NotRegisteredIpId() public {
@@ -257,8 +274,9 @@ contract DisputeModuleTest is BaseTest {
         vm.stopPrank();
     }
 
-    function test_DisputeModule_PolicySP_raiseDispute_BlacklistedPolicy() public {
+    function test_DisputeModule_raiseDispute_BlacklistedPolicy() public {
         vm.startPrank(u.admin);
+        disputeModule.setBaseArbitrationPolicy(address(mockArbitrationPolicy2));
         disputeModule.whitelistArbitrationPolicy(address(mockArbitrationPolicy), false);
         vm.stopPrank();
 
@@ -430,7 +448,7 @@ contract DisputeModuleTest is BaseTest {
         assertFalse(disputeModule.isIpTagged(ipAddr));
     }
 
-    function test_DisputeModule_PolicySP_revert_paused() public {
+    function test_DisputeModule_revert_paused() public {
         vm.startPrank(ipAccount1);
         IERC20(USDC).approve(address(mockArbitrationPolicy), ARBITRATION_PRICE);
         disputeModule.raiseDispute(ipAddr, disputeEvidenceHashExample, "PLAGIARISM", "");
@@ -446,7 +464,7 @@ contract DisputeModuleTest is BaseTest {
         vm.stopPrank();
     }
 
-    function test_DisputeModule_PolicySP_cancelDispute_revert_NotDisputeInitiator() public {
+    function test_DisputeModule_cancelDispute_revert_NotDisputeInitiator() public {
         // raise dispute
         vm.startPrank(ipAccount1);
         IERC20(USDC).approve(address(mockArbitrationPolicy), ARBITRATION_PRICE);
@@ -639,6 +657,52 @@ contract DisputeModuleTest is BaseTest {
         vm.expectRevert(Errors.DisputeModule__NotAbleToResolve.selector);
         disputeModule.resolveDispute(1, "");
         vm.stopPrank();
+    }
+
+    function test_DisputeModule_updateActiveArbitrationPolicy_BaseArbitrationPolicyToStart() public {
+        address currentArbPolicy = disputeModule.updateActiveArbitrationPolicy(address(1));
+
+        assertEq(currentArbPolicy, address(mockArbitrationPolicy));
+        assertEq(disputeModule.arbitrationPolicies(address(1)), address(0));
+        assertEq(disputeModule.nextArbitrationPolicies(address(1)), address(0));
+        assertEq(disputeModule.nextArbitrationUpdateTimestamps(address(1)), 0);
+    }
+
+    function test_DisputeModule_updateActiveArbitrationPolicy_UpdateToNextArbitrationPolicy() public {        vm.startPrank(ipAddr);
+        disputeModule.setArbitrationPolicy(ipAddr, address(mockArbitrationPolicy2));
+
+        vm.warp(block.timestamp + disputeModule.arbitrationPolicyCooldown() + 1);
+
+        disputeModule.updateActiveArbitrationPolicy(ipAddr);
+
+        assertEq(disputeModule.arbitrationPolicies(ipAddr), address(mockArbitrationPolicy2));
+        assertEq(disputeModule.nextArbitrationPolicies(ipAddr), address(0));
+        assertEq(disputeModule.nextArbitrationUpdateTimestamps(ipAddr), 0);
+
+        disputeModule.updateActiveArbitrationPolicy(ipAddr);
+
+        assertEq(disputeModule.arbitrationPolicies(ipAddr), address(mockArbitrationPolicy2));
+        assertEq(disputeModule.nextArbitrationPolicies(ipAddr), address(0));
+        assertEq(disputeModule.nextArbitrationUpdateTimestamps(ipAddr), 0);
+    }
+
+    function test_DisputeModule_updateActiveArbitrationPolicy_UpdateToBlacklistedPolicy() public {
+        vm.startPrank(ipAddr);
+        disputeModule.setArbitrationPolicy(ipAddr, address(mockArbitrationPolicy2));
+        vm.stopPrank();
+
+        vm.startPrank(u.admin);
+        disputeModule.whitelistArbitrationPolicy(address(mockArbitrationPolicy2), false);
+        vm.stopPrank();
+
+        vm.warp(block.timestamp + disputeModule.arbitrationPolicyCooldown() + 1);
+        
+        address currentArbPolicy = disputeModule.updateActiveArbitrationPolicy(ipAddr);
+
+        assertEq(currentArbPolicy, disputeModule.baseArbitrationPolicy());
+        assertEq(disputeModule.arbitrationPolicies(ipAddr), address(mockArbitrationPolicy2));
+        assertEq(disputeModule.nextArbitrationPolicies(ipAddr), address(0));
+        assertEq(disputeModule.nextArbitrationUpdateTimestamps(ipAddr), 0);
     }
 
     function test_DisputeModule_name() public {

--- a/test/foundry/modules/dispute/DisputeModule.t.sol
+++ b/test/foundry/modules/dispute/DisputeModule.t.sol
@@ -668,7 +668,8 @@ contract DisputeModuleTest is BaseTest {
         assertEq(disputeModule.nextArbitrationUpdateTimestamps(address(1)), 0);
     }
 
-    function test_DisputeModule_updateActiveArbitrationPolicy_UpdateToNextArbitrationPolicy() public {        vm.startPrank(ipAddr);
+    function test_DisputeModule_updateActiveArbitrationPolicy_UpdateToNextArbitrationPolicy() public {
+        vm.startPrank(ipAddr);
         disputeModule.setArbitrationPolicy(ipAddr, address(mockArbitrationPolicy2));
 
         vm.warp(block.timestamp + disputeModule.arbitrationPolicyCooldown() + 1);
@@ -696,7 +697,7 @@ contract DisputeModuleTest is BaseTest {
         vm.stopPrank();
 
         vm.warp(block.timestamp + disputeModule.arbitrationPolicyCooldown() + 1);
-        
+
         address currentArbPolicy = disputeModule.updateActiveArbitrationPolicy(ipAddr);
 
         assertEq(currentArbPolicy, disputeModule.baseArbitrationPolicy());


### PR DESCRIPTION
## Description
This PR adds a cooldown when setting a new arbitration policy.

When a user sets a new arbitration policy the change will only become effective after the cooldown period has passed.

Before the cooldown period has passed the previous royalty policy will still be the one used if anyone were to raise a dispute against an IP Asset during the cooldown period.