### PR TITLE
Add new dispute tags to deployment script and unit tests

### DIFF
--- a/contracts/modules/dispute/DisputeModule.sol
+++ b/contracts/modules/dispute/DisputeModule.sol
@@ -296,8 +296,9 @@ contract DisputeModule is
         Dispute memory parentDispute = $.disputes[parentDisputeId];
         if (parentDispute.targetIpId != parentIpId) revert Errors.DisputeModule__ParentIpIdMismatch();
 
-        // a dispute current tag prior to being resolved can be in 3 states - IN_DISPUTE, 0, or a tag (ie. "PLAGIARISM)
-        // by restricting IN_DISPUTE and 0 - it is ensire the parent has been tagged before resolving dispute
+        // a dispute current tag prior to being resolved can be in 3 states:
+        // IN_DISPUTE, 0, or a tag (ie. "IMPROPER_REGISTRATION")
+        // by restricting IN_DISPUTE and 0 - it is ensured the parent has been tagged before resolving dispute
         if (parentDispute.currentTag == IN_DISPUTE || parentDispute.currentTag == bytes32(0))
             revert Errors.DisputeModule__ParentNotTagged();
 

--- a/script/foundry/utils/DeployHelper.sol
+++ b/script/foundry/utils/DeployHelper.sol
@@ -749,7 +749,10 @@ contract DeployHelper is Script, BroadcastManager, JsonDeploymentHandler, Storag
         ipRoyaltyVaultBeacon.transferOwnership(address(royaltyModule));
 
         // Dispute Module and Dispute Policy
-        disputeModule.whitelistDisputeTag("PLAGIARISM", true);
+        disputeModule.whitelistDisputeTag("IMPROPER_REGISTRATION", true);
+        disputeModule.whitelistDisputeTag("IMPROPER_USAGE", true);
+        disputeModule.whitelistDisputeTag("IMPROPER_PAYMENT", true);
+        disputeModule.whitelistDisputeTag("CONTENT_STANDARDS_VIOLATION", true);
         disputeModule.whitelistArbitrationPolicy(address(arbitrationPolicyUMA), true);
         disputeModule.whitelistArbitrationRelayer(address(arbitrationPolicyUMA), address(arbitrationPolicyUMA), true);
         disputeModule.setBaseArbitrationPolicy(address(arbitrationPolicyUMA));

--- a/test/foundry/invariants/DisputeModule.t.sol
+++ b/test/foundry/invariants/DisputeModule.t.sol
@@ -119,7 +119,7 @@ contract DisputeInvariants is BaseTest {
         tags[0] = "INAPPROPRIATE_CONTENT";
         tags[1] = "COPYRIGHT_INFRINGEMENT";
         tags[2] = "TRADEMARK_INFRINGEMENT";
-        tags[3] = "PLAGIARISM";
+        tags[3] = "IMPROPER_REGISTRATION";
         tags[4] = "RANDOM_TAG5";
         tags[5] = "RANDOM_TAG";
         tags[6] = "RANDOM_TAG1";

--- a/test/foundry/modules/dispute/DisputeModule.t.sol
+++ b/test/foundry/modules/dispute/DisputeModule.t.sol
@@ -568,7 +568,11 @@ contract DisputeModuleTest is BaseTest {
         vm.startPrank(address(1));
         vm.expectEmit(true, true, true, true, address(disputeModule));
         emit IDisputeModule.DerivativeTaggedOnParentInfringement(
-            ipAddr, ipAddr2, 1, "IMPROPER_REGISTRATION", block.timestamp
+            ipAddr,
+            ipAddr2,
+            1,
+            "IMPROPER_REGISTRATION",
+            block.timestamp
         );
 
         uint256 disputeIdBefore = disputeModule.disputeCounter();

--- a/test/foundry/modules/dispute/DisputeModule.t.sol
+++ b/test/foundry/modules/dispute/DisputeModule.t.sol
@@ -251,7 +251,7 @@ contract DisputeModuleTest is BaseTest {
 
     function test_DisputeModule_raiseDispute_revert_NotRegisteredIpId() public {
         vm.expectRevert(Errors.DisputeModule__NotRegisteredIpId.selector);
-        disputeModule.raiseDispute(address(1), disputeEvidenceHashExample, "PLAGIARISM", "");
+        disputeModule.raiseDispute(address(1), disputeEvidenceHashExample, "IMPROPER_REGISTRATION", "");
     }
 
     function test_DisputeModule_raiseDispute_revert_NotWhitelistedDisputeTag() public {
@@ -261,7 +261,7 @@ contract DisputeModuleTest is BaseTest {
 
     function test_DisputeModule_raiseDispute_revert_ZeroDisputeEvidenceHash() public {
         vm.expectRevert(Errors.DisputeModule__ZeroDisputeEvidenceHash.selector);
-        disputeModule.raiseDispute(ipAddr, bytes32(""), "PLAGIARISM", "");
+        disputeModule.raiseDispute(ipAddr, bytes32(""), "IMPROPER_REGISTRATION", "");
     }
 
     function test_DisputeModule_raiseDispute_revert_paused() public {
@@ -271,7 +271,7 @@ contract DisputeModuleTest is BaseTest {
         vm.startPrank(u.bob);
         IERC20(USDC).approve(address(mockArbitrationPolicy), ARBITRATION_PRICE);
         vm.expectRevert(abi.encodeWithSelector(PausableUpgradeable.EnforcedPause.selector));
-        disputeModule.raiseDispute(ipAddr, disputeEvidenceHashExample, "PLAGIARISM", "");
+        disputeModule.raiseDispute(ipAddr, disputeEvidenceHashExample, "IMPROPER_REGISTRATION", "");
         vm.stopPrank();
     }
 
@@ -296,11 +296,11 @@ contract DisputeModuleTest is BaseTest {
             block.timestamp,
             address(mockArbitrationPolicy2),
             disputeEvidenceHashExample,
-            bytes32("PLAGIARISM"),
+            bytes32("IMPROPER_REGISTRATION"),
             ""
         );
 
-        disputeModule.raiseDispute(ipAddr, disputeEvidenceHashExample, "PLAGIARISM", "");
+        disputeModule.raiseDispute(ipAddr, disputeEvidenceHashExample, "IMPROPER_REGISTRATION", "");
 
         uint256 disputeIdAfter = disputeModule.disputeCounter();
         uint256 ipAccount1USDCBalanceAfter = IERC20(USDC).balanceOf(ipAccount1);
@@ -326,7 +326,7 @@ contract DisputeModuleTest is BaseTest {
         assertEq(disputeTimestamp, block.timestamp);
         assertEq(arbitrationPolicy, address(mockArbitrationPolicy2));
         assertEq(disputeEvidenceHash, disputeEvidenceHashExample);
-        assertEq(targetTag, bytes32("PLAGIARISM"));
+        assertEq(targetTag, bytes32("IMPROPER_REGISTRATION"));
         assertEq(currentTag, bytes32("IN_DISPUTE"));
         assertEq(parentDisputeId, 0);
     }
@@ -347,11 +347,11 @@ contract DisputeModuleTest is BaseTest {
             block.timestamp,
             address(mockArbitrationPolicy),
             disputeEvidenceHashExample,
-            bytes32("PLAGIARISM"),
+            bytes32("IMPROPER_REGISTRATION"),
             ""
         );
 
-        disputeModule.raiseDispute(ipAddr, disputeEvidenceHashExample, "PLAGIARISM", "");
+        disputeModule.raiseDispute(ipAddr, disputeEvidenceHashExample, "IMPROPER_REGISTRATION", "");
 
         uint256 disputeIdAfter = disputeModule.disputeCounter();
         uint256 ipAccount1USDCBalanceAfter = USDC.balanceOf(ipAccount1);
@@ -376,7 +376,7 @@ contract DisputeModuleTest is BaseTest {
         assertEq(disputeTimestamp, block.timestamp);
         assertEq(arbitrationPolicy, address(mockArbitrationPolicy));
         assertEq(disputeEvidenceHash, disputeEvidenceHashExample);
-        assertEq(targetTag, bytes32("PLAGIARISM"));
+        assertEq(targetTag, bytes32("IMPROPER_REGISTRATION"));
         assertEq(currentTag, bytes32("IN_DISPUTE"));
         assertEq(parentDisputeId, 0);
     }
@@ -390,7 +390,7 @@ contract DisputeModuleTest is BaseTest {
         // raise dispute
         vm.startPrank(ipAccount1);
         IERC20(USDC).approve(address(mockArbitrationPolicy), ARBITRATION_PRICE);
-        disputeModule.raiseDispute(ipAddr, disputeEvidenceHashExample, "PLAGIARISM", "");
+        disputeModule.raiseDispute(ipAddr, disputeEvidenceHashExample, "IMPROPER_REGISTRATION", "");
         vm.stopPrank();
 
         vm.expectRevert(Errors.DisputeModule__NotWhitelistedArbitrationRelayer.selector);
@@ -401,7 +401,7 @@ contract DisputeModuleTest is BaseTest {
         // raise dispute
         vm.startPrank(ipAccount1);
         IERC20(USDC).approve(address(mockArbitrationPolicy), ARBITRATION_PRICE);
-        disputeModule.raiseDispute(ipAddr, disputeEvidenceHashExample, "PLAGIARISM", "");
+        disputeModule.raiseDispute(ipAddr, disputeEvidenceHashExample, "IMPROPER_REGISTRATION", "");
         vm.stopPrank();
 
         // set dispute judgement
@@ -422,7 +422,7 @@ contract DisputeModuleTest is BaseTest {
         assertEq(ipAccount1USDCBalanceAfter - ipAccount1USDCBalanceBefore, ARBITRATION_PRICE);
         assertEq(mockArbitrationPolicyUSDCBalanceBefore - mockArbitrationPolicyUSDCBalanceAfter, ARBITRATION_PRICE);
         assertEq(currentTagBefore, bytes32("IN_DISPUTE"));
-        assertEq(currentTagAfter, bytes32("PLAGIARISM"));
+        assertEq(currentTagAfter, bytes32("IMPROPER_REGISTRATION"));
         assertTrue(disputeModule.isIpTagged(ipAddr));
     }
 
@@ -430,7 +430,7 @@ contract DisputeModuleTest is BaseTest {
         // raise dispute
         vm.startPrank(ipAccount1);
         IERC20(USDC).approve(address(mockArbitrationPolicy), ARBITRATION_PRICE);
-        disputeModule.raiseDispute(ipAddr, disputeEvidenceHashExample, "PLAGIARISM", "");
+        disputeModule.raiseDispute(ipAddr, disputeEvidenceHashExample, "IMPROPER_REGISTRATION", "");
         vm.stopPrank();
 
         // set dispute judgement
@@ -458,7 +458,7 @@ contract DisputeModuleTest is BaseTest {
     function test_DisputeModule_revert_paused() public {
         vm.startPrank(ipAccount1);
         IERC20(USDC).approve(address(mockArbitrationPolicy), ARBITRATION_PRICE);
-        disputeModule.raiseDispute(ipAddr, disputeEvidenceHashExample, "PLAGIARISM", "");
+        disputeModule.raiseDispute(ipAddr, disputeEvidenceHashExample, "IMPROPER_REGISTRATION", "");
         vm.stopPrank();
 
         vm.prank(u.admin);
@@ -475,7 +475,7 @@ contract DisputeModuleTest is BaseTest {
         // raise dispute
         vm.startPrank(ipAccount1);
         IERC20(USDC).approve(address(mockArbitrationPolicy), ARBITRATION_PRICE);
-        disputeModule.raiseDispute(ipAddr, disputeEvidenceHashExample, "PLAGIARISM", "");
+        disputeModule.raiseDispute(ipAddr, disputeEvidenceHashExample, "IMPROPER_REGISTRATION", "");
         vm.stopPrank();
 
         vm.expectRevert(Errors.DisputeModule__NotDisputeInitiator.selector);
@@ -491,7 +491,7 @@ contract DisputeModuleTest is BaseTest {
         // raise dispute
         vm.startPrank(ipAccount1);
         IERC20(USDC).approve(address(mockArbitrationPolicy), ARBITRATION_PRICE);
-        disputeModule.raiseDispute(ipAddr, disputeEvidenceHashExample, "PLAGIARISM", "");
+        disputeModule.raiseDispute(ipAddr, disputeEvidenceHashExample, "IMPROPER_REGISTRATION", "");
         vm.stopPrank();
 
         (, , , , , , bytes32 currentTagBeforeCancel, ) = disputeModule.disputes(1);
@@ -527,7 +527,7 @@ contract DisputeModuleTest is BaseTest {
         // raise dispute
         vm.startPrank(ipAccount1);
         IERC20(USDC).approve(address(mockArbitrationPolicy), ARBITRATION_PRICE);
-        disputeModule.raiseDispute(ipAddr, disputeEvidenceHashExample, "PLAGIARISM", "");
+        disputeModule.raiseDispute(ipAddr, disputeEvidenceHashExample, "IMPROPER_REGISTRATION", "");
         vm.stopPrank();
 
         vm.expectRevert(Errors.DisputeModule__ParentNotTagged.selector);
@@ -538,7 +538,7 @@ contract DisputeModuleTest is BaseTest {
         // raise dispute
         vm.startPrank(ipAccount1);
         IERC20(USDC).approve(address(mockArbitrationPolicy), ARBITRATION_PRICE);
-        disputeModule.raiseDispute(ipAddr, disputeEvidenceHashExample, "PLAGIARISM", "");
+        disputeModule.raiseDispute(ipAddr, disputeEvidenceHashExample, "IMPROPER_REGISTRATION", "");
         vm.stopPrank();
 
         // set dispute judgement
@@ -554,7 +554,7 @@ contract DisputeModuleTest is BaseTest {
         // raise dispute
         vm.startPrank(ipAccount1);
         IERC20(USDC).approve(address(mockArbitrationPolicy), ARBITRATION_PRICE);
-        disputeModule.raiseDispute(ipAddr, disputeEvidenceHashExample, "PLAGIARISM", "");
+        disputeModule.raiseDispute(ipAddr, disputeEvidenceHashExample, "IMPROPER_REGISTRATION", "");
         vm.stopPrank();
 
         // set dispute judgement
@@ -567,7 +567,9 @@ contract DisputeModuleTest is BaseTest {
         // tag child ip
         vm.startPrank(address(1));
         vm.expectEmit(true, true, true, true, address(disputeModule));
-        emit IDisputeModule.DerivativeTaggedOnParentInfringement(ipAddr, ipAddr2, 1, "PLAGIARISM", block.timestamp);
+        emit IDisputeModule.DerivativeTaggedOnParentInfringement(
+            ipAddr, ipAddr2, 1, "IMPROPER_REGISTRATION", block.timestamp
+        );
 
         uint256 disputeIdBefore = disputeModule.disputeCounter();
 
@@ -594,8 +596,8 @@ contract DisputeModuleTest is BaseTest {
         assertEq(disputeTimestamp, block.timestamp);
         assertEq(arbitrationPolicy, address(mockArbitrationPolicy));
         assertEq(disputeEvidenceHash, bytes32(0));
-        assertEq(targetTag, bytes32("PLAGIARISM"));
-        assertEq(currentTag, bytes32("PLAGIARISM"));
+        assertEq(targetTag, bytes32("IMPROPER_REGISTRATION"));
+        assertEq(currentTag, bytes32("IMPROPER_REGISTRATION"));
         assertEq(parentDisputeId, 1);
     }
 
@@ -608,7 +610,7 @@ contract DisputeModuleTest is BaseTest {
         // raise dispute
         vm.startPrank(ipAccount1);
         IERC20(USDC).approve(address(mockArbitrationPolicy), ARBITRATION_PRICE);
-        disputeModule.raiseDispute(ipAddr, disputeEvidenceHashExample, "PLAGIARISM", "");
+        disputeModule.raiseDispute(ipAddr, disputeEvidenceHashExample, "IMPROPER_REGISTRATION", "");
         vm.stopPrank();
 
         vm.startPrank(ipAccount1);
@@ -620,7 +622,7 @@ contract DisputeModuleTest is BaseTest {
         // raise dispute
         vm.startPrank(ipAccount1);
         IERC20(USDC).approve(address(mockArbitrationPolicy), ARBITRATION_PRICE);
-        disputeModule.raiseDispute(ipAddr, disputeEvidenceHashExample, "PLAGIARISM", "");
+        disputeModule.raiseDispute(ipAddr, disputeEvidenceHashExample, "IMPROPER_REGISTRATION", "");
         vm.stopPrank();
 
         // set dispute judgement
@@ -639,7 +641,7 @@ contract DisputeModuleTest is BaseTest {
         // raise dispute
         vm.startPrank(ipAccount1);
         IERC20(USDC).approve(address(mockArbitrationPolicy), ARBITRATION_PRICE);
-        disputeModule.raiseDispute(ipAddr, disputeEvidenceHashExample, "PLAGIARISM", "");
+        disputeModule.raiseDispute(ipAddr, disputeEvidenceHashExample, "IMPROPER_REGISTRATION", "");
         vm.stopPrank();
 
         // set dispute judgement
@@ -658,7 +660,7 @@ contract DisputeModuleTest is BaseTest {
 
         (, , , , , , bytes32 currentTagAfterResolve, ) = disputeModule.disputes(1);
 
-        assertEq(currentTagBeforeResolve, bytes32("PLAGIARISM"));
+        assertEq(currentTagBeforeResolve, bytes32("IMPROPER_REGISTRATION"));
         assertEq(currentTagAfterResolve, bytes32(0));
         assertFalse(disputeModule.isIpTagged(ipAddr));
 

--- a/test/foundry/modules/dispute/policies/UMA/ArbitrationPolicyUMA.t.sol
+++ b/test/foundry/modules/dispute/policies/UMA/ArbitrationPolicyUMA.t.sol
@@ -299,7 +299,12 @@ contract ArbitrationPolicyUMATest is BaseTest {
 
         bytes memory data = abi.encode(claim, liveness, currency, bond, identifier);
 
-        uint256 disputeId = newDisputeModule.raiseDispute(address(1), disputeEvidenceHashExample, "IMPROPER_REGISTRATION", data);
+        uint256 disputeId = newDisputeModule.raiseDispute(
+            address(1),
+            disputeEvidenceHashExample,
+            "IMPROPER_REGISTRATION",
+            data
+        );
 
         // settle the assertion
         bytes32 assertionId = newArbitrationPolicyUMA.disputeIdToAssertionId(disputeId);
@@ -317,7 +322,12 @@ contract ArbitrationPolicyUMATest is BaseTest {
 
         bytes memory data = abi.encode(claim, liveness, currency, bond, identifier);
 
-        uint256 disputeId = newDisputeModule.raiseDispute(address(1), disputeEvidenceHashExample, "IMPROPER_REGISTRATION", data);
+        uint256 disputeId = newDisputeModule.raiseDispute(
+            address(1),
+            disputeEvidenceHashExample,
+            "IMPROPER_REGISTRATION",
+            data
+        );
 
         // wait for assertion to expire
         vm.warp(block.timestamp + liveness + 1);
@@ -348,7 +358,12 @@ contract ArbitrationPolicyUMATest is BaseTest {
         vm.startPrank(disputer);
         MockERC20(susd).mint(disputer, bond);
         currency.approve(address(newArbitrationPolicyUMA), bond);
-        uint256 disputeId = newDisputeModule.raiseDispute(address(1), disputeEvidenceHashExample, "IMPROPER_REGISTRATION", data);
+        uint256 disputeId = newDisputeModule.raiseDispute(
+            address(1),
+            disputeEvidenceHashExample,
+            "IMPROPER_REGISTRATION",
+            data
+        );
 
         // wait for assertion to expire
         vm.warp(block.timestamp + liveness + 1);
@@ -381,7 +396,12 @@ contract ArbitrationPolicyUMATest is BaseTest {
 
         address targetIpId = address(1);
 
-        uint256 disputeId = newDisputeModule.raiseDispute(targetIpId, disputeEvidenceHashExample, "IMPROPER_REGISTRATION", data);
+        uint256 disputeId = newDisputeModule.raiseDispute(
+            targetIpId,
+            disputeEvidenceHashExample,
+            "IMPROPER_REGISTRATION",
+            data
+        );
 
         // dispute the assertion
         vm.startPrank(targetIpId);
@@ -415,7 +435,12 @@ contract ArbitrationPolicyUMATest is BaseTest {
         bytes memory data = abi.encode(claim, liveness, currency, bond, identifier);
 
         address targetIpId = address(1);
-        uint256 disputeId = newDisputeModule.raiseDispute(targetIpId, disputeEvidenceHashExample, "IMPROPER_REGISTRATION", data);
+        uint256 disputeId = newDisputeModule.raiseDispute(
+            targetIpId,
+            disputeEvidenceHashExample,
+            "IMPROPER_REGISTRATION",
+            data
+        );
 
         // dispute the assertion
         vm.startPrank(targetIpId);
@@ -436,7 +461,12 @@ contract ArbitrationPolicyUMATest is BaseTest {
         bytes memory data = abi.encode(claim, liveness, currency, bond, identifier);
 
         address targetIpId = address(1);
-        uint256 disputeId = newDisputeModule.raiseDispute(targetIpId, disputeEvidenceHashExample, "IMPROPER_REGISTRATION", data);
+        uint256 disputeId = newDisputeModule.raiseDispute(
+            targetIpId,
+            disputeEvidenceHashExample,
+            "IMPROPER_REGISTRATION",
+            data
+        );
 
         // dispute the assertion
         vm.startPrank(targetIpId);
@@ -455,7 +485,12 @@ contract ArbitrationPolicyUMATest is BaseTest {
         bytes memory data = abi.encode(claim, liveness, currency, bond, identifier);
 
         address targetIpId = address(1);
-        uint256 disputeId = newDisputeModule.raiseDispute(targetIpId, disputeEvidenceHashExample, "IMPROPER_REGISTRATION", data);
+        uint256 disputeId = newDisputeModule.raiseDispute(
+            targetIpId,
+            disputeEvidenceHashExample,
+            "IMPROPER_REGISTRATION",
+            data
+        );
 
         vm.expectRevert(Errors.ArbitrationPolicyUMA__DisputeNotFound.selector);
         newArbitrationPolicyUMA.disputeAssertion(bytes32(0), bytes32("COUNTER_EVIDENCE_HASH"));
@@ -470,7 +505,12 @@ contract ArbitrationPolicyUMATest is BaseTest {
         bytes memory data = abi.encode(claim, liveness, currency, bond, identifier);
 
         address targetIpId = address(1);
-        uint256 disputeId = newDisputeModule.raiseDispute(targetIpId, disputeEvidenceHashExample, "IMPROPER_REGISTRATION", data);
+        uint256 disputeId = newDisputeModule.raiseDispute(
+            targetIpId,
+            disputeEvidenceHashExample,
+            "IMPROPER_REGISTRATION",
+            data
+        );
 
         bytes32 assertionId = newArbitrationPolicyUMA.disputeIdToAssertionId(disputeId);
 
@@ -495,7 +535,12 @@ contract ArbitrationPolicyUMATest is BaseTest {
         bytes memory data = abi.encode(claim, liveness, currency, bond, identifier);
 
         address targetIpId = address(1);
-        uint256 disputeId = newDisputeModule.raiseDispute(targetIpId, disputeEvidenceHashExample, "IMPROPER_REGISTRATION", data);
+        uint256 disputeId = newDisputeModule.raiseDispute(
+            targetIpId,
+            disputeEvidenceHashExample,
+            "IMPROPER_REGISTRATION",
+            data
+        );
 
         // dispute the assertion
         vm.startPrank(targetIpId);
@@ -533,7 +578,12 @@ contract ArbitrationPolicyUMATest is BaseTest {
         bytes memory data = abi.encode(claim, liveness, currency, bond, identifier);
 
         address targetIpId = address(1);
-        uint256 disputeId = newDisputeModule.raiseDispute(targetIpId, disputeEvidenceHashExample, "IMPROPER_REGISTRATION", data);
+        uint256 disputeId = newDisputeModule.raiseDispute(
+            targetIpId,
+            disputeEvidenceHashExample,
+            "IMPROPER_REGISTRATION",
+            data
+        );
 
         vm.warp(block.timestamp + (liveness * 66_666_666) / 100_000_000 + 1);
 
@@ -579,7 +629,12 @@ contract ArbitrationPolicyUMATest is BaseTest {
         vm.startPrank(address(2));
         MockERC20(susd).mint(address(2), bond);
         currency.approve(address(newArbitrationPolicyUMA), bond);
-        uint256 disputeId = newDisputeModule.raiseDispute(address(1), disputeEvidenceHashExample, "IMPROPER_REGISTRATION", data);
+        uint256 disputeId = newDisputeModule.raiseDispute(
+            address(1),
+            disputeEvidenceHashExample,
+            "IMPROPER_REGISTRATION",
+            data
+        );
         vm.stopPrank();
 
         // dispute the assertion
@@ -638,7 +693,12 @@ contract ArbitrationPolicyUMATest is BaseTest {
         vm.startPrank(address(2));
         MockERC20(susd).mint(address(2), bond);
         currency.approve(address(newArbitrationPolicyUMA), bond);
-        uint256 disputeId = newDisputeModule.raiseDispute(address(1), disputeEvidenceHashExample, "IMPROPER_REGISTRATION", data);
+        uint256 disputeId = newDisputeModule.raiseDispute(
+            address(1),
+            disputeEvidenceHashExample,
+            "IMPROPER_REGISTRATION",
+            data
+        );
         vm.stopPrank();
 
         // dispute the assertion

--- a/test/foundry/modules/dispute/policies/UMA/ArbitrationPolicyUMA.t.sol
+++ b/test/foundry/modules/dispute/policies/UMA/ArbitrationPolicyUMA.t.sol
@@ -83,7 +83,7 @@ contract ArbitrationPolicyUMATest is BaseTest {
         newArbitrationPolicyUMA.setMaxBond(susd, 25000e18); // 25k USD max bond
 
         // whitelist dispute tag, arbitration policy and arbitration relayer
-        newDisputeModule.whitelistDisputeTag("PLAGIARISM", true);
+        newDisputeModule.whitelistDisputeTag("IMPROPER_REGISTRATION", true);
         newDisputeModule.whitelistArbitrationPolicy(address(newArbitrationPolicyUMA), true);
         newDisputeModule.whitelistArbitrationRelayer(
             address(newArbitrationPolicyUMA),
@@ -150,7 +150,7 @@ contract ArbitrationPolicyUMATest is BaseTest {
         bytes memory data = abi.encode(claim, liveness, currency, bond, identifier);
 
         vm.expectRevert(Errors.ArbitrationPolicyUMA__LivenessBelowMin.selector);
-        newDisputeModule.raiseDispute(address(1), disputeEvidenceHashExample, "PLAGIARISM", data);
+        newDisputeModule.raiseDispute(address(1), disputeEvidenceHashExample, "IMPROPER_REGISTRATION", data);
     }
 
     function test_ArbitrationPolicyUMA_onRaiseDispute_revert_LivenessAboveMax() public {
@@ -163,7 +163,7 @@ contract ArbitrationPolicyUMATest is BaseTest {
         bytes memory data = abi.encode(claim, liveness, currency, bond, identifier);
 
         vm.expectRevert(Errors.ArbitrationPolicyUMA__LivenessAboveMax.selector);
-        newDisputeModule.raiseDispute(address(1), disputeEvidenceHashExample, "PLAGIARISM", data);
+        newDisputeModule.raiseDispute(address(1), disputeEvidenceHashExample, "IMPROPER_REGISTRATION", data);
     }
 
     function test_ArbitrationPolicyUMA_setMaxBond() public {
@@ -190,7 +190,7 @@ contract ArbitrationPolicyUMATest is BaseTest {
         bytes memory data = abi.encode(claim, liveness, currency, bond, identifier);
 
         vm.expectRevert(Errors.ArbitrationPolicyUMA__BondAboveMax.selector);
-        newDisputeModule.raiseDispute(address(1), disputeEvidenceHashExample, "PLAGIARISM", data);
+        newDisputeModule.raiseDispute(address(1), disputeEvidenceHashExample, "IMPROPER_REGISTRATION", data);
     }
 
     function test_ArbitrationPolicyUMA_onRaiseDispute_revert_UnsupportedCurrency() public {
@@ -203,7 +203,7 @@ contract ArbitrationPolicyUMATest is BaseTest {
         bytes memory data = abi.encode(claim, liveness, currency, bond, identifier);
 
         vm.expectRevert("Unsupported currency");
-        newDisputeModule.raiseDispute(address(1), disputeEvidenceHashExample, "PLAGIARISM", data);
+        newDisputeModule.raiseDispute(address(1), disputeEvidenceHashExample, "IMPROPER_REGISTRATION", data);
     }
 
     function test_ArbitrationPolicyUMA_onRaiseDispute_revert_UnsupportedIdentifier() public {
@@ -216,7 +216,7 @@ contract ArbitrationPolicyUMATest is BaseTest {
         bytes memory data = abi.encode(claim, liveness, currency, bond, identifier);
 
         vm.expectRevert("Unsupported identifier");
-        newDisputeModule.raiseDispute(address(1), disputeEvidenceHashExample, "PLAGIARISM", data);
+        newDisputeModule.raiseDispute(address(1), disputeEvidenceHashExample, "IMPROPER_REGISTRATION", data);
     }
 
     function test_ArbitrationPolicyUMA_onRaiseDispute() public {
@@ -232,7 +232,7 @@ contract ArbitrationPolicyUMATest is BaseTest {
         emit DisputeRaisedUMA(1, address(2), claim, liveness, address(currency), bond, identifier);
 
         vm.startPrank(address(2));
-        newDisputeModule.raiseDispute(address(1), disputeEvidenceHashExample, "PLAGIARISM", data);
+        newDisputeModule.raiseDispute(address(1), disputeEvidenceHashExample, "IMPROPER_REGISTRATION", data);
 
         uint256 disputeId = newDisputeModule.disputeCounter();
         bytes32 assertionId = newArbitrationPolicyUMA.disputeIdToAssertionId(disputeId);
@@ -260,7 +260,7 @@ contract ArbitrationPolicyUMATest is BaseTest {
         uint256 raiserBalBefore = currency.balanceOf(address(2));
         uint256 oov3BalBefore = currency.balanceOf(address(newOOV3));
 
-        newDisputeModule.raiseDispute(address(1), disputeEvidenceHashExample, "PLAGIARISM", data);
+        newDisputeModule.raiseDispute(address(1), disputeEvidenceHashExample, "IMPROPER_REGISTRATION", data);
 
         uint256 raiserBalAfter = currency.balanceOf(address(2));
         uint256 oov3BalAfter = currency.balanceOf(address(newOOV3));
@@ -284,7 +284,7 @@ contract ArbitrationPolicyUMATest is BaseTest {
 
         bytes memory data = abi.encode(claim, liveness, currency, bond, identifier);
 
-        newDisputeModule.raiseDispute(address(1), disputeEvidenceHashExample, "PLAGIARISM", data);
+        newDisputeModule.raiseDispute(address(1), disputeEvidenceHashExample, "IMPROPER_REGISTRATION", data);
 
         vm.expectRevert(Errors.ArbitrationPolicyUMA__CannotCancel.selector);
         newDisputeModule.cancelDispute(1, "");
@@ -299,7 +299,7 @@ contract ArbitrationPolicyUMATest is BaseTest {
 
         bytes memory data = abi.encode(claim, liveness, currency, bond, identifier);
 
-        uint256 disputeId = newDisputeModule.raiseDispute(address(1), disputeEvidenceHashExample, "PLAGIARISM", data);
+        uint256 disputeId = newDisputeModule.raiseDispute(address(1), disputeEvidenceHashExample, "IMPROPER_REGISTRATION", data);
 
         // settle the assertion
         bytes32 assertionId = newArbitrationPolicyUMA.disputeIdToAssertionId(disputeId);
@@ -317,7 +317,7 @@ contract ArbitrationPolicyUMATest is BaseTest {
 
         bytes memory data = abi.encode(claim, liveness, currency, bond, identifier);
 
-        uint256 disputeId = newDisputeModule.raiseDispute(address(1), disputeEvidenceHashExample, "PLAGIARISM", data);
+        uint256 disputeId = newDisputeModule.raiseDispute(address(1), disputeEvidenceHashExample, "IMPROPER_REGISTRATION", data);
 
         // wait for assertion to expire
         vm.warp(block.timestamp + liveness + 1);
@@ -331,7 +331,7 @@ contract ArbitrationPolicyUMATest is BaseTest {
         (, , , , , , bytes32 currentTagAfter, ) = newDisputeModule.disputes(disputeId);
 
         assertEq(currentTagBefore, bytes32("IN_DISPUTE"));
-        assertEq(currentTagAfter, bytes32("PLAGIARISM"));
+        assertEq(currentTagAfter, bytes32("IMPROPER_REGISTRATION"));
     }
 
     function test_ArbitrationPolicyUMA_onDisputeJudgement_AssertionWithoutDisputeWithBond() public {
@@ -348,7 +348,7 @@ contract ArbitrationPolicyUMATest is BaseTest {
         vm.startPrank(disputer);
         MockERC20(susd).mint(disputer, bond);
         currency.approve(address(newArbitrationPolicyUMA), bond);
-        uint256 disputeId = newDisputeModule.raiseDispute(address(1), disputeEvidenceHashExample, "PLAGIARISM", data);
+        uint256 disputeId = newDisputeModule.raiseDispute(address(1), disputeEvidenceHashExample, "IMPROPER_REGISTRATION", data);
 
         // wait for assertion to expire
         vm.warp(block.timestamp + liveness + 1);
@@ -366,7 +366,7 @@ contract ArbitrationPolicyUMATest is BaseTest {
         (, , , , , , bytes32 currentTagAfter, ) = newDisputeModule.disputes(disputeId);
 
         assertEq(currentTagBefore, bytes32("IN_DISPUTE"));
-        assertEq(currentTagAfter, bytes32("PLAGIARISM"));
+        assertEq(currentTagAfter, bytes32("IMPROPER_REGISTRATION"));
         assertEq(disputerBalAfter - disputerBalBefore, bond);
     }
 
@@ -381,7 +381,7 @@ contract ArbitrationPolicyUMATest is BaseTest {
 
         address targetIpId = address(1);
 
-        uint256 disputeId = newDisputeModule.raiseDispute(targetIpId, disputeEvidenceHashExample, "PLAGIARISM", data);
+        uint256 disputeId = newDisputeModule.raiseDispute(targetIpId, disputeEvidenceHashExample, "IMPROPER_REGISTRATION", data);
 
         // dispute the assertion
         vm.startPrank(targetIpId);
@@ -403,7 +403,7 @@ contract ArbitrationPolicyUMATest is BaseTest {
         (, , , , , , bytes32 currentTagAfter, ) = newDisputeModule.disputes(disputeId);
 
         assertEq(currentTagBefore, bytes32("IN_DISPUTE"));
-        assertEq(currentTagAfter, bytes32("PLAGIARISM"));
+        assertEq(currentTagAfter, bytes32("IMPROPER_REGISTRATION"));
     }
 
     function test_ArbitrationPolicyUMA_disputeAssertion_revert_CannotDisputeAssertionTwice() public {
@@ -415,7 +415,7 @@ contract ArbitrationPolicyUMATest is BaseTest {
         bytes memory data = abi.encode(claim, liveness, currency, bond, identifier);
 
         address targetIpId = address(1);
-        uint256 disputeId = newDisputeModule.raiseDispute(targetIpId, disputeEvidenceHashExample, "PLAGIARISM", data);
+        uint256 disputeId = newDisputeModule.raiseDispute(targetIpId, disputeEvidenceHashExample, "IMPROPER_REGISTRATION", data);
 
         // dispute the assertion
         vm.startPrank(targetIpId);
@@ -436,7 +436,7 @@ contract ArbitrationPolicyUMATest is BaseTest {
         bytes memory data = abi.encode(claim, liveness, currency, bond, identifier);
 
         address targetIpId = address(1);
-        uint256 disputeId = newDisputeModule.raiseDispute(targetIpId, disputeEvidenceHashExample, "PLAGIARISM", data);
+        uint256 disputeId = newDisputeModule.raiseDispute(targetIpId, disputeEvidenceHashExample, "IMPROPER_REGISTRATION", data);
 
         // dispute the assertion
         vm.startPrank(targetIpId);
@@ -455,7 +455,7 @@ contract ArbitrationPolicyUMATest is BaseTest {
         bytes memory data = abi.encode(claim, liveness, currency, bond, identifier);
 
         address targetIpId = address(1);
-        uint256 disputeId = newDisputeModule.raiseDispute(targetIpId, disputeEvidenceHashExample, "PLAGIARISM", data);
+        uint256 disputeId = newDisputeModule.raiseDispute(targetIpId, disputeEvidenceHashExample, "IMPROPER_REGISTRATION", data);
 
         vm.expectRevert(Errors.ArbitrationPolicyUMA__DisputeNotFound.selector);
         newArbitrationPolicyUMA.disputeAssertion(bytes32(0), bytes32("COUNTER_EVIDENCE_HASH"));
@@ -470,7 +470,7 @@ contract ArbitrationPolicyUMATest is BaseTest {
         bytes memory data = abi.encode(claim, liveness, currency, bond, identifier);
 
         address targetIpId = address(1);
-        uint256 disputeId = newDisputeModule.raiseDispute(targetIpId, disputeEvidenceHashExample, "PLAGIARISM", data);
+        uint256 disputeId = newDisputeModule.raiseDispute(targetIpId, disputeEvidenceHashExample, "IMPROPER_REGISTRATION", data);
 
         bytes32 assertionId = newArbitrationPolicyUMA.disputeIdToAssertionId(disputeId);
 
@@ -495,7 +495,7 @@ contract ArbitrationPolicyUMATest is BaseTest {
         bytes memory data = abi.encode(claim, liveness, currency, bond, identifier);
 
         address targetIpId = address(1);
-        uint256 disputeId = newDisputeModule.raiseDispute(targetIpId, disputeEvidenceHashExample, "PLAGIARISM", data);
+        uint256 disputeId = newDisputeModule.raiseDispute(targetIpId, disputeEvidenceHashExample, "IMPROPER_REGISTRATION", data);
 
         // dispute the assertion
         vm.startPrank(targetIpId);
@@ -533,7 +533,7 @@ contract ArbitrationPolicyUMATest is BaseTest {
         bytes memory data = abi.encode(claim, liveness, currency, bond, identifier);
 
         address targetIpId = address(1);
-        uint256 disputeId = newDisputeModule.raiseDispute(targetIpId, disputeEvidenceHashExample, "PLAGIARISM", data);
+        uint256 disputeId = newDisputeModule.raiseDispute(targetIpId, disputeEvidenceHashExample, "IMPROPER_REGISTRATION", data);
 
         vm.warp(block.timestamp + (liveness * 66_666_666) / 100_000_000 + 1);
 
@@ -579,7 +579,7 @@ contract ArbitrationPolicyUMATest is BaseTest {
         vm.startPrank(address(2));
         MockERC20(susd).mint(address(2), bond);
         currency.approve(address(newArbitrationPolicyUMA), bond);
-        uint256 disputeId = newDisputeModule.raiseDispute(address(1), disputeEvidenceHashExample, "PLAGIARISM", data);
+        uint256 disputeId = newDisputeModule.raiseDispute(address(1), disputeEvidenceHashExample, "IMPROPER_REGISTRATION", data);
         vm.stopPrank();
 
         // dispute the assertion
@@ -618,7 +618,7 @@ contract ArbitrationPolicyUMATest is BaseTest {
         uint256 bondRecipientAmount = assertion.bond * 2 - oracleFee;
 
         assertEq(currentTagBefore, bytes32("IN_DISPUTE"));
-        assertEq(currentTagAfter, bytes32("PLAGIARISM"));
+        assertEq(currentTagAfter, bytes32("IMPROPER_REGISTRATION"));
         assertEq(disputeInitiatorBalAfter - disputeInitiatorBalBefore, bondRecipientAmount);
         assertEq(defenderIpIdOwnerBalAfter - defenderIpIdOwnerBalBefore, 0);
     }
@@ -638,7 +638,7 @@ contract ArbitrationPolicyUMATest is BaseTest {
         vm.startPrank(address(2));
         MockERC20(susd).mint(address(2), bond);
         currency.approve(address(newArbitrationPolicyUMA), bond);
-        uint256 disputeId = newDisputeModule.raiseDispute(address(1), disputeEvidenceHashExample, "PLAGIARISM", data);
+        uint256 disputeId = newDisputeModule.raiseDispute(address(1), disputeEvidenceHashExample, "IMPROPER_REGISTRATION", data);
         vm.stopPrank();
 
         // dispute the assertion

--- a/test/foundry/modules/royalty/RoyaltyModule.t.sol
+++ b/test/foundry/modules/royalty/RoyaltyModule.t.sol
@@ -841,7 +841,7 @@ contract TestRoyaltyModule is BaseTest {
         // raise dispute
         vm.startPrank(ipAccount1);
         USDC.approve(address(mockArbitrationPolicy), ARBITRATION_PRICE);
-        disputeModule.raiseDispute(ipAddr, disputeEvidenceHashExample, "PLAGIARISM", "");
+        disputeModule.raiseDispute(ipAddr, disputeEvidenceHashExample, "IMPROPER_REGISTRATION", "");
         vm.stopPrank();
 
         // set dispute judgement
@@ -989,7 +989,7 @@ contract TestRoyaltyModule is BaseTest {
         // raise dispute
         vm.startPrank(ipAccount1);
         USDC.approve(address(mockArbitrationPolicy), ARBITRATION_PRICE);
-        disputeModule.raiseDispute(ipAddr, disputeEvidenceHashExample, "PLAGIARISM", "");
+        disputeModule.raiseDispute(ipAddr, disputeEvidenceHashExample, "IMPROPER_REGISTRATION", "");
         vm.stopPrank();
 
         // set dispute judgement

--- a/test/foundry/utils/BaseTest.t.sol
+++ b/test/foundry/utils/BaseTest.t.sol
@@ -134,7 +134,9 @@ contract BaseTest is Test, DeployHelper, LicensingHelper {
         vm.startPrank(disputeInitiator);
         USDC.approve(address(mockArbitrationPolicy), ARBITRATION_PRICE);
         bytes32 disputeEvidenceHashExample = 0xb7b94ecbd1f9f8cb209909e5785fb2858c9a8c4b220c017995a75346ad1b5db5;
-        disputeId = disputeModule.raiseDispute(ipAddrToDispute, disputeEvidenceHashExample, "PLAGIARISM", "");
+        disputeId = disputeModule.raiseDispute(
+            ipAddrToDispute, disputeEvidenceHashExample, "IMPROPER_REGISTRATION", ""
+        );
         vm.stopPrank();
 
         vm.prank(u.relayer); // admin is a judge

--- a/test/foundry/utils/BaseTest.t.sol
+++ b/test/foundry/utils/BaseTest.t.sol
@@ -135,7 +135,10 @@ contract BaseTest is Test, DeployHelper, LicensingHelper {
         USDC.approve(address(mockArbitrationPolicy), ARBITRATION_PRICE);
         bytes32 disputeEvidenceHashExample = 0xb7b94ecbd1f9f8cb209909e5785fb2858c9a8c4b220c017995a75346ad1b5db5;
         disputeId = disputeModule.raiseDispute(
-            ipAddrToDispute, disputeEvidenceHashExample, "IMPROPER_REGISTRATION", ""
+            ipAddrToDispute,
+            disputeEvidenceHashExample,
+            "IMPROPER_REGISTRATION",
+            ""
         );
         vm.stopPrank();
 


### PR DESCRIPTION
## Description
Removes the previous tag `PLAGIARISM` and adds the new dispute tags:
- `IMPROPER_REGISTRATION` - party A registered another’s work as its own
- `IMPROPER_USAGE` - violations of commercial rights, territory, channels, etc
- `IMPROPER_PAYMENT` - disputed IP received payments that should have been shared with party A
- `CONTENT_STANDARDS_VIOLATION` - violation of the point in the content standards in the PIL