### PR TITLE
 Simplify IpRoyaltyVault to Support Claiming Revenue Without Snapshots

### DIFF
--- a/contracts/interfaces/modules/grouping/IGroupingModule.sol
+++ b/contracts/interfaces/modules/grouping/IGroupingModule.sol
@@ -35,13 +35,11 @@ interface IGroupingModule is IModule {
     /// @param token The address of the token.
     /// @param pool The address of the pool.
     /// @param amount The amount of reward.
-    /// @param snapshots The snapshot IDs of the royalty vault for the given group to collect royalties.
     event CollectedRoyaltiesToGroupPool(
         address indexed groupId,
         address indexed token,
         address indexed pool,
-        uint256 amount,
-        uint256[] snapshots
+        uint256 amount
     );
 
     /// @notice Registers a Group IPA.
@@ -75,11 +73,9 @@ interface IGroupingModule is IModule {
     /// @notice Collects royalties into the pool, making them claimable by group member IPs.
     /// @param groupId The address of the group.
     /// @param token The address of the token.
-    /// @param snapshotIds The snapshot IDs of the royalty vault for the given group to collect royalties.
     function collectRoyalties(
         address groupId,
-        address token,
-        uint256[] calldata snapshotIds
+        address token
     ) external returns (uint256 royalties);
 
     /// @notice Returns the available reward for each IP in the group.

--- a/contracts/interfaces/modules/grouping/IGroupingModule.sol
+++ b/contracts/interfaces/modules/grouping/IGroupingModule.sol
@@ -73,10 +73,7 @@ interface IGroupingModule is IModule {
     /// @notice Collects royalties into the pool, making them claimable by group member IPs.
     /// @param groupId The address of the group.
     /// @param token The address of the token.
-    function collectRoyalties(
-        address groupId,
-        address token
-    ) external returns (uint256 royalties);
+    function collectRoyalties(address groupId, address token) external returns (uint256 royalties);
 
     /// @notice Returns the available reward for each IP in the group.
     /// @param groupId The address of the group.

--- a/contracts/interfaces/modules/royalty/policies/IIpRoyaltyVault.sol
+++ b/contracts/interfaces/modules/royalty/policies/IIpRoyaltyVault.sol
@@ -76,5 +76,5 @@ interface IIpRoyaltyVault {
     /// @param claimer The address of the claimer
     /// @param token The revenue token to check
     /// @return The revenue debt of the claimer for the token
-    function revenueDebt(address claimer, address token) external view returns (int256);
+    function claimerRevenueDebt(address claimer, address token) external view returns (int256);
 }

--- a/contracts/interfaces/modules/royalty/policies/IIpRoyaltyVault.sol
+++ b/contracts/interfaces/modules/royalty/policies/IIpRoyaltyVault.sol
@@ -61,6 +61,11 @@ interface IIpRoyaltyVault {
         address claimer
     ) external returns (uint256[] memory);
 
+    function claimRevenueOnBehalfByTokenBatch(
+        address[] calldata tokenList,
+        address claimer
+    ) external returns (uint256[] memory);
+
     /// @notice Allows token holders to claim by a list of snapshot ids based on the token balance at certain snapshot
     /// @param snapshotIds The list of snapshot ids
     /// @param token The revenue token to claim

--- a/contracts/interfaces/modules/royalty/policies/IIpRoyaltyVault.sol
+++ b/contracts/interfaces/modules/royalty/policies/IIpRoyaltyVault.sol
@@ -8,11 +8,6 @@ interface IIpRoyaltyVault {
     /// @param amount The amount of revenue token added
     event RevenueTokenAddedToVault(address token, uint256 amount);
 
-    /// @notice Event emitted when a snapshot is taken
-    /// @param snapshotId The snapshot id
-    /// @param snapshotTimestamp The timestamp of the snapshot
-    event SnapshotCompleted(uint256 snapshotId, uint256 snapshotTimestamp);
-
     /// @notice Event emitted when a revenue token is claimed
     /// @param claimer The address of the claimer
     /// @param token The revenue token claimed
@@ -39,83 +34,38 @@ interface IIpRoyaltyVault {
     /// @dev Only callable by the royalty module or whitelisted royalty policy
     function updateVaultBalance(address token, uint256 amount) external;
 
-    /// @notice A function to snapshot the claimable revenue and royalty token amounts
-    /// @return The snapshot id
-    function snapshot() external returns (uint256);
 
-    /// @notice A function to calculate the amount of revenue token claimable by a token holder at certain snapshot
-    /// @param account The address of the token holder
-    /// @param snapshotId The snapshot id
-    /// @param token The revenue token to claim
-    /// @return The amount of revenue token claimable
-    function claimableRevenue(address account, uint256 snapshotId, address token) external view returns (uint256);
-
-    /// @notice Allows token holders to claim revenue token based on the token balance at certain snapshot
-    /// @param snapshotId The snapshot id
-    /// @param tokenList The list of revenue tokens to claim
-    /// @param claimer The address of the claimer
-    /// @return The amount of revenue tokens claimed for each token
-    function claimRevenueOnBehalfByTokenBatch(
-        uint256 snapshotId,
-        address[] calldata tokenList,
-        address claimer
-    ) external returns (uint256[] memory);
-
-    function claimRevenueOnBehalfByTokenBatch(
-        address[] calldata tokenList,
-        address claimer
-    ) external returns (uint256[] memory);
-
-    /// @notice Allows token holders to claim by a list of snapshot ids based on the token balance at certain snapshot
-    /// @param snapshotIds The list of snapshot ids
-    /// @param token The revenue token to claim
+    /// @notice Allows token holders to claim revenue token
+    /// @param token The revenue tokens to claim
     /// @param claimer The address of the claimer
     /// @return The amount of revenue tokens claimed
-    function claimRevenueOnBehalfBySnapshotBatch(
-        uint256[] memory snapshotIds,
+    function claimRevenueOnBehalf(
         address token,
         address claimer
     ) external returns (uint256);
 
+    /// @notice Allows token holders to claim a batch of revenue tokens
+    /// @param tokenList The list of revenue tokens to claim
+    /// @param claimer The address of the claimer
+    /// @return The amount of revenue tokens claimed of each token
+    function claimRevenueOnBehalfByTokenBatch(
+        address[] calldata tokenList,
+        address claimer
+    ) external returns (uint256[] memory);
+
     /// @notice Allows to claim revenue tokens on behalf of the ip royalty vault
-    /// @param snapshotId The snapshot id
     /// @param tokenList The list of revenue tokens to claim
     /// @param targetIpId The target ip id to claim revenue tokens from
-    function claimByTokenBatchAsSelf(uint256 snapshotId, address[] calldata tokenList, address targetIpId) external;
+    function claimByTokenBatchAsSelf(address[] calldata tokenList, address targetIpId) external;
 
-    /// @notice Allows to claim revenue tokens on behalf of the ip royalty vault by snapshot batch
-    /// @param snapshotIds The list of snapshot ids
+    /// @notice Get total amount of revenue token claimable by a token holder
+    /// @param claimer The address of the token holder
     /// @param token The revenue token to claim
-    /// @param targetIpId The target ip id to claim revenue tokens from
-    function claimBySnapshotBatchAsSelf(uint256[] memory snapshotIds, address token, address targetIpId) external;
-
-    /// @notice Returns the current snapshot id
-    function getCurrentSnapshotId() external view returns (uint256);
+    /// @return The amount of revenue token claimable
+    function claimableRevenue(address claimer, address token) external view returns (uint256);
 
     /// @notice The ip id to whom this royalty vault belongs to
     function ipId() external view returns (address);
-
-    /// @notice The last snapshotted timestamp
-    function lastSnapshotTimestamp() external view returns (uint256);
-
-    /// @notice Amount of revenue token pending to be snapshotted
-    /// @param token The address of the revenue token
-    function pendingVaultAmount(address token) external view returns (uint256);
-
-    /// @notice Amount of revenue token in the claim vault
-    /// @param token The address of the revenue token
-    function claimVaultAmount(address token) external view returns (uint256);
-
-    /// @notice Amount of revenue token claimable at a given snapshot
-    /// @param snapshotId The snapshot id
-    /// @param token The address of the revenue token
-    function claimableAtSnapshot(uint256 snapshotId, address token) external view returns (uint256);
-
-    /// @notice Indicates whether the claimer has claimed the revenue tokens at a given snapshot
-    /// @param snapshotId The snapshot id
-    /// @param claimer The address of the claimer
-    /// @param token The address of the revenue token
-    function isClaimedAtSnapshot(uint256 snapshotId, address claimer, address token) external view returns (bool);
 
     /// @notice The list of revenue tokens in the vault
     function tokens() external view returns (address[] memory);

--- a/contracts/interfaces/modules/royalty/policies/IIpRoyaltyVault.sol
+++ b/contracts/interfaces/modules/royalty/policies/IIpRoyaltyVault.sol
@@ -65,4 +65,16 @@ interface IIpRoyaltyVault {
 
     /// @notice The list of revenue tokens in the vault
     function tokens() external view returns (address[] memory);
+
+    /// @notice The accumulated balance of revenue tokens in the vault
+    /// @param token The revenue token to check
+    /// @return The accumulated balance of revenue tokens in the vault
+    function vaultAccBalances(address token) external view returns (uint256);
+
+    /// @notice The revenue debt of the claimer, used to calculate the claimable revenue
+    /// positive value means claimed need to deducted, negative value means claimable from vault
+    /// @param claimer The address of the claimer
+    /// @param token The revenue token to check
+    /// @return The revenue debt of the claimer
+    function claimerRevenueDebt(address claimer, address token) external view returns (int256);
 }

--- a/contracts/interfaces/modules/royalty/policies/IIpRoyaltyVault.sol
+++ b/contracts/interfaces/modules/royalty/policies/IIpRoyaltyVault.sol
@@ -35,18 +35,18 @@ interface IIpRoyaltyVault {
     function updateVaultBalance(address token, uint256 amount) external;
 
     /// @notice Allows token holders to claim revenue token
-    /// @param token The revenue tokens to claim
     /// @param claimer The address of the claimer
+    /// @param token The revenue tokens to claim
     /// @return The amount of revenue tokens claimed
-    function claimRevenueOnBehalf(address token, address claimer) external returns (uint256);
+    function claimRevenueOnBehalf(address claimer, address token) external returns (uint256);
 
     /// @notice Allows token holders to claim a batch of revenue tokens
-    /// @param tokenList The list of revenue tokens to claim
     /// @param claimer The address of the claimer
+    /// @param tokenList The list of revenue tokens to claim
     /// @return The amount of revenue tokens claimed of each token
     function claimRevenueOnBehalfByTokenBatch(
-        address[] calldata tokenList,
-        address claimer
+        address claimer,
+        address[] calldata tokenList
     ) external returns (uint256[] memory);
 
     /// @notice Allows to claim revenue tokens on behalf of the ip royalty vault

--- a/contracts/interfaces/modules/royalty/policies/IIpRoyaltyVault.sol
+++ b/contracts/interfaces/modules/royalty/policies/IIpRoyaltyVault.sol
@@ -75,6 +75,6 @@ interface IIpRoyaltyVault {
     /// positive value means claimed need to deducted, negative value means claimable from vault
     /// @param claimer The address of the claimer
     /// @param token The revenue token to check
-    /// @return The revenue debt of the claimer
-    function claimerRevenueDebt(address claimer, address token) external view returns (int256);
+    /// @return The revenue debt of the claimer for the token
+    function revenueDebt(address claimer, address token) external view returns (int256);
 }

--- a/contracts/interfaces/modules/royalty/policies/IIpRoyaltyVault.sol
+++ b/contracts/interfaces/modules/royalty/policies/IIpRoyaltyVault.sol
@@ -34,15 +34,11 @@ interface IIpRoyaltyVault {
     /// @dev Only callable by the royalty module or whitelisted royalty policy
     function updateVaultBalance(address token, uint256 amount) external;
 
-
     /// @notice Allows token holders to claim revenue token
     /// @param token The revenue tokens to claim
     /// @param claimer The address of the claimer
     /// @return The amount of revenue tokens claimed
-    function claimRevenueOnBehalf(
-        address token,
-        address claimer
-    ) external returns (uint256);
+    function claimRevenueOnBehalf(address token, address claimer) external returns (uint256);
 
     /// @notice Allows token holders to claim a batch of revenue tokens
     /// @param tokenList The list of revenue tokens to claim

--- a/contracts/interfaces/modules/royalty/policies/IVaultController.sol
+++ b/contracts/interfaces/modules/royalty/policies/IVaultController.sol
@@ -3,10 +3,6 @@ pragma solidity 0.8.26;
 
 /// @title VaultController interface
 interface IVaultController {
-    /// @dev Set the snapshot interval
-    /// @dev Enforced to be only callable by the protocol admin in governance
-    /// @param timestampInterval The minimum timestamp interval between snapshots
-    function setSnapshotInterval(uint256 timestampInterval) external;
 
     /// @dev Set the ip royalty vault beacon
     /// @dev Enforced to be only callable by the protocol admin in governance
@@ -17,10 +13,6 @@ interface IVaultController {
     /// @dev Enforced to be only callable by the upgrader admin
     /// @param newVault The new ip royalty vault beacon address
     function upgradeVaults(address newVault) external;
-
-    /// @notice Returns the snapshot interval
-    /// @return snapshotInterval The minimum time interval between snapshots
-    function snapshotInterval() external view returns (uint256);
 
     /// @notice Returns the ip royalty vault beacon
     /// @return ipRoyaltyVaultBeacon The ip royalty vault beacon address

--- a/contracts/interfaces/modules/royalty/policies/IVaultController.sol
+++ b/contracts/interfaces/modules/royalty/policies/IVaultController.sol
@@ -3,7 +3,6 @@ pragma solidity 0.8.26;
 
 /// @title VaultController interface
 interface IVaultController {
-
     /// @dev Set the ip royalty vault beacon
     /// @dev Enforced to be only callable by the protocol admin in governance
     /// @param beacon The ip royalty vault beacon address

--- a/contracts/lib/Errors.sol
+++ b/contracts/lib/Errors.sol
@@ -669,12 +669,6 @@ library Errors {
     /// @notice Caller is not Royalty Module.
     error IpRoyaltyVault__NotAllowedToAddTokenToVault();
 
-    /// @notice Wait for the interval to pass for the next snapshot.
-    error IpRoyaltyVault__InsufficientTimeElapsedSinceLastSnapshot();
-
-    /// @notice No new revenue since the last snapshot.
-    error IpRoyaltyVault__NoNewRevenueSinceLastSnapshot();
-
     /// @notice There is no ip royalty vault for the provided IP.
     error IpRoyaltyVault__InvalidTargetIpId();
 

--- a/contracts/lib/Errors.sol
+++ b/contracts/lib/Errors.sol
@@ -699,9 +699,14 @@ library Errors {
     /// @notice Group reward pool must claim via GroupingModule.
     error IpRoyaltyVault__GroupPoolMustClaimViaGroupingModule();
 
-    error IpRoyaltyVault__ZeroBalance(address token, address account);
+    /// @notice Zero balance.
+    error IpRoyaltyVault__ZeroBalance(address vault, address account);
 
-    error IpRoyaltyVault__InsufficientBalance(address token, address account, uint256 amount);
+    /// @notice Insufficient balance.
+    error IpRoyaltyVault__InsufficientBalance(address vault, address account, uint256 amount);
+
+    /// @notice Same from and to address.
+    error IpRoyaltyVault__SameFromToAddress(address vault, address from);
     ////////////////////////////////////////////////////////////////////////////
     //                            Vault Controller                            //
     ////////////////////////////////////////////////////////////////////////////

--- a/contracts/lib/Errors.sol
+++ b/contracts/lib/Errors.sol
@@ -699,6 +699,9 @@ library Errors {
     /// @notice Group reward pool must claim via GroupingModule.
     error IpRoyaltyVault__GroupPoolMustClaimViaGroupingModule();
 
+    error IpRoyaltyVault__ZeroBalance(address token, address account);
+
+    error IpRoyaltyVault__InsufficientBalance(address token, address account, uint256 amount);
     ////////////////////////////////////////////////////////////////////////////
     //                            Vault Controller                            //
     ////////////////////////////////////////////////////////////////////////////

--- a/contracts/modules/grouping/GroupingModule.sol
+++ b/contracts/modules/grouping/GroupingModule.sol
@@ -201,20 +201,17 @@ contract GroupingModule is
     /// @notice Collects royalties into the pool, making them claimable by group member IPs.
     /// @param groupId The address of the group.
     /// @param token The address of the token.
-    /// @param snapshotIds The snapshot IDs of the royalty vault for the given group to collect royalties.
     function collectRoyalties(
         address groupId,
-        address token,
-        uint256[] calldata snapshotIds
+        address token
     ) external whenNotPaused returns (uint256 royalties) {
         IGroupRewardPool pool = IGroupRewardPool(GROUP_IP_ASSET_REGISTRY.getGroupRewardPool(groupId));
         IIpRoyaltyVault vault = IIpRoyaltyVault(ROYALTY_MODULE.ipRoyaltyVaults(groupId));
 
         if (address(vault) == address(0)) revert Errors.GroupingModule__GroupRoyaltyVaultNotCreated(groupId);
-
-        royalties = vault.claimRevenueOnBehalfBySnapshotBatch(snapshotIds, token, address(pool));
+        royalties = vault.claimRevenueOnBehalf(token, address(pool));
         pool.depositReward(groupId, token, royalties);
-        emit CollectedRoyaltiesToGroupPool(groupId, token, address(pool), royalties, snapshotIds);
+        emit CollectedRoyaltiesToGroupPool(groupId, token, address(pool), royalties);
     }
 
     function name() external pure override returns (string memory) {

--- a/contracts/modules/grouping/GroupingModule.sol
+++ b/contracts/modules/grouping/GroupingModule.sol
@@ -201,10 +201,7 @@ contract GroupingModule is
     /// @notice Collects royalties into the pool, making them claimable by group member IPs.
     /// @param groupId The address of the group.
     /// @param token The address of the token.
-    function collectRoyalties(
-        address groupId,
-        address token
-    ) external whenNotPaused returns (uint256 royalties) {
+    function collectRoyalties(address groupId, address token) external whenNotPaused returns (uint256 royalties) {
         IGroupRewardPool pool = IGroupRewardPool(GROUP_IP_ASSET_REGISTRY.getGroupRewardPool(groupId));
         IIpRoyaltyVault vault = IIpRoyaltyVault(ROYALTY_MODULE.ipRoyaltyVaults(groupId));
 

--- a/contracts/modules/grouping/GroupingModule.sol
+++ b/contracts/modules/grouping/GroupingModule.sol
@@ -206,7 +206,7 @@ contract GroupingModule is
         IIpRoyaltyVault vault = IIpRoyaltyVault(ROYALTY_MODULE.ipRoyaltyVaults(groupId));
 
         if (address(vault) == address(0)) revert Errors.GroupingModule__GroupRoyaltyVaultNotCreated(groupId);
-        royalties = vault.claimRevenueOnBehalf(token, address(pool));
+        royalties = vault.claimRevenueOnBehalf(address(pool), token);
         pool.depositReward(groupId, token, royalties);
         emit CollectedRoyaltiesToGroupPool(groupId, token, address(pool), royalties);
     }

--- a/contracts/modules/royalty/policies/IpRoyaltyVault.sol
+++ b/contracts/modules/royalty/policies/IpRoyaltyVault.sol
@@ -11,7 +11,6 @@ import { ERC20SnapshotUpgradeable } from "@openzeppelin/contracts-upgradeable-v4
 import { SafeERC20Upgradeable } from "@openzeppelin/contracts-upgradeable-v4/token/ERC20/utils/SafeERC20Upgradeable.sol";
 import { IERC20Upgradeable } from "@openzeppelin/contracts-upgradeable-v4/token/ERC20/IERC20Upgradeable.sol";
 
-import { IVaultController } from "../../../interfaces/modules/royalty/policies/IVaultController.sol";
 import { IDisputeModule } from "../../../interfaces/modules/dispute/IDisputeModule.sol";
 import { IRoyaltyModule } from "../../../interfaces/modules/royalty/IRoyaltyModule.sol";
 import { IIpRoyaltyVault } from "../../../interfaces/modules/royalty/policies/IIpRoyaltyVault.sol";
@@ -34,7 +33,7 @@ contract IpRoyaltyVault is IIpRoyaltyVault, ERC20SnapshotUpgradeable, Reentrancy
     /// @param pendingVaultAmount [DEPRECATED] Amount of revenue token pending to be snapshotted
     /// @param claimVaultAmount [DEPRECATED] Amount of revenue token in the claim vault
     /// @param claimableAtSnapshot [DEPRECATED] Amount of revenue token claimable at a given snapshot
-    /// @param isClaimedAtSnapshot [DEPRECATED] Indicates whether the claimer has claimed the revenue tokens at a given snapshot
+    /// @param isClaimedAtSnapshot [DEPRECATED] Indicates whether the claimer has claimed the token at a given snapshot
     /// @param tokens The list of revenue tokens in the vault
     /// @param poolInfo The accumulated balance of revenue tokens in the vault
     /// @param claimerInfo The revenue debt of the claimer
@@ -161,14 +160,10 @@ contract IpRoyaltyVault is IIpRoyaltyVault, ERC20SnapshotUpgradeable, Reentrancy
         return _claimRevenueOnBehalf(tokenList, claimer);
     }
 
-
     /// @notice Allows to claim revenue tokens on behalf of the ip royalty vault
     /// @param tokenList The list of revenue tokens to claim
     /// @param targetIpId The target ip id to claim revenue tokens from
-    function claimByTokenBatchAsSelf(
-        address[] calldata tokenList,
-        address targetIpId
-    ) external whenNotPaused {
+    function claimByTokenBatchAsSelf(address[] calldata tokenList, address targetIpId) external whenNotPaused {
         address targetIpVault = ROYALTY_MODULE.ipRoyaltyVaults(targetIpId);
         if (targetIpVault == address(0)) revert Errors.IpRoyaltyVault__InvalidTargetIpId();
 
@@ -253,10 +248,7 @@ contract IpRoyaltyVault is IIpRoyaltyVault, ERC20SnapshotUpgradeable, Reentrancy
         }
     }
 
-    function _claimRevenueOnBehalf(
-        address[] memory tokenList,
-        address claimer
-    ) internal returns (uint256[] memory) {
+    function _claimRevenueOnBehalf(address[] memory tokenList, address claimer) internal returns (uint256[] memory) {
         IpRoyaltyVaultStorage storage $ = _getIpRoyaltyVaultStorage();
 
         if (ROYALTY_MODULE.isIpRoyaltyVault(claimer) && msg.sender != claimer)

--- a/contracts/modules/royalty/policies/IpRoyaltyVault.sol
+++ b/contracts/modules/royalty/policies/IpRoyaltyVault.sol
@@ -207,7 +207,7 @@ contract IpRoyaltyVault is IIpRoyaltyVault, ERC20Upgradeable, ReentrancyGuardUpg
     /// @param claimer The address of the claimer
     /// @param token The revenue token to check
     /// @return The revenue debt of the claimer
-    function claimerRevenueDebt(address claimer, address token) external view returns (int256) {
+    function revenueDebt(address claimer, address token) external view returns (int256) {
         return _getIpRoyaltyVaultStorage().claimerRevenueDebt[token][claimer];
     }
 

--- a/contracts/modules/royalty/policies/IpRoyaltyVault.sol
+++ b/contracts/modules/royalty/policies/IpRoyaltyVault.sol
@@ -45,7 +45,7 @@ contract IpRoyaltyVault is IIpRoyaltyVault, ERC20Upgradeable, ReentrancyGuardUpg
         mapping(uint256 snapshotId => mapping(address claimer => mapping(address token => bool))) isClaimedAtSnapshot;
         EnumerableSet.AddressSet tokens;
         mapping(address token => uint256 accBalance) vaultAccBalances;
-        mapping(address token => mapping(address claimer => int256 revenueDebt)) claimerRevenueDebt;
+        mapping(address token => mapping(address claimer => int256 revenueDebt)) revenueDebt;
     }
 
     // keccak256(abi.encode(uint256(keccak256("story-protocol.IpRoyaltyVault")) - 1)) & ~bytes32(uint256(0xff));
@@ -208,7 +208,7 @@ contract IpRoyaltyVault is IIpRoyaltyVault, ERC20Upgradeable, ReentrancyGuardUpg
     /// @param token The revenue token to check
     /// @return The revenue debt of the claimer
     function revenueDebt(address claimer, address token) external view returns (int256) {
-        return _getIpRoyaltyVaultStorage().claimerRevenueDebt[token][claimer];
+        return _getIpRoyaltyVaultStorage().revenueDebt[token][claimer];
     }
 
     /// @notice Returns list of revenue tokens in the vault
@@ -253,10 +253,10 @@ contract IpRoyaltyVault is IIpRoyaltyVault, ERC20Upgradeable, ReentrancyGuardUpg
             uint256 pendingFrom = _claimableRevenue(from, tokenList[i]);
             uint256 pendingTo = _claimableRevenue(to, tokenList[i]);
             uint256 accBalance = $.vaultAccBalances[tokenList[i]];
-            $.claimerRevenueDebt[tokenList[i]][to] =
+            $.revenueDebt[tokenList[i]][to] =
                 int256((accBalance * (balanceOf(to) + amount)) / totalSupply) -
                 int256(pendingTo);
-            $.claimerRevenueDebt[tokenList[i]][from] =
+            $.revenueDebt[tokenList[i]][from] =
                 int256((accBalance * (balanceOfFrom - amount)) / totalSupply) -
                 int256(pendingFrom);
         }
@@ -293,7 +293,7 @@ contract IpRoyaltyVault is IIpRoyaltyVault, ERC20Upgradeable, ReentrancyGuardUpg
         for (uint256 i = 0; i < tokenList.length; i++) {
             claimedAmounts[i] = _claimPendingRevenue(claimer, tokenList[i]);
             if (claimedAmounts[i] == 0) revert Errors.IpRoyaltyVault__NoClaimableTokens();
-            $.claimerRevenueDebt[tokenList[i]][claimer] += int256(claimedAmounts[i]);
+            $.revenueDebt[tokenList[i]][claimer] += int256(claimedAmounts[i]);
         }
 
         return claimedAmounts;
@@ -312,7 +312,7 @@ contract IpRoyaltyVault is IIpRoyaltyVault, ERC20Upgradeable, ReentrancyGuardUpg
         IpRoyaltyVaultStorage storage $ = _getIpRoyaltyVaultStorage();
         uint256 accBalance = $.vaultAccBalances[token];
         uint256 userAmount = balanceOf(claimer);
-        int256 rewardDebt = $.claimerRevenueDebt[token][claimer];
+        int256 rewardDebt = $.revenueDebt[token][claimer];
         return uint256(int256((accBalance * userAmount) / totalSupply()) - rewardDebt);
     }
 

--- a/contracts/modules/royalty/policies/IpRoyaltyVault.sol
+++ b/contracts/modules/royalty/policies/IpRoyaltyVault.sol
@@ -264,7 +264,6 @@ contract IpRoyaltyVault is IIpRoyaltyVault, ERC20Upgradeable, ReentrancyGuardUpg
             claimedAmounts[i] = _clearPendingRewards(claimer, tokenList[i]);
             if (claimedAmounts[i] == 0) revert Errors.IpRoyaltyVault__NoClaimableTokens();
             $.claimerInfo[tokenList[i]][claimer] += claimedAmounts[i];
-
         }
 
         return claimedAmounts;

--- a/contracts/modules/royalty/policies/IpRoyaltyVault.sol
+++ b/contracts/modules/royalty/policies/IpRoyaltyVault.sol
@@ -185,6 +185,8 @@ contract IpRoyaltyVault is IIpRoyaltyVault, ERC20Upgradeable, ReentrancyGuardUpg
     /// @param token The revenue token to claim
     /// @return The amount of revenue token claimable
     function claimableRevenue(address claimer, address token) external view whenNotPaused returns (uint256) {
+        // if the ip is tagged, then the unclaimed royalties are unavailable until the dispute is resolved
+        if (DISPUTE_MODULE.isIpTagged(_getIpRoyaltyVaultStorage().ipId)) return 0;
         return _claimableRevenue(claimer, token);
     }
 
@@ -247,6 +249,8 @@ contract IpRoyaltyVault is IIpRoyaltyVault, ERC20Upgradeable, ReentrancyGuardUpg
     }
 
     function _clearPendingRewards(address claimer, address token) internal returns (uint256 pending) {
+        // if the ip is tagged, then the unclaimed royalties are unavailable until the dispute is resolved
+        if (DISPUTE_MODULE.isIpTagged(_getIpRoyaltyVaultStorage().ipId)) return 0;
         pending = _claimableRevenue(claimer, token);
         if (pending > 0) {
             emit RevenueTokenClaimed(claimer, token, pending);

--- a/contracts/modules/royalty/policies/IpRoyaltyVault.sol
+++ b/contracts/modules/royalty/policies/IpRoyaltyVault.sol
@@ -235,11 +235,12 @@ contract IpRoyaltyVault is IIpRoyaltyVault, ERC20Upgradeable, ReentrancyGuardUpg
         for (uint256 i = 0; i < tokenList.length; i++) {
             uint256 pendingFrom = _claimableRevenue(from, tokenList[i]);
             uint256 pendingTo = _claimableRevenue(to, tokenList[i]);
+            uint256 accBalance = $.poolInfo[tokenList[i]];
             $.claimerInfo[tokenList[i]][to] =
-                int256(($.poolInfo[tokenList[i]] * (balanceOf(to) + amount)) / totalSupply) -
+                int256((accBalance * (balanceOf(to) + amount)) / totalSupply) -
                 int256(pendingTo);
             $.claimerInfo[tokenList[i]][from] =
-                int256(($.poolInfo[tokenList[i]] * (balanceOfFrom - amount)) / totalSupply) -
+                int256((accBalance * (balanceOfFrom - amount)) / totalSupply) -
                 int256(pendingFrom);
         }
 

--- a/contracts/modules/royalty/policies/IpRoyaltyVault.sol
+++ b/contracts/modules/royalty/policies/IpRoyaltyVault.sol
@@ -21,21 +21,23 @@ import { Errors } from "../../../lib/Errors.sol";
 /// @title Ip Royalty Vault
 /// @notice Defines the logic for claiming revenue tokens for a given IP
 /// @dev [CAUTION]
-///      Do not transfer ERC20 tokens directly to the ip royalty vault as they can be lost if the pendingVaultAmount
+///      Do not transfer ERC20 tokens directly to the ip royalty vault as they can be lost if the poolInfo
 ///      is not updated along with an ERC20 transfer.
-///      Use appropriate callpaths that can update the pendingVaultAmount when an ERC20 transfer to the vault is made.
+///      Use appropriate callpaths that can update the poolInfo when an ERC20 transfer to the vault is made.
 contract IpRoyaltyVault is IIpRoyaltyVault, ERC20SnapshotUpgradeable, ReentrancyGuardUpgradeable {
     using EnumerableSet for EnumerableSet.AddressSet;
     using SafeERC20Upgradeable for IERC20Upgradeable;
 
     /// @dev Storage structure for the IpRoyaltyVault
     /// @param ipId The ip id to whom this royalty vault belongs to
-    /// @param lastSnapshotTimestamp The last snapshotted timestamp
-    /// @param pendingVaultAmount Amount of revenue token pending to be snapshotted
-    /// @param claimVaultAmount Amount of revenue token in the claim vault
-    /// @param claimableAtSnapshot Amount of revenue token claimable at a given snapshot
-    /// @param isClaimedAtSnapshot Indicates whether the claimer has claimed the revenue tokens at a given snapshot
+    /// @param lastSnapshotTimestamp [DEPRECATED] The last snapshotted timestamp
+    /// @param pendingVaultAmount [DEPRECATED] Amount of revenue token pending to be snapshotted
+    /// @param claimVaultAmount [DEPRECATED] Amount of revenue token in the claim vault
+    /// @param claimableAtSnapshot [DEPRECATED] Amount of revenue token claimable at a given snapshot
+    /// @param isClaimedAtSnapshot [DEPRECATED] Indicates whether the claimer has claimed the revenue tokens at a given snapshot
     /// @param tokens The list of revenue tokens in the vault
+    /// @param poolInfo The accumulated balance of revenue tokens in the vault
+    /// @param claimerInfo The revenue debt of the claimer
     /// @custom:storage-location erc7201:story-protocol.IpRoyaltyVault
     struct IpRoyaltyVaultStorage {
         address ipId;
@@ -45,10 +47,8 @@ contract IpRoyaltyVault is IIpRoyaltyVault, ERC20SnapshotUpgradeable, Reentrancy
         mapping(uint256 snapshotId => mapping(address token => uint256 amount)) claimableAtSnapshot;
         mapping(uint256 snapshotId => mapping(address claimer => mapping(address token => bool))) isClaimedAtSnapshot;
         EnumerableSet.AddressSet tokens;
-        // Info of each token pool. token => PoolInfo
         mapping(address token => uint256 accBalance) poolInfo;
-        // Info of each user of a token. token => { user => UserRewardInfo }
-        mapping(address token => mapping(address user => uint256 rewardDebt)) userRewardInfo;
+        mapping(address token => mapping(address claimer => uint256 revenueDebt)) claimerInfo;
     }
 
     // keccak256(abi.encode(uint256(keccak256("story-protocol.IpRoyaltyVault")) - 1)) & ~bytes32(uint256(0xff));
@@ -137,129 +137,35 @@ contract IpRoyaltyVault is IIpRoyaltyVault, ERC20SnapshotUpgradeable, Reentrancy
         _updateVaultBalance(token, amount);
     }
 
-    /// @notice Snapshots the claimable revenue and royalty token amounts
-    /// @return The snapshot id
-    function snapshot() external whenNotPaused returns (uint256) {
-        IpRoyaltyVaultStorage storage $ = _getIpRoyaltyVaultStorage();
-
-        if (block.timestamp - $.lastSnapshotTimestamp < IVaultController(address(ROYALTY_MODULE)).snapshotInterval())
-            revert Errors.IpRoyaltyVault__InsufficientTimeElapsedSinceLastSnapshot();
-
-        uint256 snapshotId = _snapshot();
-        $.lastSnapshotTimestamp = uint40(block.timestamp);
-
-        uint256 noRevenueCounter;
-        address[] memory tokenList = $.tokens.values();
-        for (uint256 i = 0; i < tokenList.length; i++) {
-            if (IERC20Upgradeable(tokenList[i]).balanceOf(address(this)) == 0) {
-                $.tokens.remove(tokenList[i]);
-                continue;
-            }
-
-            uint256 newRevenue = $.pendingVaultAmount[tokenList[i]];
-            if (newRevenue == 0) {
-                noRevenueCounter++;
-                continue;
-            }
-
-            $.claimableAtSnapshot[snapshotId][tokenList[i]] = newRevenue;
-            $.claimVaultAmount[tokenList[i]] += newRevenue;
-            $.pendingVaultAmount[tokenList[i]] = 0;
-        }
-
-        if (noRevenueCounter == tokenList.length) revert Errors.IpRoyaltyVault__NoNewRevenueSinceLastSnapshot();
-
-        emit SnapshotCompleted(snapshotId, block.timestamp);
-
-        return snapshotId;
-    }
-
-    /// @notice Calculates the amount of revenue token claimable by a token holder at certain snapshot
-    /// @param account The address of the token holder
-    /// @param snapshotId The snapshot id
-    /// @param token The revenue token to claim
-    /// @return The amount of revenue token claimable
-    function claimableRevenue(
-        address account,
-        uint256 snapshotId,
-        address token
-    ) external view whenNotPaused returns (uint256) {
-        return _claimableRevenue(account, snapshotId, token);
-    }
-
-    /// @notice Allows token holders to claim revenue token based on the token balance at certain snapshot
-    /// @param snapshotId The snapshot id
-    /// @param tokenList The list of revenue tokens to claim
-    /// @param claimer The address of the claimer
-    /// @return The amount of revenue tokens claimed for each token
-    function claimRevenueOnBehalfByTokenBatch(
-        uint256 snapshotId,
-        address[] calldata tokenList,
-        address claimer
-    ) external nonReentrant whenNotPaused returns (uint256[] memory) {
-        IpRoyaltyVaultStorage storage $ = _getIpRoyaltyVaultStorage();
-
-        if (ROYALTY_MODULE.isIpRoyaltyVault(claimer) && msg.sender != claimer)
-            revert Errors.IpRoyaltyVault__VaultsMustClaimAsSelf();
-
-        if (IP_ASSET_REGISTRY.isWhitelistedGroupRewardPool(claimer) && msg.sender != GROUPING_MODULE)
-            revert Errors.IpRoyaltyVault__GroupPoolMustClaimViaGroupingModule();
-
-        uint256[] memory claimableAmounts = new uint256[](tokenList.length);
-        for (uint256 i = 0; i < tokenList.length; i++) {
-            claimableAmounts[i] = _claimableRevenue(claimer, snapshotId, tokenList[i]);
-            if (claimableAmounts[i] == 0) revert Errors.IpRoyaltyVault__NoClaimableTokens();
-
-            $.isClaimedAtSnapshot[snapshotId][claimer][tokenList[i]] = true;
-            $.claimVaultAmount[tokenList[i]] -= claimableAmounts[i];
-            IERC20Upgradeable(tokenList[i]).safeTransfer(claimer, claimableAmounts[i]);
-
-            emit RevenueTokenClaimed(claimer, tokenList[i], claimableAmounts[i]);
-        }
-
-        return claimableAmounts;
-    }
-
-    /// @notice Allows token holders to claim by a list of snapshot ids based on the token balance at certain snapshot
-    /// @param snapshotIds The list of snapshot ids
-    /// @param token The revenue token to claim
+    /// @notice Allows token holders to claim revenue token
+    /// @param token The revenue tokens to claim
     /// @param claimer The address of the claimer
     /// @return The amount of revenue tokens claimed
-    function claimRevenueOnBehalfBySnapshotBatch(
-        uint256[] memory snapshotIds,
+    function claimRevenueOnBehalf(
         address token,
         address claimer
     ) external nonReentrant whenNotPaused returns (uint256) {
-        IpRoyaltyVaultStorage storage $ = _getIpRoyaltyVaultStorage();
-
-        if (ROYALTY_MODULE.isIpRoyaltyVault(claimer) && msg.sender != claimer)
-            revert Errors.IpRoyaltyVault__VaultsMustClaimAsSelf();
-
-        if (IP_ASSET_REGISTRY.isWhitelistedGroupRewardPool(claimer) && msg.sender != GROUPING_MODULE)
-            revert Errors.IpRoyaltyVault__GroupPoolMustClaimViaGroupingModule();
-
-        uint256 claimableAmount;
-        for (uint256 i = 0; i < snapshotIds.length; i++) {
-            claimableAmount += _claimableRevenue(claimer, snapshotIds[i], token);
-            $.isClaimedAtSnapshot[snapshotIds[i]][claimer][token] = true;
-        }
-
-        if (claimableAmount == 0) revert Errors.IpRoyaltyVault__NoClaimableTokens();
-
-        $.claimVaultAmount[token] -= claimableAmount;
-        IERC20Upgradeable(token).safeTransfer(claimer, claimableAmount);
-
-        emit RevenueTokenClaimed(claimer, token, claimableAmount);
-
-        return claimableAmount;
+        address[] memory tokenList = new address[](1);
+        tokenList[0] = token;
+        return _claimRevenueOnBehalf(tokenList, claimer)[0];
     }
 
-    /// @notice Allows to claim revenue tokens on behalf of the ip royalty vault by token batch
-    /// @param snapshotId The snapshot id
+    /// @notice Allows token holders to claim a batch of revenue tokens
+    /// @param tokenList The list of revenue tokens to claim
+    /// @param claimer The address of the claimer
+    /// @return The amount of revenue tokens claimed of each token
+    function claimRevenueOnBehalfByTokenBatch(
+        address[] calldata tokenList,
+        address claimer
+    ) external nonReentrant whenNotPaused returns (uint256[] memory) {
+        return _claimRevenueOnBehalf(tokenList, claimer);
+    }
+
+
+    /// @notice Allows to claim revenue tokens on behalf of the ip royalty vault
     /// @param tokenList The list of revenue tokens to claim
     /// @param targetIpId The target ip id to claim revenue tokens from
     function claimByTokenBatchAsSelf(
-        uint256 snapshotId,
         address[] calldata tokenList,
         address targetIpId
     ) external whenNotPaused {
@@ -273,7 +179,6 @@ contract IpRoyaltyVault is IIpRoyaltyVault, ERC20SnapshotUpgradeable, Reentrancy
             revert Errors.IpRoyaltyVault__VaultDoesNotBelongToAnAncestor();
 
         uint256[] memory claimedAmounts = IIpRoyaltyVault(targetIpVault).claimRevenueOnBehalfByTokenBatch(
-            snapshotId,
             tokenList,
             address(this)
         );
@@ -284,38 +189,12 @@ contract IpRoyaltyVault is IIpRoyaltyVault, ERC20SnapshotUpgradeable, Reentrancy
         }
     }
 
-    /// @notice Allows to claim revenue tokens on behalf of the ip royalty vault by snapshot batch
-    /// @param snapshotIds The list of snapshot ids
+    /// @notice Get total amount of revenue token claimable by a token holder
+    /// @param claimer The address of the token holder
     /// @param token The revenue token to claim
-    /// @param targetIpId The target ip id to claim revenue tokens from
-    function claimBySnapshotBatchAsSelf(
-        uint256[] memory snapshotIds,
-        address token,
-        address targetIpId
-    ) external whenNotPaused {
-        address targetIpVault = ROYALTY_MODULE.ipRoyaltyVaults(targetIpId);
-        if (targetIpVault == address(0)) revert Errors.IpRoyaltyVault__InvalidTargetIpId();
-
-        // ensures that the target ipId is from a descendant ip which in turn ensures that
-        // all accumulated royalty policies from the ancestor ip have been checked when
-        // a payment was made to said descendant ip
-        if (!ROYALTY_MODULE.hasAncestorIp(targetIpId, _getIpRoyaltyVaultStorage().ipId))
-            revert Errors.IpRoyaltyVault__VaultDoesNotBelongToAnAncestor();
-
-        uint256 claimedAmount = IIpRoyaltyVault(targetIpVault).claimRevenueOnBehalfBySnapshotBatch(
-            snapshotIds,
-            token,
-            address(this)
-        );
-
-        // the token will be added to the vault only if claimable revenue is higher than zero
-        _updateVaultBalance(token, claimedAmount);
-    }
-
-    /// @notice Returns the current snapshot id
-    /// @return The snapshot id
-    function getCurrentSnapshotId() external view returns (uint256) {
-        return _getCurrentSnapshotId();
+    /// @return The amount of revenue token claimable
+    function claimableRevenue(address claimer, address token) external view whenNotPaused returns (uint256) {
+        return _claimableRevenue(claimer, token);
     }
 
     /// @notice The ip id to whom this royalty vault belongs to
@@ -323,58 +202,9 @@ contract IpRoyaltyVault is IIpRoyaltyVault, ERC20SnapshotUpgradeable, Reentrancy
         return _getIpRoyaltyVaultStorage().ipId;
     }
 
-    /// @notice The last snapshotted timestamp
-    function lastSnapshotTimestamp() external view returns (uint256) {
-        return _getIpRoyaltyVaultStorage().lastSnapshotTimestamp;
-    }
-
-    /// @notice Amount of revenue token pending to be snapshotted
-    /// @param token The address of the revenue token
-    function pendingVaultAmount(address token) external view returns (uint256) {
-        return _getIpRoyaltyVaultStorage().pendingVaultAmount[token];
-    }
-
-    /// @notice Amount of revenue token in the claim vault
-    /// @param token The address of the revenue token
-    function claimVaultAmount(address token) external view returns (uint256) {
-        return _getIpRoyaltyVaultStorage().claimVaultAmount[token];
-    }
-
-    /// @notice Amount of revenue token claimable at a given snapshot
-    /// @param snapshotId The snapshot id
-    /// @param token The address of the revenue token
-    function claimableAtSnapshot(uint256 snapshotId, address token) external view returns (uint256) {
-        return _getIpRoyaltyVaultStorage().claimableAtSnapshot[snapshotId][token];
-    }
-
-    /// @notice Indicates whether the claimer has claimed the revenue tokens at a given snapshot
-    /// @param snapshotId The snapshot id
-    /// @param claimer The address of the claimer
-    /// @param token The address of the revenue token
-    function isClaimedAtSnapshot(uint256 snapshotId, address claimer, address token) external view returns (bool) {
-        return _getIpRoyaltyVaultStorage().isClaimedAtSnapshot[snapshotId][claimer][token];
-    }
-
     /// @notice Returns list of revenue tokens in the vault
     function tokens() external view returns (address[] memory) {
         return (_getIpRoyaltyVaultStorage().tokens).values();
-    }
-
-    /// @notice A function to calculate the amount of revenue token claimable by a token holder at certain snapshot
-    /// @param account The address of the token holder
-    /// @param snapshotId The snapshot id
-    /// @param token The revenue token to claim
-    /// @return The amount of revenue token claimable
-    function _claimableRevenue(address account, uint256 snapshotId, address token) internal view returns (uint256) {
-        IpRoyaltyVaultStorage storage $ = _getIpRoyaltyVaultStorage();
-
-        // if the ip is tagged, then the unclaimed royalties are unavailable until the dispute is resolved
-        if (DISPUTE_MODULE.isIpTagged($.ipId)) return 0;
-
-        uint256 balance = balanceOfAt(account, snapshotId);
-        uint256 totalSupply = totalSupplyAt(snapshotId);
-        uint256 claimableToken = $.claimableAtSnapshot[snapshotId][token];
-        return $.isClaimedAtSnapshot[snapshotId][account][token] ? 0 : (balance * claimableToken) / totalSupply;
     }
 
     /// @notice Adds a new revenue token to the vault
@@ -387,47 +217,9 @@ contract IpRoyaltyVault is IIpRoyaltyVault, ERC20SnapshotUpgradeable, Reentrancy
         if (amount == 0) revert Errors.IpRoyaltyVault__ZeroAmount();
 
         $.tokens.add(token);
-        $.pendingVaultAmount[token] += amount;
         $.poolInfo[token] += amount;
 
         emit RevenueTokenAddedToVault(token, amount);
-    }
-
-    /// @dev Returns the storage struct of IpRoyaltyVault
-    function _getIpRoyaltyVaultStorage() private pure returns (IpRoyaltyVaultStorage storage $) {
-        assembly {
-            $.slot := IpRoyaltyVaultStorageLocation
-        }
-    }
-
-    function claimRevenueOnBehalfByTokenBatch(
-        address[] calldata tokenList,
-        address claimer
-    ) external nonReentrant whenNotPaused returns (uint256[] memory) {
-        IpRoyaltyVaultStorage storage $ = _getIpRoyaltyVaultStorage();
-
-        if (ROYALTY_MODULE.isIpRoyaltyVault(claimer) && msg.sender != claimer)
-            revert Errors.IpRoyaltyVault__VaultsMustClaimAsSelf();
-
-        if (IP_ASSET_REGISTRY.isWhitelistedGroupRewardPool(claimer) && msg.sender != GROUPING_MODULE)
-            revert Errors.IpRoyaltyVault__GroupPoolMustClaimViaGroupingModule();
-
-        uint256[] memory claimableAmounts = new uint256[](tokenList.length);
-        for (uint256 i = 0; i < tokenList.length; i++) {
-            claimableAmounts[i] = _clearPendingRewards(claimer, tokenList[i]);
-            if (claimableAmounts[i] == 0) revert Errors.IpRoyaltyVault__NoClaimableTokens();
-            $.userRewardInfo[tokenList[i]][claimer] += claimableAmounts[i];
-
-            $.claimVaultAmount[tokenList[i]] -= claimableAmounts[i];
-
-            emit RevenueTokenClaimed(claimer, tokenList[i], claimableAmounts[i]);
-        }
-
-        return claimableAmounts;
-    }
-
-    function pendingRewards(address user, address token) external view returns (uint256) {
-        return _pendingRewards(user, token);
     }
 
     function _transfer(address from, address to, uint256 amount) internal override {
@@ -442,25 +234,50 @@ contract IpRoyaltyVault is IIpRoyaltyVault, ERC20SnapshotUpgradeable, Reentrancy
 
         IpRoyaltyVaultStorage storage $ = _getIpRoyaltyVaultStorage();
         address[] memory tokenList = $.tokens.values();
+        uint256 totalSupply = totalSupply();
         for (uint256 i = 0; i < tokenList.length; i++) {
             address token = tokenList[i];
             _clearPendingRewards(from, token);
             _clearPendingRewards(to, token);
-            $.userRewardInfo[token][to] = ($.poolInfo[token] * (balanceOf(to) + amount)) / totalSupply();
-            $.userRewardInfo[token][from] = ($.poolInfo[token] * (balanceOf(from) - amount)) / totalSupply();
+            $.claimerInfo[token][to] = ($.poolInfo[token] * (balanceOf(to) + amount)) / totalSupply;
+            $.claimerInfo[token][from] = ($.poolInfo[token] * (balanceOf(from) - amount)) / totalSupply;
         }
 
         super._transfer(from, to, amount);
     }
 
     function _clearPendingRewards(address user, address token) internal returns (uint256 pending) {
-        pending = _pendingRewards(user, token);
+        pending = _claimableRevenue(user, token);
         if (pending > 0) {
             IERC20Upgradeable(token).safeTransfer(user, pending);
         }
     }
 
-    function _pendingRewards(address user, address token) internal view returns (uint256) {
+    function _claimRevenueOnBehalf(
+        address[] memory tokenList,
+        address claimer
+    ) internal returns (uint256[] memory) {
+        IpRoyaltyVaultStorage storage $ = _getIpRoyaltyVaultStorage();
+
+        if (ROYALTY_MODULE.isIpRoyaltyVault(claimer) && msg.sender != claimer)
+            revert Errors.IpRoyaltyVault__VaultsMustClaimAsSelf();
+
+        if (IP_ASSET_REGISTRY.isWhitelistedGroupRewardPool(claimer) && msg.sender != GROUPING_MODULE)
+            revert Errors.IpRoyaltyVault__GroupPoolMustClaimViaGroupingModule();
+
+        uint256[] memory claimedAmounts = new uint256[](tokenList.length);
+        for (uint256 i = 0; i < tokenList.length; i++) {
+            claimedAmounts[i] = _clearPendingRewards(claimer, tokenList[i]);
+            if (claimedAmounts[i] == 0) revert Errors.IpRoyaltyVault__NoClaimableTokens();
+            $.claimerInfo[tokenList[i]][claimer] += claimedAmounts[i];
+
+            emit RevenueTokenClaimed(claimer, tokenList[i], claimedAmounts[i]);
+        }
+
+        return claimedAmounts;
+    }
+
+    function _claimableRevenue(address claimer, address token) internal view returns (uint256) {
         // accBalance // accumulate revenue tokens in the vault
         // totalSupply = totalSupply() // totalSupply of RoyaltyTokens of the vault (IpRoyaltyVault)
         // accBalancePerShare = accBalance / totalSupply
@@ -469,8 +286,15 @@ contract IpRoyaltyVault is IIpRoyaltyVault, ERC20SnapshotUpgradeable, Reentrancy
         // pending = (accBalancePerShare * userAmount) - userRewardInfo[token][user].rewardDebt
         IpRoyaltyVaultStorage storage $ = _getIpRoyaltyVaultStorage();
         uint256 accBalance = $.poolInfo[token];
-        uint256 userAmount = balanceOf(user);
-        uint256 rewardDebt = $.userRewardInfo[token][user];
+        uint256 userAmount = balanceOf(claimer);
+        uint256 rewardDebt = $.claimerInfo[token][claimer];
         return (accBalance * userAmount) / totalSupply() - rewardDebt;
+    }
+
+    /// @dev Returns the storage struct of IpRoyaltyVault
+    function _getIpRoyaltyVaultStorage() private pure returns (IpRoyaltyVaultStorage storage $) {
+        assembly {
+            $.slot := IpRoyaltyVaultStorageLocation
+        }
     }
 }

--- a/contracts/modules/royalty/policies/VaultController.sol
+++ b/contracts/modules/royalty/policies/VaultController.sol
@@ -23,14 +23,6 @@ abstract contract VaultController is IVaultController, ProtocolPausableUpgradeab
     bytes32 private constant VaultControllerStorageLocation =
         0x88cf5a7bd03e240c4fc740fb2d1a8664ec6fa4816f867d60f968080755fb1700;
 
-    /// @dev Set the snapshot interval
-    /// @dev Enforced to be only callable by the protocol admin in governance
-    /// @param timestampInterval The minimum timestamp interval between snapshots
-    function setSnapshotInterval(uint256 timestampInterval) external restricted {
-        VaultControllerStorage storage $ = _getVaultControllerStorage();
-        $.snapshotInterval = timestampInterval;
-    }
-
     /// @dev Set the ip royalty vault beacon
     /// @dev Enforced to be only callable by the protocol admin in governance
     /// @param beacon The ip royalty vault beacon address
@@ -48,12 +40,6 @@ abstract contract VaultController is IVaultController, ProtocolPausableUpgradeab
         // no need to check for zero address
         VaultControllerStorage storage $ = _getVaultControllerStorage();
         UpgradeableBeacon($.ipRoyaltyVaultBeacon).upgradeTo(newVault);
-    }
-
-    /// @notice Returns the snapshot interval
-    /// @return snapshotInterval The minimum time interval between snapshots
-    function snapshotInterval() public view returns (uint256) {
-        return _getVaultControllerStorage().snapshotInterval;
     }
 
     /// @notice Returns the ip royalty vault beacon

--- a/contracts/modules/royalty/policies/VaultController.sol
+++ b/contracts/modules/royalty/policies/VaultController.sol
@@ -12,7 +12,7 @@ import { Errors } from "../../../lib/Errors.sol";
 abstract contract VaultController is IVaultController, ProtocolPausableUpgradeable {
     /// @dev Storage structure for the VaultController
     /// @param ipRoyaltyVaultBeacon The ip royalty vault beacon address
-    /// @param snapshotInterval The minimum timestamp interval between snapshots
+    /// @param snapshotInterval [DEPRECATED] The minimum timestamp interval between snapshots
     /// @custom:storage-location erc7201:story-protocol.VaultController
     struct VaultControllerStorage {
         address ipRoyaltyVaultBeacon;

--- a/package.json
+++ b/package.json
@@ -58,7 +58,6 @@
     "dependencies": {
         "@openzeppelin/contracts": "5.0.2",
         "@openzeppelin/contracts-upgradeable": "5.0.2",
-        "@openzeppelin/contracts-upgradeable-v4": "npm:@openzeppelin/contracts-upgradeable@4.9.6",
         "erc6551": "^0.3.1",
         "solady": "^0.0.192"
     }

--- a/script/foundry/utils/DeployHelper.sol
+++ b/script/foundry/utils/DeployHelper.sol
@@ -746,7 +746,6 @@ contract DeployHelper is Script, BroadcastManager, JsonDeploymentHandler, Storag
         royaltyModule.whitelistRoyaltyPolicy(address(royaltyPolicyLRP), true);
         royaltyModule.whitelistRoyaltyToken(address(erc20), true);
         royaltyModule.whitelistRoyaltyToken(WIP, true);
-        royaltyModule.setSnapshotInterval(7 days);
         royaltyModule.setIpRoyaltyVaultBeacon(address(ipRoyaltyVaultBeacon));
         ipRoyaltyVaultBeacon.transferOwnership(address(royaltyModule));
 

--- a/test/foundry/integration/BaseIntegration.t.sol
+++ b/test/foundry/integration/BaseIntegration.t.sol
@@ -20,9 +20,6 @@ contract BaseIntegration is BaseTest {
         super.setUp();
 
         dealMockAssets();
-
-        vm.prank(u.admin);
-        royaltyModule.setSnapshotInterval(7 days);
     }
 
     /*//////////////////////////////////////////////////////////////////////////

--- a/test/foundry/integration/flows/grouping/Grouping.t.sol
+++ b/test/foundry/integration/flows/grouping/Grouping.t.sol
@@ -10,7 +10,6 @@ import { ERC20 } from "@openzeppelin/contracts/token/ERC20/ERC20.sol";
 // solhint-disable-next-line max-line-length
 import { PILFlavors } from "../../../../../contracts/lib/PILFlavors.sol";
 import { IGroupingModule } from "../../../../../contracts/interfaces/modules/grouping/IGroupingModule.sol";
-import { IIpRoyaltyVault } from "../../../../../contracts/interfaces/modules/royalty/policies/IIpRoyaltyVault.sol";
 import { IGroupIPAssetRegistry } from "../../../../../contracts/interfaces/registries/IGroupIPAssetRegistry.sol";
 
 // test

--- a/test/foundry/integration/flows/grouping/Grouping.t.sol
+++ b/test/foundry/integration/flows/grouping/Grouping.t.sol
@@ -148,19 +148,14 @@ contract Flows_Integration_Grouping is BaseIntegration {
             rewards[0] = 1 ether / 2;
             rewards[1] = 1 ether / 2;
 
-            uint256 snapshotId = IIpRoyaltyVault(royaltyModule.ipRoyaltyVaults(groupId)).snapshot();
-            uint256[] memory snapshotIds = new uint256[](1);
-            snapshotIds[0] = snapshotId;
-
             vm.expectEmit(address(groupingModule));
             emit IGroupingModule.CollectedRoyaltiesToGroupPool(
                 groupId,
                 address(mockToken),
                 IGroupIPAssetRegistry(ipAssetRegistry).getGroupRewardPool(groupId),
-                1 ether,
-                snapshotIds
+                1 ether
             );
-            uint256 royalties = groupingModule.collectRoyalties(groupId, address(mockToken), snapshotIds);
+            uint256 royalties = groupingModule.collectRoyalties(groupId, address(mockToken));
             assertEq(royalties, 1 ether);
             vm.expectEmit(address(groupingModule));
             emit IGroupingModule.ClaimedReward(groupId, address(erc20), ipIds, rewards);

--- a/test/foundry/integration/flows/royalty/Royalty.t.sol
+++ b/test/foundry/integration/flows/royalty/Royalty.t.sol
@@ -201,14 +201,10 @@ contract Flows_Integration_Disputes is BaseIntegration {
             );
 
             vm.warp(block.timestamp + 7 days + 1);
-            IpRoyaltyVault(vault).snapshot();
-
-            uint256[] memory snapshotIds = new uint256[](1);
-            snapshotIds[0] = 1;
 
             uint256 aliceBalanceBefore = mockToken.balanceOf(ipAcct[1]);
 
-            IpRoyaltyVault(vault).claimRevenueOnBehalfBySnapshotBatch(snapshotIds, address(mockToken), ipAcct[1]);
+            IpRoyaltyVault(vault).claimRevenueOnBehalf(address(mockToken), ipAcct[1]);
 
             uint256 aliceBalanceAfter = mockToken.balanceOf(ipAcct[1]);
 

--- a/test/foundry/integration/flows/royalty/Royalty.t.sol
+++ b/test/foundry/integration/flows/royalty/Royalty.t.sol
@@ -204,7 +204,7 @@ contract Flows_Integration_Disputes is BaseIntegration {
 
             uint256 aliceBalanceBefore = mockToken.balanceOf(ipAcct[1]);
 
-            IpRoyaltyVault(vault).claimRevenueOnBehalf(address(mockToken), ipAcct[1]);
+            IpRoyaltyVault(vault).claimRevenueOnBehalf(ipAcct[1], address(mockToken));
 
             uint256 aliceBalanceAfter = mockToken.balanceOf(ipAcct[1]);
 

--- a/test/foundry/invariants/IpRoyaltyVault.t.sol
+++ b/test/foundry/invariants/IpRoyaltyVault.t.sol
@@ -21,7 +21,7 @@ contract IpRoyaltyVaultHarness is Test {
     }
 
     function claimRevenueByTokenBatch(address[] calldata tokenList) public {
-        vault.claimRevenueOnBehalfByTokenBatch(tokenList, address(this));
+        vault.claimRevenueOnBehalfByTokenBatch(address(this), tokenList);
     }
 
     function claimByTokenBatchAsSelf(address[] calldata tokenList, address targetIpId) public {

--- a/test/foundry/invariants/IpRoyaltyVault.t.sol
+++ b/test/foundry/invariants/IpRoyaltyVault.t.sol
@@ -50,7 +50,6 @@ contract IpRoyaltyVaultInvariant is BaseTest {
         // whitelist royalty policy
         royaltyModule.whitelistRoyaltyPolicy(address(royaltyPolicyLAP), true);
         royaltyModule.whitelistRoyaltyToken(address(LINK), true);
-        royaltyModule.setSnapshotInterval(7 days);
         vm.stopPrank();
 
         vm.startPrank(address(licensingModule));

--- a/test/foundry/invariants/IpRoyaltyVault.t.sol
+++ b/test/foundry/invariants/IpRoyaltyVault.t.sol
@@ -16,28 +16,16 @@ contract IpRoyaltyVaultHarness is Test {
         royaltyModule = RoyaltyModule(_royaltyModule);
     }
 
-    function snapshot() public {
-        vault.snapshot();
-    }
-
     function payRoyaltyOnBehalf(address receiverIpId, address payerIpId, address token, uint256 amount) external {
         royaltyModule.payRoyaltyOnBehalf(receiverIpId, payerIpId, token, amount);
     }
 
-    function claimRevenueByTokenBatch(uint256 snapshotId, address[] calldata tokenList) public {
-        vault.claimRevenueOnBehalfByTokenBatch(snapshotId, tokenList, address(this));
+    function claimRevenueByTokenBatch(address[] calldata tokenList) public {
+        vault.claimRevenueOnBehalfByTokenBatch(tokenList, address(this));
     }
 
-    function claimRevenueBySnapshotBatch(uint256[] memory snapshotIds, address token) public {
-        vault.claimRevenueOnBehalfBySnapshotBatch(snapshotIds, token, address(this));
-    }
-
-    function claimByTokenBatchAsSelf(uint256 snapshotId, address[] calldata tokenList, address targetIpId) public {
-        vault.claimByTokenBatchAsSelf(snapshotId, tokenList, targetIpId);
-    }
-
-    function claimBySnapshotBatchAsSelf(uint256[] memory snapshotIds, address token, address targetIpId) public {
-        vault.claimBySnapshotBatchAsSelf(snapshotIds, token, targetIpId);
+    function claimByTokenBatchAsSelf(address[] calldata tokenList, address targetIpId) public {
+        vault.claimByTokenBatchAsSelf(tokenList, targetIpId);
     }
 
     function updateVaultBalance(address token, uint256 amount) public {
@@ -78,15 +66,12 @@ contract IpRoyaltyVaultInvariant is BaseTest {
 
         targetContract(address(harness));
 
-        bytes4[] memory selectors = new bytes4[](8);
-        selectors[0] = harness.snapshot.selector;
-        selectors[1] = harness.claimRevenueByTokenBatch.selector;
-        selectors[2] = harness.claimRevenueBySnapshotBatch.selector;
-        selectors[3] = harness.payRoyaltyOnBehalf.selector;
-        selectors[4] = harness.claimByTokenBatchAsSelf.selector;
-        selectors[5] = harness.claimBySnapshotBatchAsSelf.selector;
-        selectors[6] = harness.updateVaultBalance.selector;
-        selectors[7] = harness.warp.selector;
+        bytes4[] memory selectors = new bytes4[](5);
+        selectors[0] = harness.claimRevenueByTokenBatch.selector;
+        selectors[1] = harness.payRoyaltyOnBehalf.selector;
+        selectors[2] = harness.claimByTokenBatchAsSelf.selector;
+        selectors[3] = harness.updateVaultBalance.selector;
+        selectors[4] = harness.warp.selector;
 
         targetSelector(FuzzSelector(address(harness), selectors));
 

--- a/test/foundry/mocks/grouping/MockEvenSplitGroupPool.sol
+++ b/test/foundry/mocks/grouping/MockEvenSplitGroupPool.sol
@@ -134,7 +134,7 @@ contract MockEvenSplitGroupPool is IGroupRewardPool {
         IIpRoyaltyVault vault = IIpRoyaltyVault(ROYALTY_MODULE.ipRoyaltyVaults(groupId));
         // ignore if group IP vault is not created
         if (address(vault) == address(0)) return;
-        uint256 royalties = vault.claimRevenueOnBehalf(token, address(this));
+        uint256 royalties = vault.claimRevenueOnBehalf(address(this), token);
         poolInfo[groupId][token].availableBalance += royalties;
         poolInfo[groupId][token].accBalance += royalties;
         groupTokens[groupId].add(token);

--- a/test/foundry/mocks/grouping/MockEvenSplitGroupPool.sol
+++ b/test/foundry/mocks/grouping/MockEvenSplitGroupPool.sol
@@ -134,9 +134,7 @@ contract MockEvenSplitGroupPool is IGroupRewardPool {
         IIpRoyaltyVault vault = IIpRoyaltyVault(ROYALTY_MODULE.ipRoyaltyVaults(groupId));
         // ignore if group IP vault is not created
         if (address(vault) == address(0)) return;
-        uint256[] memory snapshotsToClaim = new uint256[](1);
-        snapshotsToClaim[0] = vault.snapshot();
-        uint256 royalties = vault.claimRevenueOnBehalfBySnapshotBatch(snapshotsToClaim, token, address(this));
+        uint256 royalties = vault.claimRevenueOnBehalf(token, address(this));
         poolInfo[groupId][token].availableBalance += royalties;
         poolInfo[groupId][token].accBalance += royalties;
         groupTokens[groupId].add(token);

--- a/test/foundry/modules/grouping/GroupingModule.t.sol
+++ b/test/foundry/modules/grouping/GroupingModule.t.sol
@@ -12,7 +12,6 @@ import { PILFlavors } from "../../../../contracts/lib/PILFlavors.sol";
 import { EvenSplitGroupPool } from "../../../../contracts/modules/grouping/EvenSplitGroupPool.sol";
 import { MockERC721 } from "../../mocks/token/MockERC721.sol";
 import { BaseTest } from "../../utils/BaseTest.t.sol";
-import { IIpRoyaltyVault } from "../../../../contracts/interfaces/modules/royalty/policies/IIpRoyaltyVault.sol";
 
 contract GroupingModuleTest is BaseTest {
     // test register group
@@ -202,12 +201,7 @@ contract GroupingModuleTest is BaseTest {
         vm.warp(vm.getBlockTimestamp() + 7 days);
 
         vm.expectEmit();
-        emit IGroupingModule.CollectedRoyaltiesToGroupPool(
-            groupId,
-            address(erc20),
-            address(rewardPool),
-            100
-        );
+        emit IGroupingModule.CollectedRoyaltiesToGroupPool(groupId, address(erc20), address(rewardPool), 100);
         groupingModule.collectRoyalties(groupId, address(erc20));
 
         address[] memory claimIpIds = new address[](1);

--- a/test/foundry/modules/grouping/GroupingModule.t.sol
+++ b/test/foundry/modules/grouping/GroupingModule.t.sol
@@ -201,19 +201,14 @@ contract GroupingModuleTest is BaseTest {
         royaltyPolicyLAP.transferToVault(ipId3, groupId, address(erc20), 100);
         vm.warp(vm.getBlockTimestamp() + 7 days);
 
-        uint256 snapshotId = IIpRoyaltyVault(royaltyModule.ipRoyaltyVaults(groupId)).snapshot();
-        uint256[] memory snapshotIds = new uint256[](1);
-        snapshotIds[0] = snapshotId;
-
         vm.expectEmit();
         emit IGroupingModule.CollectedRoyaltiesToGroupPool(
             groupId,
             address(erc20),
             address(rewardPool),
-            100,
-            snapshotIds
+            100
         );
-        groupingModule.collectRoyalties(groupId, address(erc20), snapshotIds);
+        groupingModule.collectRoyalties(groupId, address(erc20));
 
         address[] memory claimIpIds = new address[](1);
         claimIpIds[0] = ipId1;

--- a/test/foundry/modules/royalty/IpRoyaltyVault.t.sol
+++ b/test/foundry/modules/royalty/IpRoyaltyVault.t.sol
@@ -615,7 +615,6 @@ contract TestIpRoyaltyVault is BaseTest {
         assertEq(ipRoyaltyVault.claimableRevenue(address(2), address(USDC)), 0);
         assertEq(ipRoyaltyVault.claimableRevenue(alice, address(USDC)), 0);
 
-
         // alice transfer 20% of rts to bob
         // payment is made to vault
         USDC.mint(address(1), royaltyAmount); // 100k USDC
@@ -637,10 +636,7 @@ contract TestIpRoyaltyVault is BaseTest {
         assertEq(ipRoyaltyVault.balanceOf(alice), 30e6);
         assertEq(ipRoyaltyVault.balanceOf(bob), 20e6);
         assertEq(ipRoyaltyVault.balanceOf(address(2)), 50e6);
-        assertEq(
-            USDC.balanceOf(alice),
-            aliceUsdcBalanceBefore + (royaltyAmount * 30e6) / 100e6
-        );
+        assertEq(USDC.balanceOf(alice), aliceUsdcBalanceBefore + (royaltyAmount * 30e6) / 100e6);
         assertEq(USDC.balanceOf(address(ipRoyaltyVault)), (royaltyAmount * 100e6) / 100e6);
         assertEq(USDC.balanceOf(address(2)), (royaltyAmount * 100e6) / 100e6 + (royaltyAmount * 70e6) / 100e6);
         assertEq(USDC.balanceOf(bob), bobUsdcBalanceBefore);
@@ -665,7 +661,6 @@ contract TestIpRoyaltyVault is BaseTest {
         assertEq(ipRoyaltyVault.claimableRevenue(alice, address(USDC)), 0);
         assertEq(ipRoyaltyVault.claimableRevenue(bob, address(USDC)), 0);
 
-
         // alice transfer 30% of rts to bob
         // payment is made to vault
         USDC.mint(address(1), royaltyAmount); // 100k USDC
@@ -682,7 +677,6 @@ contract TestIpRoyaltyVault is BaseTest {
         emit IERC20.Transfer(alice, bob, 30e6);
         IERC20(address(ipRoyaltyVault)).transfer(bob, 30e6);
 
-
         assertEq(ipRoyaltyVault.balanceOf(alice), 0e6);
         assertEq(ipRoyaltyVault.balanceOf(bob), 50e6);
         assertEq(ipRoyaltyVault.balanceOf(address(2)), 50e6);
@@ -690,10 +684,16 @@ contract TestIpRoyaltyVault is BaseTest {
             USDC.balanceOf(alice),
             aliceUsdcBalanceBefore + (royaltyAmount * 30e6) / 100e6 + (royaltyAmount * 50e6) / 100e6
         );
-        assertEq(USDC.balanceOf(address(ipRoyaltyVault)), (royaltyAmount * 50e6) / 100e6 + (royaltyAmount * 100e6) / 100e6);
+        assertEq(
+            USDC.balanceOf(address(ipRoyaltyVault)),
+            (royaltyAmount * 50e6) / 100e6 + (royaltyAmount * 100e6) / 100e6
+        );
         assertEq(USDC.balanceOf(address(2)), (royaltyAmount * 100e6) / 100e6 + (royaltyAmount * 70e6) / 100e6);
         assertEq(USDC.balanceOf(bob), bobUsdcBalanceBefore);
-        assertEq(ipRoyaltyVault.claimableRevenue(address(2), address(USDC)), (royaltyAmount * 50e6) / 100e6 + (royaltyAmount * 50e6) / 100e6);
+        assertEq(
+            ipRoyaltyVault.claimableRevenue(address(2), address(USDC)),
+            (royaltyAmount * 50e6) / 100e6 + (royaltyAmount * 50e6) / 100e6
+        );
         assertEq(ipRoyaltyVault.claimableRevenue(alice, address(USDC)), (royaltyAmount * 30e6) / 100e6);
         assertEq(ipRoyaltyVault.claimableRevenue(bob, address(USDC)), (royaltyAmount * 20e6) / 100e6);
     }

--- a/test/foundry/modules/royalty/IpRoyaltyVault.t.sol
+++ b/test/foundry/modules/royalty/IpRoyaltyVault.t.sol
@@ -85,7 +85,6 @@ contract TestIpRoyaltyVault is BaseTest {
 
         assertEq(ipRoyaltyVault.tokens().length, 1);
         assertEq(ipRoyaltyVault.tokens()[0], address(USDC));
-        assertEq(ipRoyaltyVault.pendingVaultAmount(address(USDC)), 1);
     }
 
     function test_IpRoyaltyVault_constructor_revert_ZeroDisputeModule() public {
@@ -154,50 +153,10 @@ contract TestIpRoyaltyVault is BaseTest {
         assertEq(ERC20(ipRoyaltyVault).symbol(), "RT");
         assertEq(ERC20(ipRoyaltyVault).totalSupply(), royaltyModule.maxPercent());
         assertEq(IIpRoyaltyVault(ipRoyaltyVault).ipId(), address(80));
-        assertEq(IIpRoyaltyVault(ipRoyaltyVault).lastSnapshotTimestamp(), block.timestamp);
         assertEq(ipId80IpIdBalance, royaltyModule.maxPercent());
     }
 
-    function test_IpRoyaltyVault_snapshot_InsufficientTimeElapsedSinceLastSnapshot() public {
-        // deploy vault
-        vm.startPrank(address(licensingModule));
-        royaltyModule.onLicenseMinting(address(1), address(royaltyPolicyLAP), uint32(10 * 10 ** 6), "");
-        IIpRoyaltyVault ipRoyaltyVault = IIpRoyaltyVault(royaltyModule.ipRoyaltyVaults(address(1)));
-        vm.stopPrank();
-
-        vm.expectRevert(Errors.IpRoyaltyVault__InsufficientTimeElapsedSinceLastSnapshot.selector);
-        ipRoyaltyVault.snapshot();
-    }
-
-    function test_IpRoyaltyVault_snapshot_revert_Paused() public {
-        // deploy vault
-        vm.startPrank(address(licensingModule));
-        royaltyModule.onLicenseMinting(address(1), address(royaltyPolicyLAP), uint32(10 * 10 ** 6), "");
-        IIpRoyaltyVault ipRoyaltyVault = IIpRoyaltyVault(royaltyModule.ipRoyaltyVaults(address(1)));
-        vm.stopPrank();
-
-        vm.stopPrank();
-        vm.prank(u.admin);
-        royaltyModule.pause();
-
-        vm.expectRevert(Errors.IpRoyaltyVault__EnforcedPause.selector);
-        ipRoyaltyVault.snapshot();
-    }
-
-    function test_IpRoyaltyVault_snapshot_revert_NoNewRevenueSinceLastSnapshot() public {
-        // deploy vault
-        vm.startPrank(address(licensingModule));
-        royaltyModule.onLicenseMinting(address(2), address(royaltyPolicyLAP), uint32(10 * 10 ** 6), "");
-        IpRoyaltyVault ipRoyaltyVault = IpRoyaltyVault(royaltyModule.ipRoyaltyVaults(address(2)));
-        vm.stopPrank();
-
-        vm.warp(block.timestamp + 7 days + 1);
-
-        vm.expectRevert(Errors.IpRoyaltyVault__NoNewRevenueSinceLastSnapshot.selector);
-        ipRoyaltyVault.snapshot();
-    }
-
-    function test_IpRoyaltyVault_snapshot() public {
+    function test_IpRoyaltyVault_claimRevenue() public {
         // payment is made to vault
         uint256 royaltyAmount = 100000 * 10 ** 6;
         USDC.mint(address(2), royaltyAmount); // 100k USDC
@@ -213,42 +172,19 @@ contract TestIpRoyaltyVault is BaseTest {
         royaltyModule.payRoyaltyOnBehalf(address(2), address(2), address(LINK), royaltyAmount);
         vm.stopPrank();
 
-        // take snapshot
-        vm.warp(block.timestamp + 7 days + 1);
-
-        uint256 usdcClaimVaultBefore = ipRoyaltyVault.claimVaultAmount(address(USDC));
-        uint256 linkClaimVaultBefore = ipRoyaltyVault.claimVaultAmount(address(LINK));
-        uint256 usdcPendingVaultBefore = ipRoyaltyVault.pendingVaultAmount(address(USDC));
-        uint256 linkPendingVaultBefore = ipRoyaltyVault.pendingVaultAmount(address(LINK));
-
-        vm.expectEmit(true, true, true, true, address(ipRoyaltyVault));
-        emit IIpRoyaltyVault.SnapshotCompleted(1, block.timestamp);
-
-        ipRoyaltyVault.snapshot();
-
-        assertEq(ipRoyaltyVault.claimVaultAmount(address(USDC)), royaltyAmount);
-        assertEq(ipRoyaltyVault.claimVaultAmount(address(LINK)), royaltyAmount);
-        assertEq(ipRoyaltyVault.claimVaultAmount(address(USDC)) - usdcClaimVaultBefore, royaltyAmount);
-        assertEq(ipRoyaltyVault.claimVaultAmount(address(LINK)) - linkClaimVaultBefore, royaltyAmount);
-        assertEq(ipRoyaltyVault.lastSnapshotTimestamp(), block.timestamp);
-        assertEq(ipRoyaltyVault.claimableAtSnapshot(1, address(USDC)), royaltyAmount);
-        assertEq(ipRoyaltyVault.claimableAtSnapshot(1, address(LINK)), royaltyAmount);
-        assertEq(usdcPendingVaultBefore - ipRoyaltyVault.pendingVaultAmount(address(USDC)), royaltyAmount);
-        assertEq(linkPendingVaultBefore - ipRoyaltyVault.pendingVaultAmount(address(LINK)), royaltyAmount);
+        uint256 usdcClaimVaultBefore = USDC.balanceOf(address(ipRoyaltyVault));
+        uint256 linkClaimVaultBefore = LINK.balanceOf(address(ipRoyaltyVault));
 
         // users claim all USDC
         address[] memory tokens = new address[](1);
         tokens[0] = address(USDC);
         vm.startPrank(address(2));
-        ipRoyaltyVault.claimRevenueOnBehalfByTokenBatch(1, tokens, address(2));
+        ipRoyaltyVault.claimRevenueOnBehalfByTokenBatch(tokens, address(2));
         vm.stopPrank();
 
-        // take snapshot
-        vm.warp(block.timestamp + 7 days + 1);
-        ipRoyaltyVault.snapshot();
-
         // all USDC was claimed but LINK was not
-        assertEq(ipRoyaltyVault.tokens().length, 1);
+        assertEq(USDC.balanceOf(address(ipRoyaltyVault)), 0);
+        assertEq(LINK.balanceOf(address(ipRoyaltyVault)), linkClaimVaultBefore);
     }
 
     function test_IpRoyaltyVault_claimRevenue_revert_Paused() public {
@@ -262,10 +198,7 @@ contract TestIpRoyaltyVault is BaseTest {
         royaltyModule.pause();
 
         vm.expectRevert(Errors.IpRoyaltyVault__EnforcedPause.selector);
-        ipRoyaltyVault.claimRevenueOnBehalfBySnapshotBatch(new uint256[](0), address(USDC), u.admin);
-
-        vm.expectRevert(Errors.IpRoyaltyVault__EnforcedPause.selector);
-        ipRoyaltyVault.claimRevenueOnBehalfByTokenBatch(1, new address[](0), u.admin);
+        ipRoyaltyVault.claimRevenueOnBehalfByTokenBatch(new address[](0), u.admin);
     }
 
     function test_IpRoyaltyVault_claimableRevenue() public {
@@ -289,12 +222,8 @@ contract TestIpRoyaltyVault is BaseTest {
         USDC.approve(address(royaltyModule), royaltyAmount);
         royaltyModule.payRoyaltyOnBehalf(receiverIpId, payerIpId, address(USDC), royaltyAmount);
 
-        // take snapshot
-        vm.warp(block.timestamp + 7 days + 1);
-        ipRoyaltyVault.snapshot();
-
-        uint256 claimableRevenueIpId = ipRoyaltyVault.claimableRevenue(receiverIpId, 1, address(USDC));
-        uint256 claimableRevenueMinHolder = ipRoyaltyVault.claimableRevenue(minorityHolder, 1, address(USDC));
+        uint256 claimableRevenueIpId = ipRoyaltyVault.claimableRevenue(receiverIpId, address(USDC));
+        uint256 claimableRevenueMinHolder = ipRoyaltyVault.claimableRevenue(minorityHolder, address(USDC));
         assertEq(claimableRevenueIpId, (royaltyAmount * 70e6) / 100e6);
         assertEq(claimableRevenueMinHolder, (royaltyAmount * 30e6) / 100e6);
     }
@@ -307,7 +236,7 @@ contract TestIpRoyaltyVault is BaseTest {
         vm.stopPrank();
 
         vm.expectRevert(Errors.IpRoyaltyVault__VaultsMustClaimAsSelf.selector);
-        IIpRoyaltyVault(ipRoyaltyVault).claimRevenueOnBehalfByTokenBatch(1, new address[](0), address(ipRoyaltyVault));
+        IIpRoyaltyVault(ipRoyaltyVault).claimRevenueOnBehalfByTokenBatch(new address[](0), address(ipRoyaltyVault));
     }
 
     function test_IpRoyaltyVault_claimRevenueOnBehalfByTokenBatch_revert_GroupPoolMustClaimViaGroupingModule() public {
@@ -322,7 +251,7 @@ contract TestIpRoyaltyVault is BaseTest {
         assertEq(IERC20(address(ipRoyaltyVault)).balanceOf(address(rewardPool)), 100e6);
 
         vm.expectRevert(Errors.IpRoyaltyVault__GroupPoolMustClaimViaGroupingModule.selector);
-        ipRoyaltyVault.claimRevenueOnBehalfByTokenBatch(1, new address[](0), address(rewardPool));
+        ipRoyaltyVault.claimRevenueOnBehalfByTokenBatch(new address[](0), address(rewardPool));
     }
 
     function test_IpRoyaltyVault_claimRevenueOnBehalfByTokenBatch_revert_NoClaimableTokens() public {
@@ -336,15 +265,11 @@ contract TestIpRoyaltyVault is BaseTest {
         ipRoyaltyVault.updateVaultBalance(address(USDC), 1);
         vm.stopPrank();
 
-        // take snapshot
-        vm.warp(block.timestamp + 7 days + 1);
-        ipRoyaltyVault.snapshot();
-
         address[] memory tokens = new address[](1);
         tokens[0] = address(USDC);
 
         vm.expectRevert(Errors.IpRoyaltyVault__NoClaimableTokens.selector);
-        ipRoyaltyVault.claimRevenueOnBehalfByTokenBatch(1, tokens, u.admin);
+        ipRoyaltyVault.claimRevenueOnBehalfByTokenBatch(tokens, u.admin);
     }
 
     function test_IpRoyaltyVault_claimRevenueOnBehalfByTokenBatch() public {
@@ -363,10 +288,6 @@ contract TestIpRoyaltyVault is BaseTest {
         royaltyModule.payRoyaltyOnBehalf(address(2), address(2), address(LINK), royaltyAmount);
         vm.stopPrank();
 
-        // take snapshot
-        vm.warp(block.timestamp + 7 days + 1);
-        ipRoyaltyVault.snapshot();
-
         address[] memory tokens = new address[](2);
         tokens[0] = address(USDC);
         tokens[1] = address(LINK);
@@ -375,8 +296,6 @@ contract TestIpRoyaltyVault is BaseTest {
         uint256 userLinkBalanceBefore = LINK.balanceOf(address(2));
         uint256 contractUsdcBalanceBefore = USDC.balanceOf(address(ipRoyaltyVault));
         uint256 contractLinkBalanceBefore = LINK.balanceOf(address(ipRoyaltyVault));
-        uint256 usdcClaimVaultBefore = ipRoyaltyVault.claimVaultAmount(address(USDC));
-        uint256 linkClaimVaultBefore = ipRoyaltyVault.claimVaultAmount(address(LINK));
 
         vm.startPrank(address(2));
 
@@ -386,107 +305,15 @@ contract TestIpRoyaltyVault is BaseTest {
         emit IIpRoyaltyVault.RevenueTokenClaimed(address(2), address(USDC), expectedAmount);
         emit IIpRoyaltyVault.RevenueTokenClaimed(address(2), address(LINK), expectedAmount);
 
-        ipRoyaltyVault.claimRevenueOnBehalfByTokenBatch(1, tokens, address(2));
+        ipRoyaltyVault.claimRevenueOnBehalfByTokenBatch(tokens, address(2));
 
         assertEq(USDC.balanceOf(address(2)) - userUsdcBalanceBefore, expectedAmount);
         assertEq(LINK.balanceOf(address(2)) - userLinkBalanceBefore, expectedAmount);
         assertEq(contractUsdcBalanceBefore - USDC.balanceOf(address(ipRoyaltyVault)), expectedAmount);
         assertEq(contractLinkBalanceBefore - LINK.balanceOf(address(ipRoyaltyVault)), expectedAmount);
-        assertEq(usdcClaimVaultBefore - ipRoyaltyVault.claimVaultAmount(address(USDC)), expectedAmount);
-        assertEq(linkClaimVaultBefore - ipRoyaltyVault.claimVaultAmount(address(LINK)), expectedAmount);
-        assertEq(ipRoyaltyVault.isClaimedAtSnapshot(1, address(2), address(USDC)), true);
-        assertEq(ipRoyaltyVault.isClaimedAtSnapshot(1, address(2), address(LINK)), true);
     }
 
-    function test_IpRoyaltyVault_claimRevenueOnBehalfBySnapshotBatch_revert_VaultsMustClaimAsSelf() public {
-        // deploy vault
-        vm.startPrank(address(licensingModule));
-        royaltyModule.onLicenseMinting(address(1), address(royaltyPolicyLAP), uint32(10 * 10 ** 6), "");
-        IpRoyaltyVault ipRoyaltyVault = IpRoyaltyVault(royaltyModule.ipRoyaltyVaults(address(1)));
-        vm.stopPrank();
-
-        vm.expectRevert(Errors.IpRoyaltyVault__VaultsMustClaimAsSelf.selector);
-        ipRoyaltyVault.claimRevenueOnBehalfBySnapshotBatch(new uint256[](0), address(USDC), address(ipRoyaltyVault));
-    }
-
-    function test_IpRoyaltyVault_claimRevenueOnBehalfBySnapshotBatch_revert_GroupPoolMustClaimViaGroupingModule()
-        public
-    {
-        address groupId = groupingModule.registerGroup(address(evenSplitGroupPool));
-        address rewardPool = ipAssetRegistry.getGroupRewardPool(groupId);
-
-        vm.startPrank(address(licensingModule));
-        royaltyModule.onLicenseMinting(address(groupId), address(royaltyPolicyLAP), uint32(10 * 10 ** 6), "");
-        IpRoyaltyVault ipRoyaltyVault = IpRoyaltyVault(royaltyModule.ipRoyaltyVaults(address(groupId)));
-        vm.stopPrank();
-
-        assertEq(IERC20(address(ipRoyaltyVault)).balanceOf(address(rewardPool)), 100e6);
-
-        vm.expectRevert(Errors.IpRoyaltyVault__GroupPoolMustClaimViaGroupingModule.selector);
-        ipRoyaltyVault.claimRevenueOnBehalfBySnapshotBatch(new uint256[](0), address(USDC), address(rewardPool));
-    }
-
-    function test_IpRoyaltyVault_claimRevenueOnBehalfBySnapshotBatch_revert_NoClaimableTokens() public {
-        // deploy vault
-        vm.startPrank(address(licensingModule));
-        royaltyModule.onLicenseMinting(address(1), address(royaltyPolicyLAP), uint32(10 * 10 ** 6), "");
-        IpRoyaltyVault ipRoyaltyVault = IpRoyaltyVault(royaltyModule.ipRoyaltyVaults(address(1)));
-        vm.stopPrank();
-
-        vm.expectRevert(Errors.IpRoyaltyVault__NoClaimableTokens.selector);
-        ipRoyaltyVault.claimRevenueOnBehalfBySnapshotBatch(new uint256[](0), address(USDC), u.admin);
-    }
-
-    function test_IpRoyaltyVault_claimRevenueOnBehalfBySnapshotBatch() public {
-        uint256 royaltyAmount = 100000 * 10 ** 6;
-        USDC.mint(address(2), royaltyAmount); // 100k USDC
-
-        vm.startPrank(address(licensingModule));
-        royaltyModule.onLicenseMinting(address(2), address(royaltyPolicyLAP), uint32(10 * 10 ** 6), "");
-        IpRoyaltyVault ipRoyaltyVault = IpRoyaltyVault(royaltyModule.ipRoyaltyVaults(address(2)));
-        vm.stopPrank();
-
-        // 1st payment is made to vault
-        vm.startPrank(address(2));
-        USDC.approve(address(royaltyModule), royaltyAmount);
-        royaltyModule.payRoyaltyOnBehalf(address(2), address(2), address(USDC), royaltyAmount / 2);
-
-        // take snapshot
-        vm.warp(block.timestamp + 7 days + 1);
-        ipRoyaltyVault.snapshot();
-
-        // 2nt payment is made to vault
-        royaltyModule.payRoyaltyOnBehalf(address(2), address(2), address(USDC), royaltyAmount / 2);
-        vm.stopPrank();
-
-        // take snapshot
-        vm.warp(block.timestamp + 7 days + 1);
-        ipRoyaltyVault.snapshot();
-
-        uint256[] memory snapshots = new uint256[](2);
-        snapshots[0] = 1;
-        snapshots[1] = 2;
-
-        uint256 userUsdcBalanceBefore = USDC.balanceOf(address(2));
-        uint256 contractUsdcBalanceBefore = USDC.balanceOf(address(ipRoyaltyVault));
-        uint256 usdcClaimVaultBefore = ipRoyaltyVault.claimVaultAmount(address(USDC));
-
-        uint256 expectedAmount = royaltyAmount;
-
-        vm.expectEmit(true, true, true, true, address(ipRoyaltyVault));
-        emit IIpRoyaltyVault.RevenueTokenClaimed(address(2), address(USDC), expectedAmount);
-
-        vm.startPrank(address(2));
-        ipRoyaltyVault.claimRevenueOnBehalfBySnapshotBatch(snapshots, address(USDC), address(2));
-
-        assertEq(USDC.balanceOf(address(2)) - userUsdcBalanceBefore, expectedAmount);
-        assertEq(contractUsdcBalanceBefore - USDC.balanceOf(address(ipRoyaltyVault)), expectedAmount);
-        assertEq(usdcClaimVaultBefore - ipRoyaltyVault.claimVaultAmount(address(USDC)), expectedAmount);
-        assertEq(ipRoyaltyVault.isClaimedAtSnapshot(1, address(2), address(USDC)), true);
-        assertEq(ipRoyaltyVault.isClaimedAtSnapshot(2, address(2), address(USDC)), true);
-    }
-
-    function test_IpRoyaltyVault_claimRevenueOnBehalfBySnapshotBatch_GroupPool() public {
+    function test_IpRoyaltyVault_claimRevenueOnBehalf_GroupPool() public {
         uint256 royaltyAmount = 100000 * 10 ** 6;
         USDC.mint(address(2), royaltyAmount); // 100k USDC
 
@@ -503,25 +330,12 @@ contract TestIpRoyaltyVault is BaseTest {
         USDC.approve(address(royaltyModule), royaltyAmount);
         royaltyModule.payRoyaltyOnBehalf(groupId, address(2), address(USDC), royaltyAmount / 2);
 
-        // take snapshot
-        vm.warp(block.timestamp + 7 days + 1);
-        ipRoyaltyVault.snapshot();
-
         // 2nt payment is made to vault
         royaltyModule.payRoyaltyOnBehalf(groupId, address(2), address(USDC), royaltyAmount / 2);
         vm.stopPrank();
 
-        // take snapshot
-        vm.warp(block.timestamp + 7 days + 1);
-        ipRoyaltyVault.snapshot();
-
-        uint256[] memory snapshots = new uint256[](2);
-        snapshots[0] = 1;
-        snapshots[1] = 2;
-
         uint256 userUsdcBalanceBefore = USDC.balanceOf(rewardPool);
         uint256 contractUsdcBalanceBefore = USDC.balanceOf(address(ipRoyaltyVault));
-        uint256 usdcClaimVaultBefore = ipRoyaltyVault.claimVaultAmount(address(USDC));
 
         uint256 expectedAmount = royaltyAmount;
 
@@ -529,13 +343,10 @@ contract TestIpRoyaltyVault is BaseTest {
         emit IIpRoyaltyVault.RevenueTokenClaimed(rewardPool, address(USDC), expectedAmount);
 
         vm.startPrank(address(2));
-        groupingModule.collectRoyalties(groupId, address(USDC), snapshots);
+        groupingModule.collectRoyalties(groupId, address(USDC));
 
         assertEq(USDC.balanceOf(rewardPool) - userUsdcBalanceBefore, expectedAmount);
         assertEq(contractUsdcBalanceBefore - USDC.balanceOf(address(ipRoyaltyVault)), expectedAmount);
-        assertEq(usdcClaimVaultBefore - ipRoyaltyVault.claimVaultAmount(address(USDC)), expectedAmount);
-        assertEq(ipRoyaltyVault.isClaimedAtSnapshot(1, rewardPool, address(USDC)), true);
-        assertEq(ipRoyaltyVault.isClaimedAtSnapshot(2, rewardPool, address(USDC)), true);
     }
 
     function test_IpRoyaltyVault_claimByTokenBatchAsSelf_revert_InvalidTargetIpId() public {
@@ -546,7 +357,7 @@ contract TestIpRoyaltyVault is BaseTest {
         vm.stopPrank();
 
         vm.expectRevert(Errors.IpRoyaltyVault__InvalidTargetIpId.selector);
-        ipRoyaltyVault.claimByTokenBatchAsSelf(1, new address[](0), address(0));
+        ipRoyaltyVault.claimByTokenBatchAsSelf(new address[](0), address(0));
     }
 
     function test_IpRoyaltyVault_claimByTokenBatchAsSelf_revert_VaultDoesNotBelongToAnAncestor() public {
@@ -576,10 +387,6 @@ contract TestIpRoyaltyVault is BaseTest {
         royaltyModule.payRoyaltyOnBehalf(address(2), address(2), address(LINK), royaltyAmount);
         vm.stopPrank();
 
-        // take snapshot
-        vm.warp(block.timestamp + 7 days + 1);
-        ipRoyaltyVault.snapshot();
-
         address[] memory tokens = new address[](2);
         tokens[0] = address(USDC);
         tokens[1] = address(LINK);
@@ -589,7 +396,7 @@ contract TestIpRoyaltyVault is BaseTest {
         uint256 expectedAmount = (royaltyAmount * 30e6) / 100e6;
 
         vm.expectRevert(Errors.IpRoyaltyVault__VaultDoesNotBelongToAnAncestor.selector);
-        ipRoyaltyVault3.claimByTokenBatchAsSelf(1, tokens, address(2));
+        ipRoyaltyVault3.claimByTokenBatchAsSelf(tokens, address(2));
     }
 
     function test_IpRoyaltyVault_claimByTokenBatchAsSelf() public {
@@ -624,10 +431,6 @@ contract TestIpRoyaltyVault is BaseTest {
         royaltyModule.payRoyaltyOnBehalf(address(2), address(1), address(LINK), royaltyAmount);
         vm.stopPrank();
 
-        // take snapshot
-        vm.warp(block.timestamp + 7 days + 1);
-        ipRoyaltyVault.snapshot();
-
         address[] memory tokens = new address[](2);
         tokens[0] = address(USDC);
         tokens[1] = address(LINK);
@@ -637,9 +440,7 @@ contract TestIpRoyaltyVault is BaseTest {
         //uint256 claimedUsdcBalanceBefore = USDC.balanceOf(address(ipRoyaltyVault));
         uint256 claimedLinkBalanceBefore = LINK.balanceOf(address(ipRoyaltyVault));
         //uint256 usdcClaimVaultBefore = ipRoyaltyVault.claimVaultAmount(address(USDC));
-        uint256 linkClaimVaultBefore = ipRoyaltyVault.claimVaultAmount(address(LINK));
         //uint256 usdcPendingVaultBefore = ipRoyaltyVault3.pendingVaultAmount(address(USDC));
-        uint256 linkPendingVaultBefore = ipRoyaltyVault3.pendingVaultAmount(address(LINK));
 
         vm.startPrank(address(100));
 
@@ -651,134 +452,14 @@ contract TestIpRoyaltyVault is BaseTest {
         vm.expectEmit(true, true, true, true, address(ipRoyaltyVault));
         emit IIpRoyaltyVault.RevenueTokenClaimed(address(ipRoyaltyVault3), address(LINK), expectedAmount);
 
-        ipRoyaltyVault3.claimByTokenBatchAsSelf(1, tokens, address(2));
+        ipRoyaltyVault3.claimByTokenBatchAsSelf(tokens, address(2));
 
         assertEq(USDC.balanceOf(address(ipRoyaltyVault3)) - claimerUsdcBalanceBefore, expectedAmount);
         assertEq(LINK.balanceOf(address(ipRoyaltyVault3)) - claimerLinkBalanceBefore, expectedAmount);
         //assertEq(claimedUsdcBalanceBefore - USDC.balanceOf(address(ipRoyaltyVault)), expectedAmount);
         assertEq(claimedLinkBalanceBefore - LINK.balanceOf(address(ipRoyaltyVault)), expectedAmount);
         //assertEq(usdcClaimVaultBefore - ipRoyaltyVault.claimVaultAmount(address(USDC)), expectedAmount);
-        assertEq(linkClaimVaultBefore - ipRoyaltyVault.claimVaultAmount(address(LINK)), expectedAmount);
         //assertEq(ipRoyaltyVault.isClaimedAtSnapshot(1, address(ipRoyaltyVault3), address(USDC)), true);
-        assertEq(ipRoyaltyVault.isClaimedAtSnapshot(1, address(ipRoyaltyVault3), address(LINK)), true);
         //assertEq(ipRoyaltyVault3.pendingVaultAmount(address(USDC)) - usdcPendingVaultBefore, expectedAmount);
-        assertEq(ipRoyaltyVault3.pendingVaultAmount(address(LINK)) - linkPendingVaultBefore, expectedAmount);
-    }
-
-    function test_IpRoyaltyVault_claimBySnapshotBatchAsSelf_revert_InvalidTargetIpId() public {
-        // deploy vault
-        vm.startPrank(address(licensingModule));
-        royaltyModule.onLicenseMinting(address(1), address(royaltyPolicyLAP), uint32(10 * 10 ** 6), "");
-        IpRoyaltyVault ipRoyaltyVault = IpRoyaltyVault(royaltyModule.ipRoyaltyVaults(address(1)));
-        vm.stopPrank();
-
-        vm.expectRevert(Errors.IpRoyaltyVault__InvalidTargetIpId.selector);
-        ipRoyaltyVault.claimBySnapshotBatchAsSelf(new uint256[](0), address(USDC), address(0));
-    }
-
-    function test_IpRoyaltyVault_claimBySnapshotBatchAsSelf_revert_VaultDoesNotBelongToAnAncestor() public {
-        // deploy two vaults and send 30% of rts to another address
-        uint256 royaltyAmount = 100000 * 10 ** 6;
-        USDC.mint(address(1), royaltyAmount); // 100k USDC
-        LINK.mint(address(1), royaltyAmount); // 100k LINK
-        vm.startPrank(address(licensingModule));
-        royaltyModule.onLicenseMinting(address(2), address(royaltyPolicyLAP), uint32(10 * 10 ** 6), "");
-        IpRoyaltyVault ipRoyaltyVault = IpRoyaltyVault(royaltyModule.ipRoyaltyVaults(address(2)));
-        vm.stopPrank();
-
-        vm.startPrank(address(licensingModule));
-        royaltyModule.onLicenseMinting(address(3), address(royaltyPolicyLAP), uint32(10 * 10 ** 6), "");
-        IpRoyaltyVault ipRoyaltyVault3 = IpRoyaltyVault(royaltyModule.ipRoyaltyVaults(address(3)));
-        vm.stopPrank();
-
-        vm.prank(address(2));
-        IERC20(address(ipRoyaltyVault)).transfer(address(ipRoyaltyVault3), 30e6);
-        vm.stopPrank();
-
-        // payment is made to vault
-        vm.startPrank(address(1));
-        USDC.approve(address(royaltyModule), royaltyAmount);
-        royaltyModule.payRoyaltyOnBehalf(address(2), address(1), address(USDC), royaltyAmount);
-        LINK.approve(address(royaltyModule), royaltyAmount);
-        royaltyModule.payRoyaltyOnBehalf(address(2), address(1), address(LINK), royaltyAmount);
-        vm.stopPrank();
-
-        // take snapshot
-        vm.warp(block.timestamp + 7 days + 1);
-        ipRoyaltyVault.snapshot();
-
-        uint256[] memory snapshots = new uint256[](2);
-        snapshots[0] = 1;
-        snapshots[1] = 2;
-
-        vm.startPrank(address(100));
-
-        vm.expectRevert(Errors.IpRoyaltyVault__VaultDoesNotBelongToAnAncestor.selector);
-        ipRoyaltyVault3.claimBySnapshotBatchAsSelf(snapshots, address(USDC), address(2));
-    }
-
-    function test_IpRoyaltyVault_claimBySnapshotBatchAsSelf() public {
-        // deploy two vaults and send 30% of rts to another address
-        uint256 royaltyAmount = 100000 * 10 ** 6;
-        USDC.mint(address(1), royaltyAmount * 2); // 100k USDC
-        vm.startPrank(address(licensingModule));
-        royaltyModule.onLicenseMinting(address(2), address(royaltyPolicyLAP), uint32(10 * 10 ** 6), "");
-        IpRoyaltyVault ipRoyaltyVault = IpRoyaltyVault(royaltyModule.ipRoyaltyVaults(address(2)));
-        vm.stopPrank();
-
-        vm.startPrank(address(licensingModule));
-        royaltyModule.onLicenseMinting(address(3), address(royaltyPolicyLAP), uint32(10 * 10 ** 6), "");
-        IpRoyaltyVault ipRoyaltyVault3 = IpRoyaltyVault(royaltyModule.ipRoyaltyVaults(address(3)));
-        vm.stopPrank();
-
-        vm.prank(address(2));
-        IERC20(address(ipRoyaltyVault)).transfer(address(ipRoyaltyVault3), 30e6);
-        vm.stopPrank();
-
-        // mock parent-child relationship
-        address[] memory parents = new address[](1);
-        parents[0] = address(3);
-        ipGraph.addParentIp(address(2), parents);
-
-        // payment is made to vault
-        vm.startPrank(address(1));
-        USDC.approve(address(royaltyModule), royaltyAmount);
-        royaltyModule.payRoyaltyOnBehalf(address(2), address(1), address(USDC), royaltyAmount);
-        vm.stopPrank();
-
-        // take snapshot
-        vm.warp(block.timestamp + 7 days + 1);
-        ipRoyaltyVault.snapshot();
-
-        // payment is made to vault
-        vm.startPrank(address(1));
-        USDC.approve(address(royaltyModule), royaltyAmount);
-        royaltyModule.payRoyaltyOnBehalf(address(2), address(1), address(USDC), royaltyAmount);
-        vm.stopPrank();
-
-        // take snapshot
-        vm.warp(block.timestamp + 15 days + 1);
-        ipRoyaltyVault.snapshot();
-
-        uint256[] memory snapshots = new uint256[](2);
-        snapshots[0] = 1;
-        snapshots[1] = 2;
-
-        uint256 expectedAmount = (royaltyAmount * 2 * 30e6) / 100e6;
-
-        vm.expectEmit(true, true, true, true, address(ipRoyaltyVault));
-        emit IIpRoyaltyVault.RevenueTokenClaimed(address(ipRoyaltyVault3), address(USDC), expectedAmount);
-
-        uint256 claimerUsdcBalanceBefore = USDC.balanceOf(address(ipRoyaltyVault3));
-        uint256 claimedUsdcBalanceBefore = USDC.balanceOf(address(ipRoyaltyVault));
-        uint256 usdcClaimVaultBefore = ipRoyaltyVault.claimVaultAmount(address(USDC));
-        uint256 usdcPendingVaultBefore = ipRoyaltyVault3.pendingVaultAmount(address(USDC));
-
-        ipRoyaltyVault3.claimBySnapshotBatchAsSelf(snapshots, address(USDC), address(2));
-
-        assertEq(USDC.balanceOf(address(ipRoyaltyVault3)) - claimerUsdcBalanceBefore, expectedAmount);
-        assertEq(claimedUsdcBalanceBefore - USDC.balanceOf(address(ipRoyaltyVault)), expectedAmount);
-        assertEq(usdcClaimVaultBefore - ipRoyaltyVault.claimVaultAmount(address(USDC)), expectedAmount);
-        assertEq(ipRoyaltyVault3.pendingVaultAmount(address(USDC)) - usdcPendingVaultBefore, expectedAmount);
     }
 }

--- a/test/foundry/modules/royalty/LAP/RoyaltyPolicyLAP.t.sol
+++ b/test/foundry/modules/royalty/LAP/RoyaltyPolicyLAP.t.sol
@@ -5,7 +5,6 @@ import { IERC20 } from "@openzeppelin/contracts/token/ERC20/IERC20.sol";
 
 // contracts
 import { RoyaltyPolicyLAP } from "../../../../../contracts/modules/royalty/policies/LAP/RoyaltyPolicyLAP.sol";
-import { IIpRoyaltyVault } from "../../../../../contracts/interfaces/modules/royalty/policies/IIpRoyaltyVault.sol";
 import { Errors } from "../../../../../contracts/lib/Errors.sol";
 
 // tests

--- a/test/foundry/modules/royalty/LAP/RoyaltyPolicyLAP.t.sol
+++ b/test/foundry/modules/royalty/LAP/RoyaltyPolicyLAP.t.sol
@@ -283,9 +283,6 @@ contract TestRoyaltyPolicyLAP is BaseTest {
         );
         uint256 usdcAncestorVaultBalanceBefore = USDC.balanceOf(ancestorIpRoyaltyVault);
         uint256 usdcLAPContractBalanceBefore = USDC.balanceOf(address(royaltyPolicyLAP));
-        uint256 ancestorPendingVaultAmountBefore = IIpRoyaltyVault(ancestorIpRoyaltyVault).pendingVaultAmount(
-            address(USDC)
-        );
 
         vm.expectEmit(true, true, true, true, address(royaltyPolicyLAP));
         emit RevenueTransferredToVault(address(80), address(10), address(USDC), 10 * 10 ** 6);
@@ -295,14 +292,10 @@ contract TestRoyaltyPolicyLAP is BaseTest {
         uint256 transferredAmountAfter = royaltyPolicyLAP.getTransferredTokens(address(80), address(10), address(USDC));
         uint256 usdcAncestorVaultBalanceAfter = USDC.balanceOf(ancestorIpRoyaltyVault);
         uint256 usdcLAPContractBalanceAfter = USDC.balanceOf(address(royaltyPolicyLAP));
-        uint256 ancestorPendingVaultAmountAfter = IIpRoyaltyVault(ancestorIpRoyaltyVault).pendingVaultAmount(
-            address(USDC)
-        );
 
         assertEq(transferredAmountAfter - transferredAmountBefore, 10 * 10 ** 6);
         assertEq(usdcAncestorVaultBalanceAfter - usdcAncestorVaultBalanceBefore, 10 * 10 ** 6);
         assertEq(usdcLAPContractBalanceBefore - usdcLAPContractBalanceAfter, 10 * 10 ** 6);
-        assertEq(ancestorPendingVaultAmountAfter - ancestorPendingVaultAmountBefore, 10 * 10 ** 6);
     }
 
     function test_RoyaltyPolicyLAP_getPolicyRtsRequiredToLink() public {

--- a/test/foundry/modules/royalty/LRP/RoyaltyPolicyLRP.t.sol
+++ b/test/foundry/modules/royalty/LRP/RoyaltyPolicyLRP.t.sol
@@ -5,7 +5,6 @@ import { IERC20 } from "@openzeppelin/contracts/token/ERC20/IERC20.sol";
 
 // contracts
 import { RoyaltyPolicyLRP } from "../../../../../contracts/modules/royalty/policies/LRP/RoyaltyPolicyLRP.sol";
-import { IIpRoyaltyVault } from "../../../../../contracts/interfaces/modules/royalty/policies/IIpRoyaltyVault.sol";
 import { Errors } from "../../../../../contracts/lib/Errors.sol";
 
 // tests

--- a/test/foundry/modules/royalty/LRP/RoyaltyPolicyLRP.t.sol
+++ b/test/foundry/modules/royalty/LRP/RoyaltyPolicyLRP.t.sol
@@ -286,23 +286,16 @@ contract TestRoyaltyPolicyLRP is BaseTest {
         );
         uint256 usdcAncestorVaultBalanceBefore = USDC.balanceOf(ancestorIpRoyaltyVault);
         uint256 usdcLRPContractBalanceBefore = USDC.balanceOf(address(royaltyPolicyLRP));
-        uint256 ancestorPendingVaultAmountBefore = IIpRoyaltyVault(ancestorIpRoyaltyVault).pendingVaultAmount(
-            address(USDC)
-        );
 
         royaltyPolicyLRP.transferToVault(address(80), address(10), address(USDC), 10 * 10 ** 6);
 
         uint256 transferredAmountAfter = royaltyPolicyLRP.getTransferredTokens(address(80), address(10), address(USDC));
         uint256 usdcAncestorVaultBalanceAfter = USDC.balanceOf(ancestorIpRoyaltyVault);
         uint256 usdcLRPContractBalanceAfter = USDC.balanceOf(address(royaltyPolicyLRP));
-        uint256 ancestorPendingVaultAmountAfter = IIpRoyaltyVault(ancestorIpRoyaltyVault).pendingVaultAmount(
-            address(USDC)
-        );
 
         assertEq(transferredAmountAfter - transferredAmountBefore, 10 * 10 ** 6);
         assertEq(usdcAncestorVaultBalanceAfter - usdcAncestorVaultBalanceBefore, 10 * 10 ** 6);
         assertEq(usdcLRPContractBalanceBefore - usdcLRPContractBalanceAfter, 10 * 10 ** 6);
-        assertEq(ancestorPendingVaultAmountAfter - ancestorPendingVaultAmountBefore, 10 * 10 ** 6);
     }
 
     function test_RoyaltyPolicyLRP_getPolicyRtsRequiredToLink() public {

--- a/test/foundry/modules/royalty/RoyaltyModule.t.sol
+++ b/test/foundry/modules/royalty/RoyaltyModule.t.sol
@@ -8,7 +8,6 @@ import { PausableUpgradeable } from "@openzeppelin/contracts-upgradeable/utils/P
 // contracts
 import { Errors } from "../../../../contracts/lib/Errors.sol";
 import { RoyaltyModule } from "../../../../contracts/modules/royalty/RoyaltyModule.sol";
-import { IIpRoyaltyVault } from "../../../../contracts/interfaces/modules/royalty/policies/IIpRoyaltyVault.sol";
 
 // tests
 import { BaseTest } from "../../utils/BaseTest.t.sol";

--- a/test/foundry/modules/royalty/RoyaltyModule.t.sol
+++ b/test/foundry/modules/royalty/RoyaltyModule.t.sol
@@ -894,7 +894,6 @@ contract TestRoyaltyModule is BaseTest {
             receiverIpId,
             address(USDC)
         );
-        uint256 pendingVaultAmountBefore = IIpRoyaltyVault(ipRoyaltyVault).pendingVaultAmount(address(USDC));
 
         vm.expectEmit(true, true, true, true, address(royaltyModule));
         emit RoyaltyPaid(receiverIpId, payerIpId, payerIpId, address(USDC), royaltyAmount, royaltyAmount);
@@ -904,12 +903,10 @@ contract TestRoyaltyModule is BaseTest {
         uint256 payerIpIdUSDCBalAfter = USDC.balanceOf(payerIpId);
         uint256 ipRoyaltyVaultUSDCBalAfter = USDC.balanceOf(ipRoyaltyVault);
         uint256 totalRevenueTokensReceivedAfter = royaltyModule.totalRevenueTokensReceived(receiverIpId, address(USDC));
-        uint256 pendingVaultAmountAfter = IIpRoyaltyVault(ipRoyaltyVault).pendingVaultAmount(address(USDC));
 
         assertEq(payerIpIdUSDCBalBefore - payerIpIdUSDCBalAfter, royaltyAmount);
         assertEq(ipRoyaltyVaultUSDCBalAfter - ipRoyaltyVaultUSDCBalBefore, royaltyAmount);
         assertEq(totalRevenueTokensReceivedAfter - totalRevenueTokensReceivedBefore, royaltyAmount);
-        assertEq(pendingVaultAmountAfter - pendingVaultAmountBefore, royaltyAmount);
     }
 
     function test_RoyaltyModule_payRoyaltyOnBehalf_WithFee() public {
@@ -939,7 +936,6 @@ contract TestRoyaltyModule is BaseTest {
             receiverIpId,
             address(USDC)
         );
-        uint256 pendingVaultAmountBefore = IIpRoyaltyVault(ipRoyaltyVault).pendingVaultAmount(address(USDC));
         uint256 usdcTreasuryAmountBefore = USDC.balanceOf(address(100));
 
         vm.expectEmit(true, true, true, true, address(royaltyModule));
@@ -961,10 +957,6 @@ contract TestRoyaltyModule is BaseTest {
         );
         assertEq(
             royaltyModule.totalRevenueTokensReceived(receiverIpId, address(USDC)) - totalRevenueTokensReceivedBefore,
-            (royaltyAmount * 90e6) / royaltyModule.maxPercent()
-        );
-        assertEq(
-            IIpRoyaltyVault(ipRoyaltyVault).pendingVaultAmount(address(USDC)) - pendingVaultAmountBefore,
             (royaltyAmount * 90e6) / royaltyModule.maxPercent()
         );
         assertEq(
@@ -1024,7 +1016,6 @@ contract TestRoyaltyModule is BaseTest {
             receiverIpId,
             address(USDC)
         );
-        uint256 pendingVaultAmountBefore = IIpRoyaltyVault(ipRoyaltyVault).pendingVaultAmount(address(USDC));
 
         vm.expectEmit(true, true, true, true, address(royaltyModule));
         emit LicenseMintingFeePaid(receiverIpId, payerAddress, address(USDC), royaltyAmount, royaltyAmount);
@@ -1036,10 +1027,6 @@ contract TestRoyaltyModule is BaseTest {
         assertEq(USDC.balanceOf(ipRoyaltyVault) - ipRoyaltyVaultUSDCBalBefore, royaltyAmount);
         assertEq(
             royaltyModule.totalRevenueTokensReceived(receiverIpId, address(USDC)) - totalRevenueTokensReceivedBefore,
-            royaltyAmount
-        );
-        assertEq(
-            IIpRoyaltyVault(ipRoyaltyVault).pendingVaultAmount(address(USDC)) - pendingVaultAmountBefore,
             royaltyAmount
         );
     }
@@ -1072,7 +1059,6 @@ contract TestRoyaltyModule is BaseTest {
             receiverIpId,
             address(USDC)
         );
-        uint256 pendingVaultAmountBefore = IIpRoyaltyVault(ipRoyaltyVault).pendingVaultAmount(address(USDC));
         uint256 usdcTreasuryAmountBefore = USDC.balanceOf(address(100));
 
         vm.expectEmit(true, true, true, true, address(royaltyModule));
@@ -1094,10 +1080,6 @@ contract TestRoyaltyModule is BaseTest {
         );
         assertEq(
             royaltyModule.totalRevenueTokensReceived(receiverIpId, address(USDC)) - totalRevenueTokensReceivedBefore,
-            (royaltyAmount * 90e6) / royaltyModule.maxPercent()
-        );
-        assertEq(
-            IIpRoyaltyVault(ipRoyaltyVault).pendingVaultAmount(address(USDC)) - pendingVaultAmountBefore,
             (royaltyAmount * 90e6) / royaltyModule.maxPercent()
         );
         assertEq(

--- a/test/foundry/modules/royalty/VaultController.t.sol
+++ b/test/foundry/modules/royalty/VaultController.t.sol
@@ -17,12 +17,6 @@ contract TestRoyaltyModule is BaseTest {
         vm.startPrank(u.admin);
     }
 
-    function test_VaultController_setSnapshotInterval() public {
-        uint256 timestampInterval = 100;
-        royaltyModule.setSnapshotInterval(timestampInterval);
-        assertEq(royaltyModule.snapshotInterval(), timestampInterval);
-    }
-
     function test_VaultController_setIpRoyaltyVaultBeacon_revert_ZeroIpRoyaltyVaultBeacon() public {
         vm.expectRevert(Errors.VaultController__ZeroIpRoyaltyVaultBeacon.selector);
         royaltyModule.setIpRoyaltyVaultBeacon(address(0));

--- a/yarn.lock
+++ b/yarn.lock
@@ -841,11 +841,6 @@
     "@nomicfoundation/solidity-analyzer-win32-ia32-msvc" "0.1.1"
     "@nomicfoundation/solidity-analyzer-win32-x64-msvc" "0.1.1"
 
-"@openzeppelin/contracts-upgradeable-v4@npm:@openzeppelin/contracts-upgradeable@4.9.6":
-  version "4.9.6"
-  resolved "https://registry.yarnpkg.com/@openzeppelin/contracts-upgradeable/-/contracts-upgradeable-4.9.6.tgz#38b21708a719da647de4bb0e4802ee235a0d24df"
-  integrity sha512-m4iHazOsOCv1DgM7eD7GupTJ+NFVujRZt1wzddDPSVGpWdKq1SKkla5htKG7+IS4d2XOCtzkUNwRZ7Vq5aEUMA==
-
 "@openzeppelin/contracts-upgradeable@5.0.2":
   version "5.0.2"
   resolved "https://registry.yarnpkg.com/@openzeppelin/contracts-upgradeable/-/contracts-upgradeable-5.0.2.tgz#3e5321a2ecdd0b206064356798c21225b6ec7105"


### PR DESCRIPTION
## Description

This PR simplifies the `IpRoyaltyVault` contract by removing the requirement to use snapshots for claiming revenue. The new approach keeps track of the latest pending claimable revenue, allowing users to check the current pending revenue or claim all pending revenue with a single call.

## Key Changes

- **Remove Snapshot Functionality**: Eliminated the need for creating and managing snapshots.
- **Simplified Claim Process**: Users can now claim all pending revenue without specifying snapshot IDs.

