### PR TITLE
Configure Wrapped IP (WIP) as Whitelisted Currency Token

### DIFF
--- a/script/foundry/utils/DeployHelper.sol
+++ b/script/foundry/utils/DeployHelper.sol
@@ -67,6 +67,7 @@ contract DeployHelper is Script, BroadcastManager, JsonDeploymentHandler, Storag
 
     // PROXY 1967 IMPLEMENTATION STORAGE SLOTS
     bytes32 internal constant IMPLEMENTATION_SLOT = 0x360894a13ba1a3210667c828492db98dca3e2076cc3735a920a3ca505d382bbc;
+    address internal constant WIP = address(0x1516000000000000000000000000000000000000);
 
     error RoleConfigError(string message);
 
@@ -744,6 +745,7 @@ contract DeployHelper is Script, BroadcastManager, JsonDeploymentHandler, Storag
         royaltyModule.whitelistRoyaltyPolicy(address(royaltyPolicyLAP), true);
         royaltyModule.whitelistRoyaltyPolicy(address(royaltyPolicyLRP), true);
         royaltyModule.whitelistRoyaltyToken(address(erc20), true);
+        royaltyModule.whitelistRoyaltyToken(WIP, true);
         royaltyModule.setSnapshotInterval(7 days);
         royaltyModule.setIpRoyaltyVaultBeacon(address(ipRoyaltyVaultBeacon));
         ipRoyaltyVaultBeacon.transferOwnership(address(royaltyModule));


### PR DESCRIPTION
## Description

This PR updates the deployment script to include Wrapped IP (WIP) as a whitelisted currency token when deploying the protocol. This ensures that WIP is recognized and can be used within the protocol from the moment of deployment.

## Key Changes

- **Whitelist WIP**: Added Wrapped IP (WIP) to the list of whitelisted currency tokens in the deployment script.
