### PR TITLE
fix typos in documentation files 

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -28,5 +28,5 @@ assignees: ''
 
 
 ## Solution recommendation
-<!--- Not mandatory, but feel free to recommend a way fix the issue. -->
+<!--- Not mandatory, but feel free to recommend a way to fix the issue. -->
 

--- a/test/foundry/modules/licensing/README.md
+++ b/test/foundry/modules/licensing/README.md
@@ -69,12 +69,12 @@ Alice wants to burn L1,L2 and L3 to link as parents for IP4
 | Commercial use          | Equal or revert                                     | One would infringe the other                                                                                      |
 | Commercial attribution  | Indifferent                                         | Holder of all licenses must attribute the ones demanding it. Disputable                                           |
 | Commercializers         | Indifferent                                         | OK if verification checks for all licenses succeed                                                                |
-| Commercial Rev Share    | Indifferent                                         | Licensing proccess must set all. Verifications must pass                                                          |
+| Commercial Rev Share    | Indifferent                                         | Licensing process must set all. Verifications must pass                                                          |
 | Derivatives             | Equal or revert                                     | One would infringe the other                                                                                      |
 | Derivatives Attribution | Indifferent                                         | Holder of all licenses must attribute the ones demanding it. Disputable                                           |
 | Derivatives Approval    | Indifferent                                         | OK if verification checks for all licenses succeed                                                                |
 | Derivatives Reciprocal  | Equal or revert. If both true, policy must be equal | One would infringe the other                                                                                      |
-| Derivatives Rev Share   | Indifferent                                         | Licensing proccess must set all. Verifications must pass                                                          |
+| Derivatives Rev Share   | Indifferent                                         | Licensing process must set all. Verifications must pass                                                          |
 | Territories             | All equal, or some empty and the rest equal         | All permissive is OK. Some permissive except some with same restrictions OK. Different restrictions is a conflict |
 | Distribution Channels   | Same as previous                                    | Same as previous                                                                                                  |
 | Content Restrictions    | Same as previous                                    | Same as previous                                                                                                  |
@@ -127,7 +127,7 @@ Alice cannot set policies in IP2
 Alice cannot mint licenses from IP2
 // TODO: royalties?
 
-# Unnatributed derivative
+# Unattributed derivative
 Bob owns IP1 
 Bob sets P1 in IP1 (he can, since he clains IP1 is original)
 Alice owns IP2


### PR DESCRIPTION
## Description
This PR introduces the following updates:

- Fixed a small inconsistency in the bug report template in `.github/ISSUE_TEMPLATE/bug_report.md` by adjusting a comment regarding the recommendation to fix the issue.
- Corrected the spelling error in the `Licensing/README.md` file, changing "Licensing process must set all" to a more consistent wording.

## Test Plan
- 1. Review the `.github/ISSUE_TEMPLATE/bug_report.md` for proper wording in the comments regarding issue fixing.
- 2. Check the `Licensing/README.md` to confirm the accuracy of the text changes related to the licensing process.