### PR TITLE
Make IP Registration Idempotent by Returning Existing IP ID

### DIFF
--- a/contracts/lib/Errors.sol
+++ b/contracts/lib/Errors.sol
@@ -143,9 +143,6 @@ library Errors {
     /// @notice Zero address provided for Access Manager in initializer.
     error IPAssetRegistry__ZeroAccessManager();
 
-    /// @notice The IP asset has already been registered.
-    error IPAssetRegistry__AlreadyRegistered();
-
     /// @notice The NFT token contract is not valid ERC721 contract.
     error IPAssetRegistry__UnsupportedIERC721(address contractAddress);
 

--- a/contracts/registries/IPAssetRegistry.sol
+++ b/contracts/registries/IPAssetRegistry.sol
@@ -75,7 +75,8 @@ contract IPAssetRegistry is
         __UUPSUpgradeable_init();
     }
 
-    /// @notice Registers an NFT as an IP asset.
+    /// @notice Registers an NFT as an IP asset and creates an IP account for it.
+    ///         if the IP was already registered, return the IP address.
     /// @dev The IP required metadata name and URI are derived from the NFT's metadata.
     /// @param chainid The chain identifier of where the IP NFT resides.
     /// @param tokenContract The address of the NFT.
@@ -104,8 +105,9 @@ contract IPAssetRegistry is
         id = _registerIpAccount(chainid, tokenContract, tokenId);
         IIPAccount ipAccount = IIPAccount(payable(id));
 
+        // return if the IP was already registered
         if (bytes(ipAccount.getString("NAME")).length != 0) {
-            revert Errors.IPAssetRegistry__AlreadyRegistered();
+            return id;
         }
 
         (string memory name, string memory uri) = _getNameAndUri(chainid, tokenContract, tokenId);

--- a/test/foundry/invariants/IPAssetRegistry.t.sol
+++ b/test/foundry/invariants/IPAssetRegistry.t.sol
@@ -169,10 +169,9 @@ contract IPAssetRegistryAllRegisteredInvariants is IPAssetRegistryInvariants {
         harness.register(3);
     }
 
-    /// @dev Invariant: every registration should revert when the IP Account is already registered
-    function invariant_allRevert() public {
+    /// @dev Invariant: every registration should return existing IP Account address
+    function invariant_idempotency() public {
         for (uint256 i = 0; i < harness.ipAccountCount(); i++) {
-            vm.expectRevert(abi.encodeWithSelector(Errors.IPAssetRegistry__AlreadyRegistered.selector));
             harness.register(uint8(i));
         }
     }

--- a/test/foundry/invariants/IPAssetRegistry.t.sol
+++ b/test/foundry/invariants/IPAssetRegistry.t.sol
@@ -10,7 +10,6 @@ import { IPAccountStorageOps } from "contracts/lib/IPAccountStorageOps.sol";
 import { IERC721Metadata } from "@openzeppelin/contracts/token/ERC721/extensions/IERC721Metadata.sol";
 import { IERC721 } from "@openzeppelin/contracts/token/ERC721/IERC721.sol";
 import { PausableUpgradeable } from "@openzeppelin/contracts-upgradeable/utils/PausableUpgradeable.sol";
-import { Errors } from "contracts/lib/Errors.sol";
 import { Test } from "forge-std/Test.sol";
 import { ShortStrings } from "@openzeppelin/contracts/utils/ShortStrings.sol";
 import { Strings } from "@openzeppelin/contracts/utils/Strings.sol";

--- a/test/foundry/registries/IPAssetRegistry.t.sol
+++ b/test/foundry/registries/IPAssetRegistry.t.sol
@@ -214,11 +214,22 @@ contract IPAssetRegistryTest is BaseTest {
         assertTrue(!IPAccountChecker.isRegistered(ipAccountRegistry, block.chainid, tokenAddress, tokenId));
 
         vm.prank(alice);
-        registry.register(block.chainid, tokenAddress, tokenId);
+        string memory name = string.concat(block.chainid.toString(), ": Ape #99");
+        vm.expectEmit(true, true, true, true);
+        emit IIPAssetRegistry.IPRegistered(
+            ipId,
+            block.chainid,
+            tokenAddress,
+            tokenId,
+            name,
+            "https://storyprotocol.xyz/erc721/99",
+            block.timestamp
+        );
+        address ipId = registry.register(block.chainid, tokenAddress, tokenId);
 
-        vm.expectRevert(Errors.IPAssetRegistry__AlreadyRegistered.selector);
         vm.prank(alice);
-        registry.register(block.chainid, tokenAddress, tokenId);
+        address ipIdAgain = registry.register(block.chainid, tokenAddress, tokenId);
+        assertEq(ipId, ipIdAgain);
     }
 
     function test_IPAssetRegistry_revert_paused() public {
@@ -311,10 +322,10 @@ contract IPAssetRegistryTest is BaseTest {
         assertTrue(!registry.isRegistered(ipId));
         assertTrue(!IPAccountChecker.isRegistered(ipAccountRegistry, block.chainid, tokenAddress, tokenId));
 
-        registry.register(chainid, tokenAddress, tokenId);
+        address ipId = registry.register(chainid, tokenAddress, tokenId);
 
-        vm.expectRevert(Errors.IPAssetRegistry__AlreadyRegistered.selector);
-        registry.register(chainid, tokenAddress, tokenId);
+        address ipIdAgain = registry.register(chainid, tokenAddress, tokenId);
+        assertEq(ipId, ipIdAgain);
     }
 
     /// @notice Helper function for generating an account address.


### PR DESCRIPTION
## Description

This PR updates the IP registration process to be idempotent. When attempting to register an IP with the same `chainId`, `nftTokenContract`, and `tokenId`, the function will now return the existing `ipId` instead of reverting. This ensures that the registration process is idempotent.

## Key Changes

- **Idempotent Registration**: Modified the IP registration function to return the existing `ipId` if the IP is already registered with the same `chainId`, `nftTokenContract`, and `tokenId`.

## Objectives

- **Ensure Idempotency**: Make the IP registration process idempotent by returning the existing `ipId` for duplicate registrations.
- **Improve User Experience**: Allow users to safely re-register IPs without causing errors or reverts.

## Implementation Steps

1. **Update Registration Function**: Modify the IP registration function to check for existing IPs and return the existing `ipId` if found.
2. **Testing**: Add tests to verify the idempotent behavior of the registration function.

This update ensures that the IP registration process is idempotent, improving the robustness and user experience of the protocol.