### PR TITLE
Validate IP Account Address Registration Through IPAssetRegistry

### DIFF
--- a/contracts/access/AccessControlled.sol
+++ b/contracts/access/AccessControlled.sol
@@ -3,7 +3,7 @@ pragma solidity 0.8.26;
 
 import { IAccessController } from "../interfaces/access/IAccessController.sol";
 import { IPAccountChecker } from "../lib/registries/IPAccountChecker.sol";
-import { IIPAccountRegistry } from "../interfaces/registries/IIPAccountRegistry.sol";
+import { IIPAssetRegistry } from "../interfaces/registries/IIPAssetRegistry.sol";
 import { Errors } from "../lib/Errors.sol";
 
 /// @title AccessControlled
@@ -14,14 +14,14 @@ import { Errors } from "../lib/Errors.sol";
 /// It provides modifiers and functions to verify if the caller has the necessary permission
 /// and is a registered IP account.
 abstract contract AccessControlled {
-    using IPAccountChecker for IIPAccountRegistry;
+    using IPAccountChecker for IIPAssetRegistry;
 
     /// @notice The IAccessController instance for permission checks.
     /// @custom:oz-upgrades-unsafe-allow state-variable-immutable
     IAccessController public immutable ACCESS_CONTROLLER;
-    /// @notice The IIPAccountRegistry instance for IP account verification.
+    /// @notice The IIPAssetRegistry instance for IP account verification.
     /// @custom:oz-upgrades-unsafe-allow state-variable-immutable
-    IIPAccountRegistry public immutable IP_ACCOUNT_REGISTRY;
+    IIPAssetRegistry public immutable IP_ASSET_REGISTRY;
 
     /// @notice Verifies that the caller has the necessary permission for the given IPAccount.
     /// @dev Modifier that calls _verifyPermission to check if the provided IP account has the required permission.
@@ -37,7 +37,7 @@ abstract contract AccessControlled {
     /// modules can use this modifier to check if the caller is a registered IP account.
     /// so that enforce only registered IP Account can call the functions.
     modifier onlyIpAccount() {
-        if (!IP_ACCOUNT_REGISTRY.isIpAccount(msg.sender)) {
+        if (!IP_ASSET_REGISTRY.isIpAccount(msg.sender)) {
             revert Errors.AccessControlled__CallerIsNotIpAccount(msg.sender);
         }
         _;
@@ -51,14 +51,14 @@ abstract contract AccessControlled {
         if (accessController == address(0)) revert Errors.AccessControlled__ZeroAddress();
         if (ipAccountRegistry == address(0)) revert Errors.AccessControlled__ZeroAddress();
         ACCESS_CONTROLLER = IAccessController(accessController);
-        IP_ACCOUNT_REGISTRY = IIPAccountRegistry(ipAccountRegistry);
+        IP_ASSET_REGISTRY = IIPAssetRegistry(ipAccountRegistry);
     }
 
     /// @dev Internal function to verify if the caller (msg.sender) has the required permission to execute
     /// the function on provided ipAccount.
     /// @param ipAccount The address of the IP account to verify.
     function _verifyPermission(address ipAccount) internal view {
-        if (!IP_ACCOUNT_REGISTRY.isIpAccount(ipAccount)) {
+        if (!IP_ASSET_REGISTRY.isIpAccount(ipAccount)) {
             revert Errors.AccessControlled__NotIpAccount(ipAccount);
         }
 
@@ -73,7 +73,7 @@ abstract contract AccessControlled {
     /// @param ipAccount The address of the IP account to check.
     /// @return bool Returns true if the caller has permission, false otherwise.
     function _hasPermission(address ipAccount) internal view returns (bool) {
-        if (!IP_ACCOUNT_REGISTRY.isIpAccount(ipAccount)) {
+        if (!IP_ASSET_REGISTRY.isIpAccount(ipAccount)) {
             return false;
         }
 

--- a/contracts/access/AccessController.sol
+++ b/contracts/access/AccessController.sol
@@ -6,7 +6,7 @@ import { UUPSUpgradeable } from "@openzeppelin/contracts-upgradeable/proxy/utils
 
 import { IAccessController } from "../interfaces/access/IAccessController.sol";
 import { IModuleRegistry } from "../interfaces/registries/IModuleRegistry.sol";
-import { IIPAccountRegistry } from "../interfaces/registries/IIPAccountRegistry.sol";
+import { IIPAssetRegistry } from "../interfaces/registries/IIPAssetRegistry.sol";
 import { IModuleRegistry } from "../interfaces/registries/IModuleRegistry.sol";
 import { IIPAccount } from "../interfaces/IIPAccount.sol";
 import { ProtocolPausableUpgradeable } from "../pause/ProtocolPausableUpgradeable.sol";
@@ -18,7 +18,7 @@ import { Errors } from "../lib/Errors.sol";
 /// @dev This contract is used to control access permissions for different function calls in the protocol.
 /// It allows setting permissions for specific function calls, checking permissions, and initializing the contract.
 /// The contract uses a mapping to store policies, which are represented as a nested mapping structure.
-/// The contract also interacts with other contracts such as IIPAccountRegistry, IModuleRegistry, and IIPAccount.
+/// The contract also interacts with other contracts such as IIPAssetRegistry, IModuleRegistry, and IIPAccount.
 ///
 /// Each policy is represented as a mapping from an IP account address to a signer address to a recipient
 /// address to a function selector to a permission level.
@@ -30,10 +30,10 @@ import { Errors } from "../lib/Errors.sol";
 /// - getPermission: Returns the permission level for a specific function call.
 /// - checkPermission: Checks if a specific function call is allowed.
 contract AccessController is IAccessController, ProtocolPausableUpgradeable, UUPSUpgradeable {
-    using IPAccountChecker for IIPAccountRegistry;
+    using IPAccountChecker for IIPAssetRegistry;
 
     /// @custom:oz-upgrades-unsafe-allow state-variable-immutable
-    IIPAccountRegistry public immutable IP_ACCOUNT_REGISTRY;
+    IIPAssetRegistry public immutable IP_ASSET_REGISTRY;
     /// @custom:oz-upgrades-unsafe-allow state-variable-immutable
     IModuleRegistry public immutable MODULE_REGISTRY;
 
@@ -56,7 +56,7 @@ contract AccessController is IAccessController, ProtocolPausableUpgradeable, UUP
     constructor(address ipAccountRegistry, address moduleRegistry) {
         if (ipAccountRegistry == address(0)) revert Errors.AccessController__ZeroIPAccountRegistry();
         if (moduleRegistry == address(0)) revert Errors.AccessController__ZeroModuleRegistry();
-        IP_ACCOUNT_REGISTRY = IIPAccountRegistry(ipAccountRegistry);
+        IP_ASSET_REGISTRY = IIPAssetRegistry(ipAccountRegistry);
         MODULE_REGISTRY = IModuleRegistry(moduleRegistry);
         _disableInitializers();
     }
@@ -137,7 +137,7 @@ contract AccessController is IAccessController, ProtocolPausableUpgradeable, UUP
     function checkPermission(address ipAccount, address signer, address to, bytes4 func) external view {
         AccessControllerStorage storage $ = _getAccessControllerStorage();
         // Must be a valid IPAccount
-        if (!IP_ACCOUNT_REGISTRY.isIpAccount(ipAccount)) {
+        if (!IP_ASSET_REGISTRY.isIpAccount(ipAccount)) {
             revert Errors.AccessController__IPAccountIsNotValid(ipAccount);
         }
         // Owner can call any contracts either registered module or unregistered/external contracts
@@ -201,7 +201,7 @@ contract AccessController is IAccessController, ProtocolPausableUpgradeable, UUP
             revert Errors.AccessController__SignerIsZeroAddress();
         }
         AccessControllerStorage storage $ = _getAccessControllerStorage();
-        if (!IP_ACCOUNT_REGISTRY.isIpAccount(ipAccount)) {
+        if (!IP_ASSET_REGISTRY.isIpAccount(ipAccount)) {
             revert Errors.AccessController__IPAccountIsNotValid(ipAccount);
         }
         // permission must be one of ABSTAIN, ALLOW, DENY

--- a/contracts/lib/registries/IPAccountChecker.sol
+++ b/contracts/lib/registries/IPAccountChecker.sol
@@ -31,10 +31,7 @@ library IPAccountChecker {
     /// @param ipAssetRegistry_ The IP Account registry contract.
     /// @param ipAccountAddress_ The address to check.
     /// @return True if the address is a valid IP Account, false otherwise.
-    function isIpAccount(
-        IIPAssetRegistry ipAssetRegistry_,
-        address ipAccountAddress_
-    ) internal view returns (bool) {
+    function isIpAccount(IIPAssetRegistry ipAssetRegistry_, address ipAccountAddress_) internal view returns (bool) {
         if (ipAccountAddress_ == address(0)) return false;
         if (ipAccountAddress_.code.length == 0) return false;
         if (!ERC165Checker.supportsERC165(ipAccountAddress_)) return false;

--- a/contracts/lib/registries/IPAccountChecker.sol
+++ b/contracts/lib/registries/IPAccountChecker.sol
@@ -4,7 +4,7 @@ pragma solidity 0.8.26;
 import { ERC165Checker } from "@openzeppelin/contracts/utils/introspection/ERC165Checker.sol";
 import { IERC6551Account } from "erc6551/interfaces/IERC6551Account.sol";
 
-import { IIPAccountRegistry } from "../../interfaces/registries/IIPAccountRegistry.sol";
+import { IIPAssetRegistry } from "../../interfaces/registries/IIPAssetRegistry.sol";
 import { IIPAccount } from "../../interfaces/IIPAccount.sol";
 import { IIPAccountStorage } from "../../interfaces/IIPAccountStorage.sol";
 
@@ -19,20 +19,20 @@ library IPAccountChecker {
     /// @param tokenId_ The ID of the token associated with the IP Account.
     /// @return True if the IP Account is registered, false otherwise.
     function isRegistered(
-        IIPAccountRegistry ipAccountRegistry_,
+        IIPAssetRegistry ipAssetRegistry_,
         uint256 chainId_,
         address tokenContract_,
         uint256 tokenId_
     ) internal view returns (bool) {
-        return ipAccountRegistry_.ipAccount(chainId_, tokenContract_, tokenId_).code.length != 0;
+        return ipAssetRegistry_.isRegistered(ipAssetRegistry_.ipId(chainId_, tokenContract_, tokenId_));
     }
 
     /// @notice Checks if the given address is a valid IP Account.
-    /// @param ipAccountRegistry_ The IP Account registry contract.
+    /// @param ipAssetRegistry_ The IP Account registry contract.
     /// @param ipAccountAddress_ The address to check.
     /// @return True if the address is a valid IP Account, false otherwise.
     function isIpAccount(
-        IIPAccountRegistry ipAccountRegistry_,
+        IIPAssetRegistry ipAssetRegistry_,
         address ipAccountAddress_
     ) internal view returns (bool) {
         if (ipAccountAddress_ == address(0)) return false;
@@ -41,7 +41,6 @@ library IPAccountChecker {
         if (!ERC165Checker.supportsInterface(ipAccountAddress_, type(IERC6551Account).interfaceId)) return false;
         if (!ERC165Checker.supportsInterface(ipAccountAddress_, type(IIPAccount).interfaceId)) return false;
         if (!ERC165Checker.supportsInterface(ipAccountAddress_, type(IIPAccountStorage).interfaceId)) return false;
-        (uint chainId, address tokenContract, uint tokenId) = IIPAccount(payable(ipAccountAddress_)).token();
-        return ipAccountAddress_ == ipAccountRegistry_.ipAccount(chainId, tokenContract, tokenId);
+        return ipAssetRegistry_.isRegistered(ipAccountAddress_);
     }
 }

--- a/contracts/modules/dispute/DisputeModule.sol
+++ b/contracts/modules/dispute/DisputeModule.sol
@@ -9,7 +9,6 @@ import { MulticallUpgradeable } from "@openzeppelin/contracts-upgradeable/utils/
 import { DISPUTE_MODULE_KEY } from "../../lib/modules/Module.sol";
 import { BaseModule } from "../../modules/BaseModule.sol";
 import { AccessControlled } from "../../access/AccessControlled.sol";
-import { IIPAssetRegistry } from "../../interfaces/registries/IIPAssetRegistry.sol";
 import { ILicenseRegistry } from "../../interfaces/registries/ILicenseRegistry.sol";
 import { IDisputeModule } from "../../interfaces/modules/dispute/IDisputeModule.sol";
 import { IArbitrationPolicy } from "../../interfaces/modules/dispute/policies/IArbitrationPolicy.sol";

--- a/contracts/modules/dispute/DisputeModule.sol
+++ b/contracts/modules/dispute/DisputeModule.sol
@@ -67,10 +67,6 @@ contract DisputeModule is
     /// @notice Tag to represent the dispute is in dispute state waiting for judgement
     bytes32 public constant IN_DISPUTE = bytes32("IN_DISPUTE");
 
-    /// @notice Protocol-wide IP asset registry
-    /// @custom:oz-upgrades-unsafe-allow state-variable-immutable
-    IIPAssetRegistry public immutable IP_ASSET_REGISTRY;
-
     /// @notice Protocol-wide license registry
     /// @custom:oz-upgrades-unsafe-allow state-variable-immutable
     ILicenseRegistry public immutable LICENSE_REGISTRY;
@@ -89,7 +85,6 @@ contract DisputeModule is
         if (ipAssetRegistry == address(0)) revert Errors.DisputeModule__ZeroIPAssetRegistry();
         if (accessController == address(0)) revert Errors.DisputeModule__ZeroAccessController();
 
-        IP_ASSET_REGISTRY = IIPAssetRegistry(ipAssetRegistry);
         LICENSE_REGISTRY = ILicenseRegistry(licenseRegistry);
         _disableInitializers();
     }

--- a/contracts/modules/licensing/LicensingModule.sol
+++ b/contracts/modules/licensing/LicensingModule.sol
@@ -11,7 +11,7 @@ import { UUPSUpgradeable } from "@openzeppelin/contracts-upgradeable/proxy/utils
 import { IIPAccount } from "../../interfaces/IIPAccount.sol";
 import { IModule } from "../../interfaces/modules/base/IModule.sol";
 import { ILicensingModule } from "../../interfaces/modules/licensing/ILicensingModule.sol";
-import { IIPAccountRegistry } from "../../interfaces/registries/IIPAccountRegistry.sol";
+import { IIPAssetRegistry } from "../../interfaces/registries/IIPAssetRegistry.sol";
 import { IDisputeModule } from "../../interfaces/modules/dispute/IDisputeModule.sol";
 import { ILicenseRegistry } from "../../interfaces/registries/ILicenseRegistry.sol";
 import { Errors } from "../../lib/Errors.sol";
@@ -42,7 +42,7 @@ contract LicensingModule is
     UUPSUpgradeable
 {
     using ERC165Checker for address;
-    using IPAccountChecker for IIPAccountRegistry;
+    using IPAccountChecker for IIPAssetRegistry;
     using EnumerableSet for EnumerableSet.UintSet;
     using EnumerableSet for EnumerableSet.AddressSet;
     using Strings for *;
@@ -172,7 +172,7 @@ contract LicensingModule is
         if (receiver == address(0)) {
             revert Errors.LicensingModule__ReceiverZeroAddress();
         }
-        if (!IP_ACCOUNT_REGISTRY.isIpAccount(licensorIpId)) {
+        if (!IP_ASSET_REGISTRY.isIpAccount(licensorIpId)) {
             revert Errors.LicensingModule__LicensorIpNotRegistered();
         }
         _verifyIpNotDisputed(licensorIpId);
@@ -460,7 +460,7 @@ contract LicensingModule is
         if (receiver == address(0)) {
             revert Errors.LicensingModule__ReceiverZeroAddress();
         }
-        if (!IP_ACCOUNT_REGISTRY.isIpAccount(licensorIpId)) {
+        if (!IP_ASSET_REGISTRY.isIpAccount(licensorIpId)) {
             revert Errors.LicensingModule__LicensorIpNotRegistered();
         }
         Licensing.LicensingConfig memory lsc = LICENSE_REGISTRY.verifyMintLicenseToken(

--- a/test/foundry/IPAccount.t.sol
+++ b/test/foundry/IPAccount.t.sol
@@ -65,7 +65,7 @@ contract IPAccountTest is BaseTest {
         mockNFT.mintId(owner, tokenId);
 
         vm.prank(owner, owner);
-        address account = mockIpAccountRegistry.registerIpAccount(block.chainid, address(mockNFT), tokenId);
+        address account = ipAssetRegistry.register(block.chainid, address(mockNFT), tokenId);
 
         IIPAccount ipAccount = IIPAccount(payable(account));
 
@@ -100,7 +100,7 @@ contract IPAccountTest is BaseTest {
         mockNFT.mintId(owner, tokenId);
 
         vm.prank(owner, owner);
-        address account = mockIpAccountRegistry.registerIpAccount(block.chainid, address(mockNFT), tokenId);
+        address account = ipAssetRegistry.register(block.chainid, address(mockNFT), tokenId);
 
         uint256 subTokenId = 111;
         mockNFT.mintId(account, subTokenId);
@@ -136,7 +136,7 @@ contract IPAccountTest is BaseTest {
 
         mockNFT.mintId(owner, tokenId);
 
-        address account = mockIpAccountRegistry.registerIpAccount(block.chainid, address(mockNFT), tokenId);
+        address account = ipAssetRegistry.register(block.chainid, address(mockNFT), tokenId);
 
         IIPAccount ipAccount = IIPAccount(payable(account));
 
@@ -165,7 +165,7 @@ contract IPAccountTest is BaseTest {
 
         mockNFT.mintId(owner, tokenId);
 
-        address account = mockIpAccountRegistry.registerIpAccount(block.chainid, address(mockNFT), tokenId);
+        address account = ipAssetRegistry.register(block.chainid, address(mockNFT), tokenId);
 
         IIPAccount ipAccount = IIPAccount(payable(account));
 
@@ -218,7 +218,7 @@ contract IPAccountTest is BaseTest {
 
         mockNFT.mintId(owner, tokenId);
 
-        address account = mockIpAccountRegistry.registerIpAccount(block.chainid, address(mockNFT), tokenId);
+        address account = ipAssetRegistry.register(block.chainid, address(mockNFT), tokenId);
 
         uint256 subTokenId = 111;
         mockNFT.mintId(account, subTokenId);
@@ -245,7 +245,7 @@ contract IPAccountTest is BaseTest {
 
         mockNFT.mintId(owner, tokenId);
 
-        address account = mockIpAccountRegistry.registerIpAccount(block.chainid, address(mockNFT), tokenId);
+        address account = ipAssetRegistry.register(block.chainid, address(mockNFT), tokenId);
 
         uint256 subTokenId = 111;
         mockNFT.mintId(account, subTokenId);
@@ -265,7 +265,7 @@ contract IPAccountTest is BaseTest {
         mockNFT.mintId(owner, tokenId);
 
         vm.prank(owner, owner);
-        address account = mockIpAccountRegistry.registerIpAccount(block.chainid, address(mockNFT), tokenId);
+        address account = ipAssetRegistry.register(block.chainid, address(mockNFT), tokenId);
 
         address otherOwner = vm.addr(2);
         uint256 otherTokenId = 200;
@@ -283,7 +283,7 @@ contract IPAccountTest is BaseTest {
         mockNFT.mintId(owner, tokenId);
 
         vm.prank(owner, owner);
-        address account = mockIpAccountRegistry.registerIpAccount(block.chainid, address(mockNFT), tokenId);
+        address account = ipAssetRegistry.register(block.chainid, address(mockNFT), tokenId);
 
         ERC6551 ipAccount = ERC6551(payable(account));
 
@@ -318,7 +318,7 @@ contract IPAccountTest is BaseTest {
         mockNFT.mintId(owner, tokenId);
 
         vm.prank(owner, owner);
-        address account = mockIpAccountRegistry.registerIpAccount(block.chainid, address(mockNFT), tokenId);
+        address account = ipAssetRegistry.register(block.chainid, address(mockNFT), tokenId);
 
         ERC6551 ipAccount = ERC6551(payable(account));
 
@@ -339,7 +339,7 @@ contract IPAccountTest is BaseTest {
         mockNFT.mintId(owner, tokenId);
 
         vm.prank(owner, owner);
-        address account = mockIpAccountRegistry.registerIpAccount(block.chainid, address(mockNFT), tokenId);
+        address account = ipAssetRegistry.register(block.chainid, address(mockNFT), tokenId);
 
         ERC6551 ipAccount = ERC6551(payable(account));
 

--- a/test/foundry/mocks/module/MockMetaTxModule.sol
+++ b/test/foundry/mocks/module/MockMetaTxModule.sol
@@ -6,7 +6,7 @@ import { ERC165Checker } from "@openzeppelin/contracts/utils/introspection/ERC16
 import { IAccessController } from "../../../../contracts/interfaces/access/IAccessController.sol";
 import { IIPAccount } from "../../../../contracts/interfaces/IIPAccount.sol";
 import { IModule } from "../../../../contracts/interfaces/modules/base/IModule.sol";
-import { IIPAccountRegistry } from "../../../../contracts/interfaces/registries/IIPAccountRegistry.sol";
+import { IIPAssetRegistry } from "../../../../contracts/interfaces/registries/IIPAssetRegistry.sol";
 import { IModuleRegistry } from "../../../../contracts/interfaces/registries/IModuleRegistry.sol";
 import { AccessPermission } from "../../../../contracts/lib/AccessPermission.sol";
 import { IPAccountChecker } from "../../../../contracts/lib/registries/IPAccountChecker.sol";
@@ -15,14 +15,14 @@ import { MockAccessControlledModule } from "./MockAccessControlledModule.sol";
 
 contract MockMetaTxModule is BaseModule {
     using ERC165Checker for address;
-    using IPAccountChecker for IIPAccountRegistry;
+    using IPAccountChecker for IIPAssetRegistry;
 
-    IIPAccountRegistry public ipAccountRegistry;
+    IIPAssetRegistry public ipAccountRegistry;
     IModuleRegistry public moduleRegistry;
     IAccessController public accessController;
 
     constructor(address _ipAccountRegistry, address _moduleRegistry, address _accessController) {
-        ipAccountRegistry = IIPAccountRegistry(_ipAccountRegistry);
+        ipAccountRegistry = IIPAssetRegistry(_ipAccountRegistry);
         moduleRegistry = IModuleRegistry(_moduleRegistry);
         accessController = IAccessController(_accessController);
     }

--- a/test/foundry/mocks/module/MockModule.sol
+++ b/test/foundry/mocks/module/MockModule.sol
@@ -5,21 +5,21 @@ import { ERC165Checker } from "@openzeppelin/contracts/utils/introspection/ERC16
 
 import { IIPAccount } from "../../../../contracts/interfaces/IIPAccount.sol";
 import { IModule } from "../../../../contracts/interfaces/modules/base/IModule.sol";
-import { IIPAccountRegistry } from "../../../../contracts/interfaces/registries/IIPAccountRegistry.sol";
+import { IIPAssetRegistry } from "../../../../contracts/interfaces/registries/IIPAssetRegistry.sol";
 import { IModuleRegistry } from "../../../../contracts/interfaces/registries/IModuleRegistry.sol";
 import { IPAccountChecker } from "../../../../contracts/lib/registries/IPAccountChecker.sol";
 import { BaseModule } from "../../../../contracts/modules/BaseModule.sol";
 
 contract MockModule is BaseModule {
     using ERC165Checker for address;
-    using IPAccountChecker for IIPAccountRegistry;
+    using IPAccountChecker for IIPAssetRegistry;
 
-    IIPAccountRegistry public ipAccountRegistry;
+    IIPAssetRegistry public ipAccountRegistry;
     IModuleRegistry public moduleRegistry;
     string public name;
 
     constructor(address _ipAccountRegistry, address _moduleRegistry, string memory _name) {
-        ipAccountRegistry = IIPAccountRegistry(_ipAccountRegistry);
+        ipAccountRegistry = IIPAssetRegistry(_ipAccountRegistry);
         moduleRegistry = IModuleRegistry(_moduleRegistry);
         name = _name;
     }

--- a/test/foundry/mocks/module/MockOrchestratorModule.sol
+++ b/test/foundry/mocks/module/MockOrchestratorModule.sol
@@ -6,19 +6,19 @@ import { ERC165Checker } from "@openzeppelin/contracts/utils/introspection/ERC16
 import { IIPAccount } from "../../../../contracts/interfaces/IIPAccount.sol";
 import { IModule } from "../../../../contracts/interfaces/modules/base/IModule.sol";
 import { IModuleRegistry } from "../../../../contracts/interfaces/registries/IModuleRegistry.sol";
-import { IIPAccountRegistry } from "../../../../contracts/interfaces/registries/IIPAccountRegistry.sol";
+import { IIPAssetRegistry } from "../../../../contracts/interfaces/registries/IIPAssetRegistry.sol";
 import { IPAccountChecker } from "../../../../contracts/lib/registries/IPAccountChecker.sol";
 import { BaseModule } from "../../../../contracts/modules/BaseModule.sol";
 
 contract MockOrchestratorModule is BaseModule {
     using ERC165Checker for address;
-    using IPAccountChecker for IIPAccountRegistry;
+    using IPAccountChecker for IIPAssetRegistry;
 
-    IIPAccountRegistry public ipAccountRegistry;
+    IIPAssetRegistry public ipAccountRegistry;
     IModuleRegistry public moduleRegistry;
 
     constructor(address _ipAccountRegistry, address _moduleRegistry) {
-        ipAccountRegistry = IIPAccountRegistry(_ipAccountRegistry);
+        ipAccountRegistry = IIPAssetRegistry(_ipAccountRegistry);
         moduleRegistry = IModuleRegistry(_moduleRegistry);
     }
 

--- a/test/foundry/registries/IPAccountRegistry.t.sol
+++ b/test/foundry/registries/IPAccountRegistry.t.sol
@@ -2,7 +2,6 @@
 pragma solidity 0.8.26;
 
 import { IPAccountImpl } from "../../../contracts/IPAccountImpl.sol";
-import { IPAccountChecker } from "../../../contracts/lib/registries/IPAccountChecker.sol";
 import { IPAccountRegistry } from "../../../contracts/registries/IPAccountRegistry.sol";
 import { Errors } from "contracts/lib/Errors.sol";
 
@@ -13,7 +12,6 @@ contract MockIPAccountRegistry is IPAccountRegistry {
 }
 
 contract IPAccountRegistryTest is BaseTest {
-    using IPAccountChecker for IPAccountRegistry;
 
     uint256 internal chainId = 100;
     address internal tokenAddress = address(200);

--- a/test/foundry/registries/IPAccountRegistry.t.sol
+++ b/test/foundry/registries/IPAccountRegistry.t.sol
@@ -12,7 +12,6 @@ contract MockIPAccountRegistry is IPAccountRegistry {
 }
 
 contract IPAccountRegistryTest is BaseTest {
-
     uint256 internal chainId = 100;
     address internal tokenAddress = address(200);
     uint256 internal tokenId = 300;

--- a/test/foundry/registries/IPAssetRegistry.t.sol
+++ b/test/foundry/registries/IPAssetRegistry.t.sol
@@ -4,6 +4,7 @@ pragma solidity 0.8.26;
 import { IIPAssetRegistry } from "contracts/interfaces/registries/IIPAssetRegistry.sol";
 import { IPAccountChecker } from "contracts/lib/registries/IPAccountChecker.sol";
 import { IPAssetRegistry } from "contracts/registries/IPAssetRegistry.sol";
+import { IPAccountRegistry } from "contracts/registries/IPAccountRegistry.sol";
 import { Errors } from "contracts/lib/Errors.sol";
 import { IIPAccount } from "contracts/interfaces/IIPAccount.sol";
 import { IPAccountStorageOps } from "contracts/lib/IPAccountStorageOps.sol";
@@ -13,6 +14,14 @@ import { MockERC721WithoutMetadata } from "test/foundry/mocks/token/MockERC721Wi
 import { PausableUpgradeable } from "@openzeppelin/contracts-upgradeable/utils/PausableUpgradeable.sol";
 
 import { BaseTest } from "../utils/BaseTest.t.sol";
+
+contract MockIPAccountRegistry is IPAccountRegistry {
+    constructor(address erc6551Registry, address ipAccountImpl) IPAccountRegistry(erc6551Registry, ipAccountImpl) {}
+
+    function registerIpAccount(uint256 chainId, address tokenContract, uint256 tokenId) public returns (address) {
+        return _registerIpAccount(chainId, tokenContract, tokenId);
+    }
+}
 
 /// @title IP Asset Registry Testing Contract
 /// @notice Contract for testing core IP registration.
@@ -57,7 +66,7 @@ contract IPAssetRegistryTest is BaseTest {
         uint256 totalSupply = registry.totalSupply();
 
         assertTrue(!registry.isRegistered(ipId));
-        assertTrue(!IPAccountChecker.isRegistered(ipAccountRegistry, block.chainid, tokenAddress, tokenId));
+        assertTrue(!IPAccountChecker.isRegistered(ipAssetRegistry, block.chainid, tokenAddress, tokenId));
         string memory name = string.concat(block.chainid.toString(), ": Ape #99");
         vm.expectEmit(true, true, true, true);
         emit IIPAssetRegistry.IPRegistered(
@@ -73,7 +82,7 @@ contract IPAssetRegistryTest is BaseTest {
         registry.register(block.chainid, tokenAddress, tokenId);
 
         assertEq(totalSupply + 1, registry.totalSupply());
-        assertTrue(IPAccountChecker.isRegistered(ipAccountRegistry, block.chainid, tokenAddress, tokenId));
+        assertTrue(IPAccountChecker.isRegistered(ipAssetRegistry, block.chainid, tokenAddress, tokenId));
         assertEq(IIPAccount(payable(ipId)).getString(address(registry), "NAME"), name);
         assertEq(IIPAccount(payable(ipId)).getString(address(registry), "URI"), "https://storyprotocol.xyz/erc721/99");
         assertEq(IIPAccount(payable(ipId)).getUint256(address(registry), "REGISTRATION_DATE"), block.timestamp);
@@ -154,7 +163,7 @@ contract IPAssetRegistryTest is BaseTest {
         registry.register(block.chainid, tokenAddress, tokenId);
 
         assertEq(totalSupply + 1, registry.totalSupply());
-        assertTrue(IPAccountChecker.isRegistered(ipAccountRegistry, block.chainid, tokenAddress, tokenId));
+        assertTrue(IPAccountChecker.isRegistered(ipAssetRegistry, block.chainid, tokenAddress, tokenId));
         assertEq(IIPAccount(payable(ipId)).getString(address(registry), "NAME"), name);
         assertEq(IIPAccount(payable(ipId)).getString(address(registry), "URI"), "https://storyprotocol.xyz/erc721/99");
         assertEq(IIPAccount(payable(ipId)).getUint256(address(registry), "REGISTRATION_DATE"), block.timestamp);
@@ -202,7 +211,7 @@ contract IPAssetRegistryTest is BaseTest {
         registry.register(block.chainid, tokenAddress, tokenId);
 
         assertEq(totalSupply + 1, registry.totalSupply());
-        assertTrue(IPAccountChecker.isRegistered(ipAccountRegistry, block.chainid, tokenAddress, tokenId));
+        assertTrue(IPAccountChecker.isRegistered(ipAssetRegistry, block.chainid, tokenAddress, tokenId));
         assertEq(IIPAccount(payable(ipId)).getString(address(registry), "NAME"), name);
         assertEq(IIPAccount(payable(ipId)).getString(address(registry), "URI"), "https://storyprotocol.xyz/erc721/99");
         assertEq(IIPAccount(payable(ipId)).getUint256(address(registry), "REGISTRATION_DATE"), block.timestamp);
@@ -211,7 +220,7 @@ contract IPAssetRegistryTest is BaseTest {
     /// @notice Tests registration of the same IP twice.
     function test_IPAssetRegistry_revert_RegisterPermissionlessTwice() public {
         assertTrue(!registry.isRegistered(ipId));
-        assertTrue(!IPAccountChecker.isRegistered(ipAccountRegistry, block.chainid, tokenAddress, tokenId));
+        assertTrue(!IPAccountChecker.isRegistered(ipAssetRegistry, block.chainid, tokenAddress, tokenId));
 
         vm.prank(alice);
         string memory name = string.concat(block.chainid.toString(), ": Ape #99");
@@ -294,7 +303,7 @@ contract IPAssetRegistryTest is BaseTest {
         ipId = _getIPAccount(chainid, tokenId);
 
         assertTrue(!registry.isRegistered(ipId));
-        assertTrue(!IPAccountChecker.isRegistered(ipAccountRegistry, chainid, tokenAddress, tokenId));
+        assertTrue(!IPAccountChecker.isRegistered(ipAssetRegistry, chainid, tokenAddress, tokenId));
         string memory name = string.concat(
             chainid.toString(),
             ": ",
@@ -307,7 +316,7 @@ contract IPAssetRegistryTest is BaseTest {
         address registeredIpId = registry.register(chainid, tokenAddress, tokenId);
 
         assertEq(totalSupply + 1, registry.totalSupply());
-        assertTrue(IPAccountChecker.isRegistered(ipAccountRegistry, chainid, tokenAddress, tokenId));
+        assertTrue(IPAccountChecker.isRegistered(ipAssetRegistry, chainid, tokenAddress, tokenId));
         assertEq(IIPAccount(payable(ipId)).getString(address(registry), "NAME"), name);
         assertEq(IIPAccount(payable(ipId)).getUint256(address(registry), "REGISTRATION_DATE"), block.timestamp);
     }
@@ -320,12 +329,28 @@ contract IPAssetRegistryTest is BaseTest {
 
         ipId = _getIPAccount(chainid, tokenId);
         assertTrue(!registry.isRegistered(ipId));
-        assertTrue(!IPAccountChecker.isRegistered(ipAccountRegistry, block.chainid, tokenAddress, tokenId));
+        assertTrue(!IPAccountChecker.isRegistered(ipAssetRegistry, block.chainid, tokenAddress, tokenId));
 
         address ipId = registry.register(chainid, tokenAddress, tokenId);
 
         address ipIdAgain = registry.register(chainid, tokenAddress, tokenId);
         assertEq(ipId, ipIdAgain);
+    }
+
+    function test_IPAssetRegistry_revert_registerWithDummyIPAccountRegister() public {
+        MockIPAccountRegistry mockIpAccountRegistry = new MockIPAccountRegistry(
+            ipAccountRegistry.ERC6551_PUBLIC_REGISTRY(),
+            ipAccountRegistry.IP_ACCOUNT_IMPL()
+        );
+        address owner = vm.addr(1);
+        uint256 tokenId = 100;
+
+        mockNFT.mintId(owner, tokenId);
+
+        vm.prank(owner, owner);
+        address account = mockIpAccountRegistry.registerIpAccount(block.chainid, address(mockNFT), tokenId);
+        assertTrue(!IPAccountChecker.isIpAccount(ipAssetRegistry, account));
+
     }
 
     /// @notice Helper function for generating an account address.

--- a/test/foundry/registries/IPAssetRegistry.t.sol
+++ b/test/foundry/registries/IPAssetRegistry.t.sol
@@ -350,7 +350,6 @@ contract IPAssetRegistryTest is BaseTest {
         vm.prank(owner, owner);
         address account = mockIpAccountRegistry.registerIpAccount(block.chainid, address(mockNFT), tokenId);
         assertTrue(!IPAccountChecker.isIpAccount(ipAssetRegistry, account));
-
     }
 
     /// @notice Helper function for generating an account address.


### PR DESCRIPTION
## Description

This PR introduces validation checks to ensure that IP Account addresses are registered through the `IPAssetRegistry`. This enhancement improves the integrity and security of the IP registration process by verifying the legitimacy of IP Account addresses.

## Key Changes

- **IP Account Validation**: Added checks to validate that IP Account addresses are registered through the `IPAssetRegistry`.

Closes storyprotocol/trust-protocol-contracts-v1#9



