### PR TITLE
Prevent Adding IPs with Expiration Time to Group

### DIFF
--- a/contracts/lib/Errors.sol
+++ b/contracts/lib/Errors.sol
@@ -136,6 +136,9 @@ library Errors {
     /// @notice The Group IP has been frozen due to already mint license tokens.
     error GroupingModule__GroupFrozenDueToAlreadyMintLicenseTokens(address groupId);
 
+    /// @notice Cannot add IP which has expiration to group.
+    error GroupingModule__CannotAddIpWithExpirationToGroup(address ipId);
+
     ////////////////////////////////////////////////////////////////////////////
     //                            IP Asset Registry                           //
     ////////////////////////////////////////////////////////////////////////////

--- a/contracts/modules/grouping/GroupingModule.sol
+++ b/contracts/modules/grouping/GroupingModule.sol
@@ -167,6 +167,10 @@ contract GroupingModule is
                     groupLicenseTermsId
                 );
             }
+            // IP must not have expiration time to be added to group
+            if (LICENSE_REGISTRY.getExpireTime(ipIds[i]) != 0) {
+                revert Errors.GroupingModule__CannotAddIpWithExpirationToGroup(ipIds[i]);
+            }
             pool.addIp(groupIpId, ipIds[i]);
         }
 

--- a/test/foundry/modules/grouping/GroupingModule.t.sol
+++ b/test/foundry/modules/grouping/GroupingModule.t.sol
@@ -292,8 +292,6 @@ contract GroupingModuleTest is BaseTest {
         assertEq(rewardPool.getIpAddedTime(groupId1, ipId2), 0);
     }
 
-
-
     function test_GroupingModule_addIp_revert_after_registerDerivative() public {
         uint256 termsId = pilTemplate.registerLicenseTerms(
             PILFlavors.commercialRemix({

--- a/test/foundry/modules/grouping/GroupingModule.t.sol
+++ b/test/foundry/modules/grouping/GroupingModule.t.sol
@@ -8,6 +8,7 @@ import { Strings } from "@openzeppelin/contracts/utils/Strings.sol";
 import { Errors } from "../../../../contracts/lib/Errors.sol";
 import { IGroupingModule } from "../../../../contracts/interfaces/modules/grouping/IGroupingModule.sol";
 import { PILFlavors } from "../../../../contracts/lib/PILFlavors.sol";
+import { PILTerms } from "../../../../contracts/interfaces/modules/licensing/IPILicenseTemplate.sol";
 // test
 import { EvenSplitGroupPool } from "../../../../contracts/modules/grouping/EvenSplitGroupPool.sol";
 import { MockERC721 } from "../../mocks/token/MockERC721.sol";
@@ -252,6 +253,46 @@ contract GroupingModuleTest is BaseTest {
         assertEq(rewardPool.getTotalIps(groupId1), 0);
         assertEq(rewardPool.getIpAddedTime(groupId1, ipId1), 0);
     }
+
+    function test_GroupingModule_addIp_revert_ipWithExpiration() public {
+        PILTerms memory expiredTerms = PILFlavors.commercialRemix({
+            mintingFee: 0,
+            commercialRevShare: 10,
+            currencyToken: address(erc20),
+            royaltyPolicy: address(royaltyPolicyLAP)
+        });
+        expiredTerms.expiration = 10 days;
+        uint256 termsId = pilTemplate.registerLicenseTerms(expiredTerms);
+
+        vm.startPrank(alice);
+        address groupId1 = groupingModule.registerGroup(address(rewardPool));
+        licensingModule.attachLicenseTerms(groupId1, address(pilTemplate), termsId);
+        vm.stopPrank();
+
+        vm.prank(ipOwner1);
+        licensingModule.attachLicenseTerms(ipId1, address(pilTemplate), termsId);
+
+        address[] memory parentIpIds = new address[](1);
+        parentIpIds[0] = ipId1;
+        uint256[] memory licenseTermsIds = new uint256[](1);
+        licenseTermsIds[0] = termsId;
+        vm.prank(ipOwner2);
+        licensingModule.registerDerivative(ipId2, parentIpIds, licenseTermsIds, address(pilTemplate), "", 0);
+
+        address[] memory ipIds = new address[](1);
+        ipIds[0] = ipId2;
+        vm.expectRevert(
+            abi.encodeWithSelector(Errors.GroupingModule__CannotAddIpWithExpirationToGroup.selector, ipId2)
+        );
+        vm.prank(alice);
+        groupingModule.addIp(groupId1, ipIds);
+
+        assertEq(ipAssetRegistry.totalMembers(groupId1), 0);
+        assertEq(rewardPool.getTotalIps(groupId1), 0);
+        assertEq(rewardPool.getIpAddedTime(groupId1, ipId2), 0);
+    }
+
+
 
     function test_GroupingModule_addIp_revert_after_registerDerivative() public {
         uint256 termsId = pilTemplate.registerLicenseTerms(


### PR DESCRIPTION
## Description

This PR introduces checks to ensure that IPs with expiration times cannot be added to a group. This enhancement improves the integrity of the grouping process by preventing IPs that have expiration times from being included.

## Key Changes

- **Expiration Time Check**: Added logic to verify that IPs being added to a group do not have expiration times.
- **Revert on IPs with Expiration**: The `addIp` function now reverts if any IP in the provided list has an expiration time.

Closes https://github.com/storyprotocol/trust-protocol-contracts-v1/issues/5