### PR TITLE
Support for IP Owner to Enable/Disable Licenses

### DIFF
--- a/contracts/lib/Errors.sol
+++ b/contracts/lib/Errors.sol
@@ -255,9 +255,6 @@ library Errors {
     /// @notice Zero address provided for IP Graph ACL.
     error LicenseRegistry__ZeroIPGraphACL();
 
-    /// @notice license terms disabled.
-    error LicenseRegistry__LicenseTermsDisabled(address ipId, address licenseTemplate, uint256 licenseTermsId);
-
     /// @notice When Set LicenseConfig the license template cannot be Zero address if royalty percentage is not Zero.
     error LicensingModule__LicenseTemplateCannotBeZeroAddressToOverrideRoyaltyPercent();
 

--- a/contracts/lib/Errors.sol
+++ b/contracts/lib/Errors.sol
@@ -255,6 +255,9 @@ library Errors {
     /// @notice Zero address provided for IP Graph ACL.
     error LicenseRegistry__ZeroIPGraphACL();
 
+    /// @notice license terms disabled.
+    error LicenseRegistry__LicenseTermsDisabled(address ipId, address licenseTemplate, uint256 licenseTermsId);
+
     /// @notice When Set LicenseConfig the license template cannot be Zero address if royalty percentage is not Zero.
     error LicensingModule__LicenseTemplateCannotBeZeroAddressToOverrideRoyaltyPercent();
 
@@ -367,6 +370,9 @@ library Errors {
 
     /// @notice licensing minting fee is above the maximum minting fee.
     error LicensingModule__MintingFeeExceedMaxMintingFee(uint256 mintingFee, uint256 maxMintingFee);
+
+    /// @notice license terms disabled.
+    error LicensingModule__LicenseDisabled(address ipId, address licenseTemplate, uint256 licenseTermsId);
 
     ////////////////////////////////////////////////////////////////////////////
     //                             Dispute Module                             //

--- a/contracts/lib/Licensing.sol
+++ b/contracts/lib/Licensing.sol
@@ -16,11 +16,13 @@ library Licensing {
     /// @param licensingHook  The hook contract address for the licensing module, or address(0) if none
     /// @param hookData The data to be used by the licensing hook.
     /// @param commercialRevShare The commercial revenue share percentage.
+    /// @param disabled Whether the license is disabled or not.
     struct LicensingConfig {
         bool isSet;
         uint256 mintingFee;
         address licensingHook;
         bytes hookData;
         uint32 commercialRevShare;
+        bool disabled;
     }
 }

--- a/contracts/modules/licensing/LicensingModule.sol
+++ b/contracts/modules/licensing/LicensingModule.sol
@@ -182,8 +182,13 @@ contract LicensingModule is
             licenseTermsId,
             _hasPermission(licensorIpId)
         );
+
+        if (lsc.isSet && lsc.disabled) {
+            revert Errors.LicensingModule__LicenseDisabled(licensorIpId, licenseTemplate, licenseTermsId);
+        }
+
         uint256 mintingFeeByHook = 0;
-        if (lsc.licensingHook != address(0)) {
+        if (lsc.isSet && lsc.licensingHook != address(0)) {
             mintingFeeByHook = ILicensingHook(lsc.licensingHook).beforeMintLicenseTokens(
                 msg.sender,
                 licensorIpId,
@@ -537,9 +542,12 @@ contract LicensingModule is
             licenseTemplate,
             licenseTermsId
         );
+        if (lsc.isSet && lsc.disabled) {
+            revert Errors.LicensingModule__LicenseDisabled(parentIpId, licenseTemplate, licenseTermsId);
+        }
         // check childIpOwner is qualified with check receiver module
         uint256 mintingFeeByHook = 0;
-        if (lsc.licensingHook != address(0)) {
+        if (lsc.isSet && lsc.licensingHook != address(0)) {
             mintingFeeByHook = ILicensingHook(lsc.licensingHook).beforeRegisterDerivative(
                 msg.sender,
                 childIpId,

--- a/contracts/registries/LicenseRegistry.sol
+++ b/contracts/registries/LicenseRegistry.sol
@@ -148,7 +148,8 @@ contract LicenseRegistry is ILicenseRegistry, AccessManagedUpgradeable, UUPSUpgr
             mintingFee: licensingConfig.mintingFee,
             licensingHook: licensingConfig.licensingHook,
             hookData: licensingConfig.hookData,
-            commercialRevShare: licensingConfig.commercialRevShare
+            commercialRevShare: licensingConfig.commercialRevShare,
+            disabled: licensingConfig.disabled
         });
 
         emit LicensingConfigSetForLicense(ipId, licenseTemplate, licenseTermsId, licensingConfig);
@@ -169,7 +170,8 @@ contract LicenseRegistry is ILicenseRegistry, AccessManagedUpgradeable, UUPSUpgr
             mintingFee: licensingConfig.mintingFee,
             licensingHook: licensingConfig.licensingHook,
             hookData: licensingConfig.hookData,
-            commercialRevShare: licensingConfig.commercialRevShare
+            commercialRevShare: licensingConfig.commercialRevShare,
+            disabled: licensingConfig.disabled
         });
         emit LicensingConfigSetForIP(ipId, licensingConfig);
     }

--- a/test/foundry/modules/licensing/LicensingModule.t.sol
+++ b/test/foundry/modules/licensing/LicensingModule.t.sol
@@ -1689,7 +1689,8 @@ contract LicensingModuleTest is BaseTest {
             mintingFee: 100,
             licensingHook: address(licensingHook),
             hookData: abi.encode(address(0x123)),
-            commercialRevShare: 0
+            commercialRevShare: 0,
+            disabled: false
         });
         vm.prank(ipOwner1);
         licensingModule.setLicensingConfig(ipId1, address(pilTemplate), socialRemixTermsId, licensingConfig);
@@ -1739,7 +1740,8 @@ contract LicensingModuleTest is BaseTest {
             mintingFee: 100,
             licensingHook: address(licensingHook),
             hookData: abi.encode(address(0x123)),
-            commercialRevShare: 10_000_000
+            commercialRevShare: 10_000_000,
+            disabled: false
         });
         vm.prank(ipOwner1);
         licensingModule.setLicensingConfig(ipId1, address(pilTemplate), commercialRemixTermsId, licensingConfig);
@@ -1788,7 +1790,8 @@ contract LicensingModuleTest is BaseTest {
             mintingFee: 0,
             licensingHook: address(0),
             hookData: "",
-            commercialRevShare: 10_000_000
+            commercialRevShare: 10_000_000,
+            disabled: false
         });
         vm.prank(ipOwner2);
         licensingModule.setLicensingConfig(ipId2, address(pilTemplate), termsId, licensingConfig);
@@ -1827,7 +1830,8 @@ contract LicensingModuleTest is BaseTest {
             mintingFee: 100,
             licensingHook: address(licensingHook),
             hookData: abi.encode(address(0x123)),
-            commercialRevShare: 0
+            commercialRevShare: 0,
+            disabled: false
         });
         vm.prank(ipOwner1);
         licensingModule.setLicensingConfig(ipId1, address(pilTemplate), socialRemixTermsId, licensingConfig);
@@ -1877,7 +1881,8 @@ contract LicensingModuleTest is BaseTest {
             mintingFee: 100,
             licensingHook: address(licensingHook),
             hookData: abi.encode(address(0x123)),
-            commercialRevShare: 0
+            commercialRevShare: 0,
+            disabled: false
         });
         vm.expectRevert(
             abi.encodeWithSelector(Errors.LicensingModule__InvalidLicenseTermsId.selector, address(pilTemplate), 0)
@@ -1906,7 +1911,8 @@ contract LicensingModuleTest is BaseTest {
             mintingFee: 100,
             licensingHook: address(licensingHook),
             hookData: abi.encode(address(0x123)),
-            commercialRevShare: 1000
+            commercialRevShare: 1000,
+            disabled: false
         });
         vm.expectRevert(
             abi.encodeWithSelector(Errors.LicenseRegistry__UnregisteredLicenseTemplate.selector, address(0x123))
@@ -1939,7 +1945,8 @@ contract LicensingModuleTest is BaseTest {
             mintingFee: 100,
             licensingHook: address(licensingHook),
             hookData: abi.encode(address(0x123)),
-            commercialRevShare: 0
+            commercialRevShare: 0,
+            disabled: false
         });
         vm.expectRevert(
             abi.encodeWithSelector(Errors.LicensingModule__InvalidLicensingHook.selector, address(licensingHook))
@@ -1957,7 +1964,8 @@ contract LicensingModuleTest is BaseTest {
             mintingFee: 100,
             licensingHook: address(tokenGatedHook),
             hookData: abi.encode(address(0x123)),
-            commercialRevShare: 0
+            commercialRevShare: 0,
+            disabled: false
         });
         vm.expectRevert(
             abi.encodeWithSelector(Errors.LicensingModule__InvalidLicensingHook.selector, address(tokenGatedHook))
@@ -1979,7 +1987,8 @@ contract LicensingModuleTest is BaseTest {
             mintingFee: 100,
             licensingHook: address(licensingHook),
             hookData: abi.encode(address(0x123)),
-            commercialRevShare: 0
+            commercialRevShare: 0,
+            disabled: false
         });
         vm.expectRevert(abi.encodeWithSelector(PausableUpgradeable.EnforcedPause.selector));
         vm.prank(ipOwner1);
@@ -1996,7 +2005,8 @@ contract LicensingModuleTest is BaseTest {
             mintingFee: 100,
             licensingHook: address(licensingHook),
             hookData: abi.encode(address(0x123)),
-            commercialRevShare: 0
+            commercialRevShare: 0,
+            disabled: false
         });
         vm.prank(ipOwner1);
         licensingModule.setLicensingConfig(ipId1, address(pilTemplate), termsId, licensingConfig);
@@ -2005,6 +2015,41 @@ contract LicensingModuleTest is BaseTest {
 
         address receiver = address(0x123);
         vm.expectRevert("MockLicensingHook: receiver is invalid");
+        licensingModule.mintLicenseTokens({
+            licensorIpId: ipId1,
+            licenseTemplate: address(pilTemplate),
+            licenseTermsId: termsId,
+            amount: 1,
+            receiver: receiver,
+            royaltyContext: "",
+            maxMintingFee: 0
+        });
+    }
+
+    function test_LicensingModule_mintLicenseTokens_revert_licenseDisabled() public {
+        uint256 termsId = pilTemplate.registerLicenseTerms(PILFlavors.defaultValuesLicenseTerms());
+        Licensing.LicensingConfig memory licensingConfig = Licensing.LicensingConfig({
+            isSet: true,
+            mintingFee: 100,
+            licensingHook: address(0),
+            hookData: "",
+            commercialRevShare: 0,
+            disabled: true
+        });
+        vm.prank(ipOwner1);
+        licensingModule.setLicensingConfig(ipId1, address(pilTemplate), termsId, licensingConfig);
+        vm.prank(ipOwner1);
+        licensingModule.attachLicenseTerms(ipId1, address(pilTemplate), termsId);
+
+        address receiver = address(0x123);
+        vm.expectRevert(
+            abi.encodeWithSelector(
+                Errors.LicensingModule__LicenseDisabled.selector,
+                ipId1,
+                address(pilTemplate),
+                termsId
+            )
+        );
         licensingModule.mintLicenseTokens({
             licensorIpId: ipId1,
             licenseTemplate: address(pilTemplate),
@@ -2034,7 +2079,8 @@ contract LicensingModuleTest is BaseTest {
             mintingFee: 999999,
             licensingHook: address(licensingHook),
             hookData: abi.encode(address(0x123)),
-            commercialRevShare: 0
+            commercialRevShare: 0,
+            disabled: false
         });
         vm.prank(ipOwner1);
         licensingModule.setLicensingConfig(ipId1, address(pilTemplate), termsId, licensingConfig);
@@ -2093,7 +2139,8 @@ contract LicensingModuleTest is BaseTest {
             mintingFee: 1000,
             licensingHook: address(0),
             hookData: abi.encode(address(0x123)),
-            commercialRevShare: 0
+            commercialRevShare: 0,
+            disabled: false
         });
         vm.prank(ipOwner1);
         licensingModule.setLicensingConfig(ipId1, address(pilTemplate), termsId, licensingConfig);
@@ -2204,7 +2251,8 @@ contract LicensingModuleTest is BaseTest {
             mintingFee: 999999,
             licensingHook: address(licensingHook),
             hookData: abi.encode(address(0x123)),
-            commercialRevShare: 0
+            commercialRevShare: 0,
+            disabled: false
         });
         vm.prank(ipOwner1);
         licensingModule.setLicensingConfig(ipId1, address(pilTemplate), termsId, licensingConfig);
@@ -2256,7 +2304,8 @@ contract LicensingModuleTest is BaseTest {
             mintingFee: 999999,
             licensingHook: address(licensingHook),
             hookData: abi.encode(address(0x123)),
-            commercialRevShare: 0
+            commercialRevShare: 0,
+            disabled: false
         });
         vm.prank(ipOwner1);
         licensingModule.setLicensingConfig(ipId1, address(pilTemplate), termsId, licensingConfig);
@@ -2309,7 +2358,8 @@ contract LicensingModuleTest is BaseTest {
             mintingFee: 999999,
             licensingHook: address(licensingHook),
             hookData: abi.encode(address(0x123)),
-            commercialRevShare: 0
+            commercialRevShare: 0,
+            disabled: false
         });
         vm.prank(ipOwner1);
         licensingModule.setLicensingConfig(ipId1, address(pilTemplate), termsId, licensingConfig);
@@ -2349,7 +2399,8 @@ contract LicensingModuleTest is BaseTest {
             mintingFee: 0,
             licensingHook: address(0),
             hookData: abi.encode(address(0)),
-            commercialRevShare: 0
+            commercialRevShare: 0,
+            disabled: false
         });
         vm.prank(ipOwner1);
         licensingModule.setLicensingConfig(ipId1, address(pilTemplate), termsId, licensingConfig2);
@@ -2380,7 +2431,8 @@ contract LicensingModuleTest is BaseTest {
             mintingFee: 100,
             licensingHook: address(licensingHook),
             hookData: abi.encode(address(ipOwner2)),
-            commercialRevShare: 0
+            commercialRevShare: 0,
+            disabled: false
         });
         vm.prank(ipOwner1);
         licensingModule.setLicensingConfig(ipId1, address(pilTemplate), termsId, licensingConfig);
@@ -2401,6 +2453,35 @@ contract LicensingModuleTest is BaseTest {
         licenseTermsIds[0] = termsId;
         vm.prank(ipOwner2);
         vm.expectRevert("MockLicensingHook: caller is invalid");
+        licensingModule.registerDerivative(ipId2, parentIpIds, licenseTermsIds, address(pilTemplate), "", 0);
+    }
+
+    function test_LicensingModule_registerDerivative_revert_licenseDisabled() public {
+        uint256 termsId = pilTemplate.registerLicenseTerms(PILFlavors.nonCommercialSocialRemixing());
+        Licensing.LicensingConfig memory licensingConfig = Licensing.LicensingConfig({
+            isSet: true,
+            mintingFee: 100,
+            licensingHook: address(0),
+            hookData: "",
+            commercialRevShare: 0,
+            disabled: true
+        });
+        vm.prank(ipOwner1);
+        licensingModule.setLicensingConfig(ipId1, address(pilTemplate), termsId, licensingConfig);
+
+        address[] memory parentIpIds = new address[](1);
+        uint256[] memory licenseTermsIds = new uint256[](1);
+        parentIpIds[0] = ipId1;
+        licenseTermsIds[0] = termsId;
+        vm.prank(ipOwner2);
+        vm.expectRevert(
+            abi.encodeWithSelector(
+                Errors.LicensingModule__LicenseDisabled.selector,
+                ipId1,
+                address(pilTemplate),
+                termsId
+            )
+        );
         licensingModule.registerDerivative(ipId2, parentIpIds, licenseTermsIds, address(pilTemplate), "", 0);
     }
 

--- a/test/foundry/registries/LicenseRegistry.t.sol
+++ b/test/foundry/registries/LicenseRegistry.t.sol
@@ -103,7 +103,8 @@ contract LicenseRegistryTest is BaseTest {
             mintingFee: 100,
             licensingHook: address(0),
             hookData: "",
-            commercialRevShare: 0
+            commercialRevShare: 0,
+            disabled: false
         });
 
         vm.prank(address(licensingModule));
@@ -131,7 +132,8 @@ contract LicenseRegistryTest is BaseTest {
             mintingFee: 100,
             licensingHook: address(0),
             hookData: "",
-            commercialRevShare: 0
+            commercialRevShare: 0,
+            disabled: false
         });
 
         vm.expectRevert(
@@ -148,7 +150,8 @@ contract LicenseRegistryTest is BaseTest {
             mintingFee: 100,
             licensingHook: address(0),
             hookData: "",
-            commercialRevShare: 0
+            commercialRevShare: 0,
+            disabled: false
         });
 
         vm.prank(address(licensingModule));


### PR DESCRIPTION
## Description

This PR introduces functionality that allows IP owners to disable a license, preventing the minting of license tokens or the registration of derivatives for the IP through the disabled license. Additionally, IP owners can re-enable a disabled license.

## Key Changes

- **License Disabling**: Added functionality for IP owners to disable a license, which prevents minting license tokens and registering derivatives.

## Objectives

- **Control Over Licensing**: Provide IP owners with the ability to control the availability of their licenses.
- **Prevent Unauthorized Use**: Ensure that disabled licenses cannot be used to mint tokens or register derivatives.

This update provides IP owners with greater control over their licenses, enhancing the security and management of IP assets.

Closes #287 