### PR TITLE
fix typos README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -173,7 +173,7 @@ We use [solidity-docgen](https://github.com/OpenZeppelin/solidity-docgen) to gen
 npx hardhat docgen
 ```
 
-By default, the documents are generated in Markdown format in the `doc` folder of the project. Each Solidity file (`*.sol`) has its own Markdown (`*.md`) file. To update the configuration for document generation, you can update the following section in `harhat.config.js`:
+By default, the documents are generated in Markdown format in the `doc` folder of the project. Each Solidity file (`*.sol`) has its own Markdown (`*.md`) file. To update the configuration for document generation, you can update the following section in `hardhat.config.js`:
 
 ```
 docgen: {


### PR DESCRIPTION
## Description
This PR fixes a typo in the documentation where "harhat.config.js" was incorrectly written. The correct file name is "hardhat.config.js". This change ensures clarity and consistency in the documentation.

## Test Plan
- Verify that the corrected file name "hardhat.config.js" is properly displayed in the "Document Generation" section of the documentation.
- Confirm that no other instances of "harhat.config.js" remain in the documentation or codebase.

## Related Issue
None.

## Notes
- Ensure that documentation changes are reflected in any related README files or wiki pages if applicable.
