### PR TITLE
Add maxRts restriction when creating a derivative

### DIFF
--- a/contracts/interfaces/modules/licensing/ILicensingModule.sol
+++ b/contracts/interfaces/modules/licensing/ILicensingModule.sol
@@ -105,13 +105,15 @@ interface ILicensingModule is IModule {
     /// @param licenseTemplate The address of the license template of the license terms Ids.
     /// @param royaltyContext The context of the royalty.
     /// @param maxMintingFee The maximum minting fee that the caller is willing to pay. if set to 0 then no limit.
+    /// @param maxRts The maximum number of royalty tokens that can be distributed to the external royalty policies.
     function registerDerivative(
         address childIpId,
         address[] calldata parentIpIds,
         uint256[] calldata licenseTermsIds,
         address licenseTemplate,
         bytes calldata royaltyContext,
-        uint256 maxMintingFee
+        uint256 maxMintingFee,
+        uint32 maxRts
     ) external;
 
     /// @notice Registers a derivative with license tokens.
@@ -121,10 +123,12 @@ interface ILicensingModule is IModule {
     /// @param childIpId The derivative IP ID.
     /// @param licenseTokenIds The IDs of the license tokens.
     /// @param royaltyContext The context of the royalty.
+    /// @param maxRts The maximum number of royalty tokens that can be distributed to the external royalty policies.
     function registerDerivativeWithLicenseTokens(
         address childIpId,
         uint256[] calldata licenseTokenIds,
-        bytes calldata royaltyContext
+        bytes calldata royaltyContext,
+        uint32 maxRts
     ) external;
 
     /// @notice Sets the licensing configuration for a specific license terms of an IP.

--- a/contracts/interfaces/modules/royalty/IRoyaltyModule.sol
+++ b/contracts/interfaces/modules/royalty/IRoyaltyModule.sol
@@ -145,12 +145,14 @@ interface IRoyaltyModule is IModule {
     /// @param parentIpIds The parent ipIds that the children ipId is being linked to
     /// @param licensesPercent The license percentage of the licenses being minted
     /// @param externalData The external data custom to each the royalty policy
+    /// @param maxRts The maximum number of royalty tokens that can be distributed to the external royalty policies
     function onLinkToParents(
         address ipId,
         address[] calldata parentIpIds,
         address[] calldata licenseRoyaltyPolicies,
         uint32[] calldata licensesPercent,
-        bytes calldata externalData
+        bytes calldata externalData,
+        uint32 maxRts
     ) external;
 
     /// @notice Allows the function caller to pay royalties to the receiver IP asset on behalf of the payer IP asset.

--- a/contracts/lib/Errors.sol
+++ b/contracts/lib/Errors.sol
@@ -534,6 +534,9 @@ library Errors {
     /// @notice Above maximum percentage.
     error RoyaltyModule__AboveMaxPercent();
 
+    /// @notice Above maximum royalty tokens defined by the user.
+    error RoyaltyModule__AboveMaxRts();
+
     /// @notice Caller is unauthorized.
     error RoyaltyModule__NotAllowedCaller();
 

--- a/contracts/modules/licensing/LicensingModule.sol
+++ b/contracts/modules/licensing/LicensingModule.sol
@@ -298,7 +298,14 @@ contract LicensingModule is
             maxRts
         );
 
-        emit DerivativeRegistered(msg.sender, childIpId, new uint256[](0), parentIpIds, licenseTermsIds, licenseTemplate);
+        emit DerivativeRegistered(
+            msg.sender,
+            childIpId,
+            new uint256[](0),
+            parentIpIds,
+            licenseTermsIds,
+            licenseTemplate
+        );
     }
 
     /// @notice Registers a derivative with license tokens.

--- a/contracts/modules/licensing/LicensingModule.sol
+++ b/contracts/modules/licensing/LicensingModule.sol
@@ -287,35 +287,18 @@ contract LicensingModule is
         // Set the expiration timestamp for the derivative IP by invoking the license template to calculate
         // the earliest expiration time among all license terms.
         LICENSE_REGISTRY.registerDerivativeIp(childIpId, parentIpIds, licenseTemplate, licenseTermsIds, false);
-        // Process the payment for the minting fee.
-        (address[] memory royaltyPolicies, uint32[] memory royaltyPercents) = _payMintingFeeForAllParentIps(
+        _processPaymentAndSetupRoyalty(
             childIpId,
             parentIpIds,
             licenseTermsIds,
             licenseTemplate,
             childIpOwner,
             royaltyContext,
-            maxMintingFee
-        );
-        // emit event
-        emit DerivativeRegistered(
-            msg.sender,
-            childIpId,
-            new uint256[](0),
-            parentIpIds,
-            licenseTermsIds,
-            licenseTemplate
-        );
-
-        if (royaltyPolicies.length == 0 || royaltyPolicies[0] == address(0)) return;
-        ROYALTY_MODULE.onLinkToParents(
-            childIpId,
-            parentIpIds,
-            royaltyPolicies,
-            royaltyPercents,
-            royaltyContext,
+            maxMintingFee,
             maxRts
         );
+
+        emit DerivativeRegistered(msg.sender, childIpId, new uint256[](0), parentIpIds, licenseTermsIds, licenseTemplate);
     }
 
     /// @notice Registers a derivative with license tokens.
@@ -364,27 +347,8 @@ contract LicensingModule is
         // all license terms.
         LICENSE_REGISTRY.registerDerivativeIp(childIpId, parentIpIds, licenseTemplate, licenseTermsIds, true);
 
-        // Confirm that the royalty policies defined in all license terms of the parent IPs are identical.
-        address[] memory rPolicies = new address[](parentIpIds.length);
-        uint32[] memory rPercents = new uint32[](parentIpIds.length);
-        for (uint256 i = 0; i < parentIpIds.length; i++) {
-            (address royaltyPolicy, uint32 royaltyPercent, , ) = lct.getRoyaltyPolicy(licenseTermsIds[i]);
-            Licensing.LicensingConfig memory lsc = LICENSE_REGISTRY.getLicensingConfig(
-                parentIpIds[i],
-                licenseTemplate,
-                licenseTermsIds[i]
-            );
-            if (lsc.isSet && lsc.commercialRevShare != 0) {
-                royaltyPercent = lsc.commercialRevShare;
-            }
-            rPercents[i] = royaltyPercent;
-            rPolicies[i] = royaltyPolicy;
-        }
+        _setupRoyalty(childIpId, parentIpIds, licenseTermsIds, licenseTemplate, royaltyContext, maxRts);
 
-        if (rPolicies.length != 0 && rPolicies[0] != address(0)) {
-            // Notify the royalty module
-            ROYALTY_MODULE.onLinkToParents(childIpId, parentIpIds, rPolicies, rPercents, royaltyContext, maxRts);
-        }
         // burn license tokens
         LICENSE_NFT.burnLicenseTokens(childIpOwner, licenseTokenIds);
         emit DerivativeRegistered(
@@ -500,6 +464,72 @@ contract LicensingModule is
 
         if (royaltyPolicy != address(0)) {
             tokenAmount = _getTotalMintingFee(lsc, mintingFeeByHook, mintingFeeByLicense, amount);
+        }
+    }
+
+    /// @dev process the minting fee and setup royalty between derivative IP and parent IPs
+    function _processPaymentAndSetupRoyalty(
+        address childIpId,
+        address[] calldata parentIpIds,
+        uint256[] calldata licenseTermsIds,
+        address licenseTemplate,
+        address childIpOwner,
+        bytes calldata royaltyContext,
+        uint256 maxMintingFee,
+        uint32 maxRts
+    ) private {
+        // Process the payment for the minting fee.
+        (address[] memory royaltyPolicies, uint32[] memory royaltyPercents) = _payMintingFeeForAllParentIps(
+            childIpId,
+            parentIpIds,
+            licenseTermsIds,
+            licenseTemplate,
+            childIpOwner,
+            royaltyContext,
+            maxMintingFee
+        );
+
+        if (royaltyPolicies.length == 0 || royaltyPolicies[0] == address(0)) return;
+        ROYALTY_MODULE.onLinkToParents(
+            childIpId,
+            parentIpIds,
+            royaltyPolicies,
+            royaltyPercents,
+            royaltyContext,
+            maxRts
+        );
+    }
+
+    /// @dev set up royalty between child IP and parent IPs
+    function _setupRoyalty(
+        address childIpId,
+        address[] memory parentIpIds,
+        uint256[] memory licenseTermsIds,
+        address licenseTemplate,
+        bytes memory royaltyContext,
+        uint32 maxRts
+    ) private {
+        ILicenseTemplate lct = ILicenseTemplate(licenseTemplate);
+        // Confirm that the royalty policies defined in all license terms of the parent IPs are identical.
+        address[] memory rPolicies = new address[](parentIpIds.length);
+        uint32[] memory rPercents = new uint32[](parentIpIds.length);
+        for (uint256 i = 0; i < parentIpIds.length; i++) {
+            (address royaltyPolicy, uint32 royaltyPercent, , ) = lct.getRoyaltyPolicy(licenseTermsIds[i]);
+            Licensing.LicensingConfig memory lsc = LICENSE_REGISTRY.getLicensingConfig(
+                parentIpIds[i],
+                licenseTemplate,
+                licenseTermsIds[i]
+            );
+            if (lsc.isSet && lsc.commercialRevShare != 0) {
+                royaltyPercent = lsc.commercialRevShare;
+            }
+            rPercents[i] = royaltyPercent;
+            rPolicies[i] = royaltyPolicy;
+        }
+
+        if (rPolicies.length != 0 && rPolicies[0] != address(0)) {
+            // Notify the royalty module
+            ROYALTY_MODULE.onLinkToParents(childIpId, parentIpIds, rPolicies, rPercents, royaltyContext, maxRts);
         }
     }
 

--- a/contracts/modules/royalty/RoyaltyModule.sol
+++ b/contracts/modules/royalty/RoyaltyModule.sol
@@ -497,10 +497,22 @@ contract RoyaltyModule is IRoyaltyModule, VaultController, ReentrancyGuardUpgrad
         for (uint256 i = 0; i < parentIpIds.length; i++) {
             if (parentIpIds[i] == address(0)) revert Errors.RoyaltyModule__ZeroParentIpId();
             if (licenseRoyaltyPolicies[i] == address(0)) revert Errors.RoyaltyModule__ZeroRoyaltyPolicy();
-            _addToAccumulatedRoyaltyPolicies(parentIpIds[i], licenseRoyaltyPolicies[i]);
-            address[] memory accParentRoyaltyPolicies = $.accumulatedRoyaltyPolicies[parentIpIds[i]].values();
 
+            // transfer the royalty tokens and add royalty policy to child if it's not contained in the parent
+            // since if it's already contained then it will be transferred in the next loop already
+            if (!$.accumulatedRoyaltyPolicies[parentIpIds[i]].contains(licenseRoyaltyPolicies[i])) {
+                _addToAccumulatedRoyaltyPolicies(ipId, licenseRoyaltyPolicies[i]);
+                totalRtsRequiredToLink += _transferRoyaltyTokensToPolicy(
+                    parentIpIds[i],
+                    licenseRoyaltyPolicies[i],
+                    licensesPercent[i],
+                    ipRoyaltyVault
+                );
+            }
+
+            // transfer the royalty tokens and add all the parent royalty policies to the child
             // this loop is limited to accumulatedRoyaltyPoliciesLimit
+            address[] memory accParentRoyaltyPolicies = $.accumulatedRoyaltyPolicies[parentIpIds[i]].values();
             for (uint256 j = 0; j < accParentRoyaltyPolicies.length; j++) {
                 // add the parent ancestor royalty policies to the child
                 _addToAccumulatedRoyaltyPolicies(ipId, accParentRoyaltyPolicies[j]);
@@ -508,13 +520,12 @@ contract RoyaltyModule is IRoyaltyModule, VaultController, ReentrancyGuardUpgrad
                 uint32 licensePercent = accParentRoyaltyPolicies[j] == licenseRoyaltyPolicies[i]
                     ? licensesPercent[i]
                     : 0;
-                uint32 rtsRequiredToLink = IRoyaltyPolicy(accParentRoyaltyPolicies[j]).getPolicyRtsRequiredToLink(
+                totalRtsRequiredToLink += _transferRoyaltyTokensToPolicy(
                     parentIpIds[i],
-                    licensePercent
+                    accParentRoyaltyPolicies[j],
+                    licensePercent,
+                    ipRoyaltyVault
                 );
-                totalRtsRequiredToLink += rtsRequiredToLink;
-                if (totalRtsRequiredToLink > MAX_PERCENT) revert Errors.RoyaltyModule__AboveMaxPercent();
-                IERC20(ipRoyaltyVault).safeTransfer(accParentRoyaltyPolicies[j], rtsRequiredToLink);
             }
         }
 
@@ -535,6 +546,23 @@ contract RoyaltyModule is IRoyaltyModule, VaultController, ReentrancyGuardUpgrad
     /// @param royaltyPolicy The address of the royalty policy
     function _addToAccumulatedRoyaltyPolicies(address ipId, address royaltyPolicy) internal {
         _getRoyaltyModuleStorage().accumulatedRoyaltyPolicies[ipId].add(royaltyPolicy);
+    }
+
+    /// @notice Transfers the royalty tokens to the royalty policy
+    /// @param parentIpId The parent IP asset
+    /// @param royaltyPolicy The address of the royalty policy
+    /// @param licensePercent The license percentage
+    /// @param ipRoyaltyVault The address of the ipRoyaltyVault
+    /// @return rtsRequiredToLink The required royalty tokens to link
+    function _transferRoyaltyTokensToPolicy(    
+        address parentIpId,
+        address royaltyPolicy,
+        uint32 licensePercent,
+        address ipRoyaltyVault
+    ) internal returns (uint32) {
+        uint32 rtsRequiredToLink = IRoyaltyPolicy(royaltyPolicy).getPolicyRtsRequiredToLink(parentIpId, licensePercent);
+        IERC20(ipRoyaltyVault).safeTransfer(royaltyPolicy, rtsRequiredToLink);
+        return rtsRequiredToLink;
     }
 
     /// @notice Handles the payment of royalties

--- a/contracts/modules/royalty/RoyaltyModule.sol
+++ b/contracts/modules/royalty/RoyaltyModule.sol
@@ -554,7 +554,7 @@ contract RoyaltyModule is IRoyaltyModule, VaultController, ReentrancyGuardUpgrad
     /// @param licensePercent The license percentage
     /// @param ipRoyaltyVault The address of the ipRoyaltyVault
     /// @return rtsRequiredToLink The required royalty tokens to link
-    function _transferRoyaltyTokensToPolicy(    
+    function _transferRoyaltyTokensToPolicy(
         address parentIpId,
         address royaltyPolicy,
         uint32 licensePercent,

--- a/test/foundry/integration/BaseIntegration.t.sol
+++ b/test/foundry/integration/BaseIntegration.t.sol
@@ -84,7 +84,7 @@ contract BaseIntegration is BaseTest {
     ) internal {
         vm.startPrank(caller);
         // TODO: events check
-        licensingModule.registerDerivativeWithLicenseTokens(ipId, licenseTokenIds, royaltyContext);
+        licensingModule.registerDerivativeWithLicenseTokens(ipId, licenseTokenIds, royaltyContext, 100e6);
         vm.stopPrank();
     }
 }

--- a/test/foundry/integration/big-bang/SingleNftCollection.t.sol
+++ b/test/foundry/integration/big-bang/SingleNftCollection.t.sol
@@ -270,7 +270,7 @@ contract BigBang_Integration_SingleNftCollection is BaseIntegration {
                     carl_licenses
                 )
             );
-            licensingModule.registerDerivativeWithLicenseTokens(ipAcct[tokenId], carl_licenses, "");
+            licensingModule.registerDerivativeWithLicenseTokens(ipAcct[tokenId], carl_licenses, "", 100e6);
 
             uint256 license1_mintAmount = 500;
             mockToken.mint(u.carl, mintingFee * license1_mintAmount);

--- a/test/foundry/integration/flows/disputes/Disputes.t.sol
+++ b/test/foundry/integration/flows/disputes/Disputes.t.sol
@@ -97,7 +97,7 @@ contract Flows_Integration_Disputes is BaseIntegration {
 
         vm.prank(u.carl);
         vm.expectRevert(abi.encodeWithSelector(Errors.LicenseToken__RevokedLicense.selector, licenseId));
-        licensingModule.registerDerivativeWithLicenseTokens(ipAcct[3], licenseIds, "");
+        licensingModule.registerDerivativeWithLicenseTokens(ipAcct[3], licenseIds, "", 100e6);
     }
 
     function test_Integration_Disputes_revert_cannotRegisterDerivativeFromDisputedIpParent() public {
@@ -117,7 +117,8 @@ contract Flows_Integration_Disputes is BaseIntegration {
             licenseTermsIds: licenseTermsIds,
             licenseTemplate: address(pilTemplate),
             royaltyContext: "",
-            maxMintingFee: 0
+            maxMintingFee: 0,
+            maxRts: 100e6
         });
     }
 

--- a/test/foundry/integration/flows/grouping/Grouping.t.sol
+++ b/test/foundry/integration/flows/grouping/Grouping.t.sol
@@ -97,7 +97,7 @@ contract Flows_Integration_Grouping is BaseIntegration {
             parentIpIds[0] = groupId;
             uint256[] memory licenseIds = new uint256[](1);
             licenseIds[0] = commRemixTermsId;
-            licensingModule.registerDerivative(ipAcct[3], parentIpIds, licenseIds, address(pilTemplate), "", 0);
+            licensingModule.registerDerivative(ipAcct[3], parentIpIds, licenseIds, address(pilTemplate), "", 0, 100e6);
             vm.stopPrank();
         }
 

--- a/test/foundry/integration/flows/licensing/LicensingIntegration.t.sol
+++ b/test/foundry/integration/flows/licensing/LicensingIntegration.t.sol
@@ -122,7 +122,7 @@ contract LicensingIntegrationTest is BaseIntegration {
         parentIpIds[0] = ipAcct[1];
         licenseTermsIds[0] = 1;
 
-        licensingModule.registerDerivative(ipAcct[2], parentIpIds, licenseTermsIds, address(pilTemplate), "", 0);
+        licensingModule.registerDerivative(ipAcct[2], parentIpIds, licenseTermsIds, address(pilTemplate), "", 0, 100e6);
 
         assertEq(licenseRegistry.hasIpAttachedLicenseTerms(ipAcct[2], address(pilTemplate), 1), true);
         assertEq(licenseRegistry.getAttachedLicenseTermsCount(ipAcct[2]), 2);
@@ -158,7 +158,7 @@ contract LicensingIntegrationTest is BaseIntegration {
         uint256[] memory licenseTokens = new uint256[](1);
         licenseTokens[0] = lcTokenId;
 
-        licensingModule.registerDerivativeWithLicenseTokens(ipAcct[3], licenseTokens, "");
+        licensingModule.registerDerivativeWithLicenseTokens(ipAcct[3], licenseTokens, "", 100e6);
 
         assertEq(licenseRegistry.hasIpAttachedLicenseTerms(ipAcct[3], address(pilTemplate), 1), true);
         assertEq(licenseRegistry.getAttachedLicenseTermsCount(ipAcct[3]), 2);
@@ -196,7 +196,7 @@ contract LicensingIntegrationTest is BaseIntegration {
         licenseTokens = new uint256[](1);
         licenseTokens[0] = lcTokenId;
 
-        licensingModule.registerDerivativeWithLicenseTokens(ipAcct[6], licenseTokens, "");
+        licensingModule.registerDerivativeWithLicenseTokens(ipAcct[6], licenseTokens, "", 100e6);
 
         assertEq(licenseRegistry.hasIpAttachedLicenseTerms(ipAcct[6], address(pilTemplate), 2), true);
         assertEq(licenseRegistry.getAttachedLicenseTermsCount(ipAcct[6]), 2);
@@ -226,7 +226,7 @@ contract LicensingIntegrationTest is BaseIntegration {
         parentIpIds[0] = ipAcct[1];
         licenseTermsIds[0] = 2;
 
-        licensingModule.registerDerivative(ipAcct[7], parentIpIds, licenseTermsIds, address(pilTemplate), "", 0);
+        licensingModule.registerDerivative(ipAcct[7], parentIpIds, licenseTermsIds, address(pilTemplate), "", 0, 100e6);
 
         assertEq(licenseRegistry.hasIpAttachedLicenseTerms(ipAcct[7], address(pilTemplate), 2), true);
         assertEq(licenseRegistry.getAttachedLicenseTermsCount(ipAcct[7]), 2);
@@ -274,7 +274,8 @@ contract LicensingIntegrationTest is BaseIntegration {
             licenseTermsIds: licenseTermsIds,
             licenseTemplate: address(anotherPILTemplate),
             royaltyContext: "",
-            maxMintingFee: 0
+            maxMintingFee: 0,
+            maxRts: 100e6
         });
     }
 
@@ -321,7 +322,8 @@ contract LicensingIntegrationTest is BaseIntegration {
             licenseTermsIds: licenseTermsIds,
             licenseTemplate: address(pilTemplate),
             royaltyContext: "",
-            maxMintingFee: 0
+            maxMintingFee: 0,
+            maxRts: 100e6
         });
     }
 }

--- a/test/foundry/integration/flows/licensing/LicensingScenarios.t.sol
+++ b/test/foundry/integration/flows/licensing/LicensingScenarios.t.sol
@@ -141,7 +141,7 @@ contract Licensing_Scenarios is BaseIntegration {
             royaltyContext: "",
             maxMintingFee: 0
         });
-        licensingModule.registerDerivativeWithLicenseTokens(ipAcct[2], licenseIds, "");
+        licensingModule.registerDerivativeWithLicenseTokens(ipAcct[2], licenseIds, "", 100e6);
 
         // Mint license for commercial use, then link to new IPA to make it a derivative
         IERC20(USDC).approve(address(royaltyModule), mintingFee);
@@ -161,7 +161,7 @@ contract Licensing_Scenarios is BaseIntegration {
                 licenseIds
             )
         );
-        licensingModule.registerDerivativeWithLicenseTokens(ipAcct[3], licenseIds, "");
+        licensingModule.registerDerivativeWithLicenseTokens(ipAcct[3], licenseIds, "", 100e6);
 
         // Mint license for commercial remixing, then link to new IPA to make it a derivative
         IERC20(USDC).approve(address(royaltyModule), mintingFee);
@@ -174,7 +174,7 @@ contract Licensing_Scenarios is BaseIntegration {
             royaltyContext: "",
             maxMintingFee: 0
         });
-        licensingModule.registerDerivativeWithLicenseTokens(ipAcct[4], licenseIds, "");
+        licensingModule.registerDerivativeWithLicenseTokens(ipAcct[4], licenseIds, "", 100e6);
 
         vm.stopPrank();
     }

--- a/test/foundry/integration/flows/royalty/Royalty.t.sol
+++ b/test/foundry/integration/flows/royalty/Royalty.t.sol
@@ -96,7 +96,7 @@ contract Flows_Integration_Disputes is BaseIntegration {
                     commRemixTermsId
                 )
             );
-            licensingModule.registerDerivativeWithLicenseTokens(ipAcct[2], licenseIds, "");
+            licensingModule.registerDerivativeWithLicenseTokens(ipAcct[2], licenseIds, "", 100e6);
 
             // can link max two
             uint256[] memory licenseIdsMax = new uint256[](1);
@@ -254,7 +254,7 @@ contract Flows_Integration_Disputes is BaseIntegration {
             ipAcct[5] = registerIpAccount(mockNFT, 5, u.alice);
             vm.label(ipAcct[5], "IPAccount5");
 
-            licensingModule.registerDerivativeWithLicenseTokens(ipAcct[5], licenseId, "");
+            licensingModule.registerDerivativeWithLicenseTokens(ipAcct[5], licenseId, "", 100e6);
 
             vm.stopPrank();
         }

--- a/test/foundry/invariants/DisputeModule.t.sol
+++ b/test/foundry/invariants/DisputeModule.t.sol
@@ -181,7 +181,8 @@ contract DisputeInvariants is BaseTest {
             licenseTermsIds: licenseTermsIds,
             licenseTemplate: address(pilTemplate),
             royaltyContext: "",
-            maxMintingFee: 0
+            maxMintingFee: 0,
+            maxRts: 100e6
         });
 
         /*         targetContract(address(harness));

--- a/test/foundry/invariants/IpRoyaltyVault.t.sol
+++ b/test/foundry/invariants/IpRoyaltyVault.t.sol
@@ -97,7 +97,7 @@ contract IpRoyaltyVaultInvariant is BaseTest {
         parentRoyalties[1] = uint32(10 * 10 ** 6);
         parentRoyalties[2] = uint32(7 * 10 ** 6);
         ipGraph.addParentIp(address(40), parents);
-        royaltyModule.onLinkToParents(address(40), parents, licenseRoyaltyPolicies, parentRoyalties, "");
+        royaltyModule.onLinkToParents(address(40), parents, licenseRoyaltyPolicies, parentRoyalties, "", 100e6);
 
         // mint license for 40
         royaltyModule.onLicenseMinting(address(40), address(royaltyPolicyLRP), uint32(5 * 10 ** 6), "");
@@ -110,7 +110,7 @@ contract IpRoyaltyVaultInvariant is BaseTest {
         licenseRoyaltyPolicies[0] = address(royaltyPolicyLRP);
         parentRoyalties[0] = uint32(5 * 10 ** 6);
         ipGraph.addParentIp(address(50), parents);
-        royaltyModule.onLinkToParents(address(50), parents, licenseRoyaltyPolicies, parentRoyalties, "");
+        royaltyModule.onLinkToParents(address(50), parents, licenseRoyaltyPolicies, parentRoyalties, "", 100e6);
 
         // mint license for 50
         royaltyModule.onLicenseMinting(address(50), address(royaltyPolicyLRP), uint32(15 * 10 ** 6), "");
@@ -123,7 +123,7 @@ contract IpRoyaltyVaultInvariant is BaseTest {
         licenseRoyaltyPolicies[0] = address(royaltyPolicyLRP);
         parentRoyalties[0] = uint32(15 * 10 ** 6);
         ipGraph.addParentIp(address(60), parents);
-        royaltyModule.onLinkToParents(address(60), parents, licenseRoyaltyPolicies, parentRoyalties, "");
+        royaltyModule.onLinkToParents(address(60), parents, licenseRoyaltyPolicies, parentRoyalties, "", 100e6);
     }
 
     /// @notice Invariant to check anyone's balance should be <= init (1000 * 10 ** 6)

--- a/test/foundry/invariants/LicensingModule.t.sol
+++ b/test/foundry/invariants/LicensingModule.t.sol
@@ -103,7 +103,15 @@ contract LicensingModuleHarness is Test {
             require(parentIpIdsNth[i] < availableIpIds.length, "LicensingModuleHarness: invalid parentIpIdsNth");
             parentIpIds[i] = availableIpIds[parentIpIdsNth[i]];
         }
-        licensingModule.registerDerivative(childIpId, parentIpIds, licenseTermsIds, licenseTemplate, royaltyContext, 0);
+        licensingModule.registerDerivative(
+            childIpId,
+            parentIpIds,
+            licenseTermsIds,
+            licenseTemplate,
+            royaltyContext,
+            0,
+            100e6
+        );
 
         mintedOrRegisterDerivative = true;
     }
@@ -117,7 +125,7 @@ contract LicensingModuleHarness is Test {
     ) external {
         require(childIpIdNth < availableIpIds.length, "LicensingModuleHarness: invalid childIpIdNth");
         address childIpId = availableIpIds[childIpIdNth];
-        licensingModule.registerDerivativeWithLicenseTokens(childIpId, licenseTokenIds, royaltyContext);
+        licensingModule.registerDerivativeWithLicenseTokens(childIpId, licenseTokenIds, royaltyContext, 100e6);
 
         mintedOrRegisterDerivative = true;
     }

--- a/test/foundry/modules/dispute/DisputeModule.t.sol
+++ b/test/foundry/modules/dispute/DisputeModule.t.sol
@@ -103,7 +103,7 @@ contract DisputeModuleTest is BaseTest {
 
         ipAddr2 = ipAssetRegistry.register(block.chainid, address(mockNFT), 1);
 
-        licensingModule.registerDerivativeWithLicenseTokens(ipAddr2, licenseIds, "");
+        licensingModule.registerDerivativeWithLicenseTokens(ipAddr2, licenseIds, "", 100e6);
 
         vm.stopPrank();
 

--- a/test/foundry/modules/grouping/GroupingModule.t.sol
+++ b/test/foundry/modules/grouping/GroupingModule.t.sol
@@ -221,7 +221,7 @@ contract GroupingModuleTest is BaseTest {
         uint256[] memory licenseTermsIds = new uint256[](1);
         licenseTermsIds[0] = termsId;
         vm.prank(ipOwner3);
-        licensingModule.registerDerivative(ipId3, parentIpIds, licenseTermsIds, address(pilTemplate), "", 0);
+        licensingModule.registerDerivative(ipId3, parentIpIds, licenseTermsIds, address(pilTemplate), "", 0, 100e6);
 
         erc20.mint(ipOwner3, 1000);
         vm.startPrank(ipOwner3);
@@ -301,7 +301,7 @@ contract GroupingModuleTest is BaseTest {
         uint256[] memory licenseTermsIds = new uint256[](1);
         licenseTermsIds[0] = termsId;
         vm.prank(ipOwner2);
-        licensingModule.registerDerivative(ipId2, parentIpIds, licenseTermsIds, address(pilTemplate), "", 0);
+        licensingModule.registerDerivative(ipId2, parentIpIds, licenseTermsIds, address(pilTemplate), "", 0, 100e6);
 
         address[] memory ipIds = new address[](1);
         ipIds[0] = ipId2;
@@ -342,7 +342,7 @@ contract GroupingModuleTest is BaseTest {
         parentIpIds[0] = groupId;
         licenseTermsIds[0] = termsId;
 
-        licensingModule.registerDerivative(ipId3, parentIpIds, licenseTermsIds, address(pilTemplate), "", 0);
+        licensingModule.registerDerivative(ipId3, parentIpIds, licenseTermsIds, address(pilTemplate), "", 0, 100e6);
         vm.stopPrank();
 
         address[] memory ipIds = new address[](2);
@@ -395,7 +395,7 @@ contract GroupingModuleTest is BaseTest {
         parentIpIds[0] = groupId;
         licenseTermsIds[0] = termsId;
 
-        licensingModule.registerDerivative(ipId3, parentIpIds, licenseTermsIds, address(pilTemplate), "", 0);
+        licensingModule.registerDerivative(ipId3, parentIpIds, licenseTermsIds, address(pilTemplate), "", 0, 100e6);
         vm.stopPrank();
 
         address[] memory removeIpIds = new address[](1);

--- a/test/foundry/modules/licensing/LicensingModule.t.sol
+++ b/test/foundry/modules/licensing/LicensingModule.t.sol
@@ -223,7 +223,7 @@ contract LicensingModuleTest is BaseTest {
         uint256[] memory licenseTokens = new uint256[](1);
         licenseTokens[0] = lcTokenId;
         vm.prank(ipOwner2);
-        licensingModule.registerDerivativeWithLicenseTokens(ipId2, licenseTokens, "");
+        licensingModule.registerDerivativeWithLicenseTokens(ipId2, licenseTokens, "", 100e6);
 
         assertEq(licenseRegistry.hasIpAttachedLicenseTerms(ipId2, address(pilTemplate), termsId), true);
         assertEq(licenseRegistry.getAttachedLicenseTermsCount(ipId2), 2);
@@ -775,7 +775,7 @@ contract LicensingModuleTest is BaseTest {
         uint256[] memory licenseTokens = new uint256[](1);
         licenseTokens[0] = lcTokenId;
         vm.prank(ipOwner2);
-        licensingModule.registerDerivativeWithLicenseTokens(ipId2, licenseTokens, "");
+        licensingModule.registerDerivativeWithLicenseTokens(ipId2, licenseTokens, "", 100e6);
 
         assertEq(licenseRegistry.hasIpAttachedLicenseTerms(ipId2, address(pilTemplate), termsId), true);
         assertEq(licenseRegistry.getAttachedLicenseTermsCount(ipId2), 2);
@@ -832,7 +832,7 @@ contract LicensingModuleTest is BaseTest {
         uint256[] memory licenseTokens = new uint256[](1);
         licenseTokens[0] = lcTokenId;
         vm.prank(ipOwner2);
-        licensingModule.registerDerivativeWithLicenseTokens(ipId2, licenseTokens, "");
+        licensingModule.registerDerivativeWithLicenseTokens(ipId2, licenseTokens, "", 100e6);
 
         assertEq(licenseRegistry.hasIpAttachedLicenseTerms(ipId2, address(pilTemplate), termsId), true);
         assertEq(licenseRegistry.hasIpAttachedLicenseTerms(ipId1, address(pilTemplate), termsId), false);
@@ -887,7 +887,7 @@ contract LicensingModuleTest is BaseTest {
         licenseTokens[0] = lcTokenId;
         vm.expectRevert(abi.encodeWithSelector(PausableUpgradeable.EnforcedPause.selector));
         vm.prank(ipOwner2);
-        licensingModule.registerDerivativeWithLicenseTokens(ipId2, licenseTokens, "");
+        licensingModule.registerDerivativeWithLicenseTokens(ipId2, licenseTokens, "", 100e6);
     }
 
     function test_LicensingModule_registerDerivativeWithLicenseTokens_twoParents() public {
@@ -951,7 +951,7 @@ contract LicensingModuleTest is BaseTest {
         licenseTokens[0] = lcTokenId1;
         licenseTokens[1] = lcTokenId2;
         vm.prank(ipOwner3);
-        licensingModule.registerDerivativeWithLicenseTokens(ipId3, licenseTokens, "");
+        licensingModule.registerDerivativeWithLicenseTokens(ipId3, licenseTokens, "", 100e6);
 
         assertEq(licenseRegistry.hasIpAttachedLicenseTerms(ipId3, address(pilTemplate), termsId), true);
         assertEq(licenseRegistry.getAttachedLicenseTermsCount(ipId3), 2);
@@ -1004,7 +1004,7 @@ contract LicensingModuleTest is BaseTest {
 
         vm.expectRevert(abi.encodeWithSelector(Errors.LicenseRegistry__DerivativeIsParent.selector, ipId1));
         vm.prank(ipOwner1);
-        licensingModule.registerDerivativeWithLicenseTokens(ipId1, licenseTokens, "");
+        licensingModule.registerDerivativeWithLicenseTokens(ipId1, licenseTokens, "", 100e6);
     }
 
     function test_LicensingModule_registerDerivativeWithLicenseTokens_revert_ParentExpired() public {
@@ -1055,7 +1055,7 @@ contract LicensingModuleTest is BaseTest {
         licenseTokens[0] = lcTokenId1;
         licenseTokens[1] = lcTokenId2;
         vm.prank(ipOwner3);
-        licensingModule.registerDerivativeWithLicenseTokens(ipId3, licenseTokens, "");
+        licensingModule.registerDerivativeWithLicenseTokens(ipId3, licenseTokens, "", 100e6);
 
         assertEq(licenseRegistry.hasIpAttachedLicenseTerms(ipId3, address(pilTemplate), expiredTermsId), true);
         assertEq(licenseRegistry.getAttachedLicenseTermsCount(ipId3), 2);
@@ -1101,7 +1101,7 @@ contract LicensingModuleTest is BaseTest {
 
         vm.expectRevert(abi.encodeWithSelector(Errors.LicenseRegistry__ParentIpExpired.selector, ipId3));
         vm.prank(ipOwner5);
-        licensingModule.registerDerivativeWithLicenseTokens(ipId5, licenseTokens, "");
+        licensingModule.registerDerivativeWithLicenseTokens(ipId5, licenseTokens, "", 100e6);
     }
 
     function test_LicensingModule_registerDerivativeWithLicenseTokens_revert_childAlreadyAttachedLicense() public {
@@ -1132,7 +1132,7 @@ contract LicensingModuleTest is BaseTest {
 
         vm.expectRevert(abi.encodeWithSelector(Errors.LicenseRegistry__DerivativeIsParent.selector, ipId1));
         vm.prank(ipOwner1);
-        licensingModule.registerDerivativeWithLicenseTokens(ipId1, licenseTokens, "");
+        licensingModule.registerDerivativeWithLicenseTokens(ipId1, licenseTokens, "", 100e6);
     }
 
     function test_LicensingModule_registerDerivativeWithLicenseTokens_revert_DerivativeIpAlreadyHasChildIp() public {
@@ -1181,13 +1181,13 @@ contract LicensingModuleTest is BaseTest {
         uint256[] memory licenseTokens = new uint256[](1);
         licenseTokens[0] = lcTokenId2;
         vm.prank(ipOwner3);
-        licensingModule.registerDerivativeWithLicenseTokens(ipId3, licenseTokens, "");
+        licensingModule.registerDerivativeWithLicenseTokens(ipId3, licenseTokens, "", 100e6);
 
         licenseTokens = new uint256[](1);
         licenseTokens[0] = lcTokenId1;
         vm.expectRevert(abi.encodeWithSelector(Errors.LicenseRegistry__DerivativeIpAlreadyHasChild.selector, ipId2));
         vm.prank(ipOwner2);
-        licensingModule.registerDerivativeWithLicenseTokens(ipId2, licenseTokens, "");
+        licensingModule.registerDerivativeWithLicenseTokens(ipId2, licenseTokens, "", 100e6);
     }
 
     function test_LicensingModule_registerDerivativeWithLicenseTokens_revert_AlreadyRegisteredAsDerivative() public {
@@ -1236,13 +1236,13 @@ contract LicensingModuleTest is BaseTest {
         uint256[] memory licenseTokens = new uint256[](1);
         licenseTokens[0] = lcTokenId1;
         vm.prank(ipOwner3);
-        licensingModule.registerDerivativeWithLicenseTokens(ipId3, licenseTokens, "");
+        licensingModule.registerDerivativeWithLicenseTokens(ipId3, licenseTokens, "", 100e6);
 
         licenseTokens = new uint256[](1);
         licenseTokens[0] = lcTokenId2;
         vm.expectRevert(abi.encodeWithSelector(Errors.LicenseRegistry__DerivativeAlreadyRegistered.selector, ipId3));
         vm.prank(ipOwner3);
-        licensingModule.registerDerivativeWithLicenseTokens(ipId3, licenseTokens, "");
+        licensingModule.registerDerivativeWithLicenseTokens(ipId3, licenseTokens, "", 100e6);
     }
 
     function test_LicensingModule_registerDerivativeWithLicenseTokens_ownedByDelegator() public {
@@ -1274,7 +1274,7 @@ contract LicensingModuleTest is BaseTest {
         licenseTokens[0] = lcTokenId;
 
         vm.prank(ipOwner2);
-        licensingModule.registerDerivativeWithLicenseTokens(ipId3, licenseTokens, "");
+        licensingModule.registerDerivativeWithLicenseTokens(ipId3, licenseTokens, "", 100e6);
     }
 
     function test_LicensingModule_registerDerivativeWithLicenseTokens_ownedByChildIp() public {
@@ -1304,7 +1304,7 @@ contract LicensingModuleTest is BaseTest {
         licenseTokens[0] = lcTokenId;
 
         vm.prank(ipOwner3);
-        licensingModule.registerDerivativeWithLicenseTokens(ipId3, licenseTokens, "");
+        licensingModule.registerDerivativeWithLicenseTokens(ipId3, licenseTokens, "", 100e6);
     }
 
     function test_LicensingModule_registerDerivativeWithLicenseTokens_revert_notLicensee() public {
@@ -1343,7 +1343,7 @@ contract LicensingModuleTest is BaseTest {
             )
         );
         vm.prank(ipOwner3);
-        licensingModule.registerDerivativeWithLicenseTokens(ipId3, licenseTokens, "");
+        licensingModule.registerDerivativeWithLicenseTokens(ipId3, licenseTokens, "", 100e6);
     }
 
     function test_LicensingModule_singleTransfer_verifyOk() public {
@@ -1375,7 +1375,7 @@ contract LicensingModuleTest is BaseTest {
         uint256[] memory licenseTokens = new uint256[](1);
         licenseTokens[0] = lcTokenId;
         vm.prank(ipOwner3);
-        licensingModule.registerDerivativeWithLicenseTokens(ipId3, licenseTokens, "");
+        licensingModule.registerDerivativeWithLicenseTokens(ipId3, licenseTokens, "", 100e6);
 
         assertEq(licenseRegistry.hasIpAttachedLicenseTerms(ipId3, address(pilTemplate), termsId), true);
         assertEq(licenseRegistry.getAttachedLicenseTermsCount(ipId3), 2);
@@ -1557,21 +1557,21 @@ contract LicensingModuleTest is BaseTest {
             )
         );
         vm.prank(ipOwner2);
-        licensingModule.registerDerivativeWithLicenseTokens(ipId2, licenseTokens, "");
+        licensingModule.registerDerivativeWithLicenseTokens(ipId2, licenseTokens, "", 100e6);
     }
 
     // test registerDerivativeWithLicenseTokens revert licenseTokenIds is empty
     function test_LicensingModule_registerDerivativeWithLicenseTokens_revert_emptyLicenseTokens() public {
         vm.expectRevert(Errors.LicensingModule__NoLicenseToken.selector);
         vm.prank(ipOwner1);
-        licensingModule.registerDerivativeWithLicenseTokens(ipId1, new uint256[](0), "");
+        licensingModule.registerDerivativeWithLicenseTokens(ipId1, new uint256[](0), "", 100e6);
     }
 
     // test registerDerivative revert parentIpIds is empty
     function test_LicensingModule_registerDerivative_revert_emptyParentIpIds() public {
         vm.expectRevert(Errors.LicensingModule__NoParentIp.selector);
         vm.prank(ipOwner2);
-        licensingModule.registerDerivative(ipId2, new address[](0), new uint256[](0), address(0), "", 0);
+        licensingModule.registerDerivative(ipId2, new address[](0), new uint256[](0), address(0), "", 0, 100e6);
     }
 
     function test_LicensingModule_registerDerivative_revert_parentIdsLengthMismatchWithLicenseIds() public {
@@ -1579,7 +1579,7 @@ contract LicensingModuleTest is BaseTest {
         parentIpIds[0] = ipId1;
         vm.expectRevert(abi.encodeWithSelector(Errors.LicensingModule__LicenseTermsLengthMismatch.selector, 1, 0));
         vm.prank(ipOwner2);
-        licensingModule.registerDerivative(ipId2, parentIpIds, new uint256[](0), address(0), "", 0);
+        licensingModule.registerDerivative(ipId2, parentIpIds, new uint256[](0), address(0), "", 0, 100e6);
     }
 
     function test_LicensingModule_registerDerivative_revert_IncompatibleLicenses() public {
@@ -1617,7 +1617,7 @@ contract LicensingModuleTest is BaseTest {
             abi.encodeWithSelector(Errors.LicensingModule__LicenseNotCompatibleForDerivative.selector, ipId3)
         );
         vm.prank(ipOwner3);
-        licensingModule.registerDerivative(ipId3, parentIpIds, licenseTermsIds, address(pilTemplate), "", 0);
+        licensingModule.registerDerivative(ipId3, parentIpIds, licenseTermsIds, address(pilTemplate), "", 0, 100e6);
     }
 
     function test_LicensingModule_registerDerivative_revert_CommercialUseOnlyLicense() public {
@@ -1645,7 +1645,7 @@ contract LicensingModuleTest is BaseTest {
             abi.encodeWithSelector(Errors.LicensingModule__LicenseNotCompatibleForDerivative.selector, ipId3)
         );
         vm.prank(ipOwner3);
-        licensingModule.registerDerivative(ipId3, parentIpIds, licenseTermsIds, address(pilTemplate), "", 0);
+        licensingModule.registerDerivative(ipId3, parentIpIds, licenseTermsIds, address(pilTemplate), "", 0, 100e6);
     }
 
     function test_LicensingModule_registerDerivative_revert_NotAllowDerivativesReciprocal() public {
@@ -1666,7 +1666,7 @@ contract LicensingModuleTest is BaseTest {
         licenseTermsIds[0] = socialRemixTermsId;
 
         vm.prank(ipOwner2);
-        licensingModule.registerDerivative(ipId2, parentIpIds, licenseTermsIds, address(pilTemplate), "", 0);
+        licensingModule.registerDerivative(ipId2, parentIpIds, licenseTermsIds, address(pilTemplate), "", 0, 100e6);
 
         // register derivative of derivative, should revert
         parentIpIds = new address[](1);
@@ -1676,7 +1676,7 @@ contract LicensingModuleTest is BaseTest {
             abi.encodeWithSelector(Errors.LicensingModule__LicenseNotCompatibleForDerivative.selector, ipId3)
         );
         vm.prank(ipOwner3);
-        licensingModule.registerDerivative(ipId3, parentIpIds, licenseTermsIds, address(pilTemplate), "", 0);
+        licensingModule.registerDerivative(ipId3, parentIpIds, licenseTermsIds, address(pilTemplate), "", 0, 100e6);
     }
 
     function test_LicensingModule_setLicensingConfig() public {
@@ -1781,7 +1781,7 @@ contract LicensingModuleTest is BaseTest {
         licenseTermsIds[0] = termsId;
         // register derivative
         vm.prank(ipOwner2);
-        licensingModule.registerDerivative(ipId2, parentIpIds, licenseTermsIds, address(pilTemplate), "", 0);
+        licensingModule.registerDerivative(ipId2, parentIpIds, licenseTermsIds, address(pilTemplate), "", 0, 100e6);
 
         Licensing.LicensingConfig memory licensingConfig = Licensing.LicensingConfig({
             isSet: true,
@@ -1804,7 +1804,7 @@ contract LicensingModuleTest is BaseTest {
         parentIpIds = new address[](1);
         parentIpIds[0] = ipId2;
         vm.prank(ipOwner3);
-        licensingModule.registerDerivative(ipId3, parentIpIds, licenseTermsIds, address(pilTemplate), "", 0);
+        licensingModule.registerDerivative(ipId3, parentIpIds, licenseTermsIds, address(pilTemplate), "", 0, 100e6);
 
         erc20.mint(ipOwner3, 1000);
         vm.startPrank(ipOwner3);
@@ -2282,7 +2282,7 @@ contract LicensingModuleTest is BaseTest {
             licenseTermsIds,
             address(pilTemplate)
         );
-        licensingModule.registerDerivative(ipId2, parentIpIds, licenseTermsIds, address(pilTemplate), "", 0);
+        licensingModule.registerDerivative(ipId2, parentIpIds, licenseTermsIds, address(pilTemplate), "", 0, 100e6);
         vm.stopPrank();
 
         assertEq(erc20.balanceOf(ipOwner2), 900);
@@ -2335,7 +2335,7 @@ contract LicensingModuleTest is BaseTest {
             licenseTermsIds,
             address(pilTemplate)
         );
-        licensingModule.registerDerivative(ipId2, parentIpIds, licenseTermsIds, address(pilTemplate), "", 0);
+        licensingModule.registerDerivative(ipId2, parentIpIds, licenseTermsIds, address(pilTemplate), "", 0, 100e6);
         vm.stopPrank();
 
         assertEq(erc20.balanceOf(ipOwner2), 900);
@@ -2401,7 +2401,7 @@ contract LicensingModuleTest is BaseTest {
         licenseTermsIds[0] = termsId;
         vm.prank(ipOwner2);
         vm.expectRevert("MockLicensingHook: caller is invalid");
-        licensingModule.registerDerivative(ipId2, parentIpIds, licenseTermsIds, address(pilTemplate), "", 0);
+        licensingModule.registerDerivative(ipId2, parentIpIds, licenseTermsIds, address(pilTemplate), "", 0, 100e6);
     }
 
     function onERC721Received(address, address, uint256, bytes memory) public pure returns (bytes4) {

--- a/test/foundry/modules/licensing/PILicenseTemplate.t.sol
+++ b/test/foundry/modules/licensing/PILicenseTemplate.t.sol
@@ -335,7 +335,7 @@ contract PILicenseTemplateTest is BaseTest {
         uint256[] memory licenseTermsIds = new uint256[](1);
         licenseTermsIds[0] = commRemixTermsId;
         vm.prank(ipOwner[2]);
-        licensingModule.registerDerivative(ipAcct[2], parentIpIds, licenseTermsIds, address(pilTemplate), "", 0);
+        licensingModule.registerDerivative(ipAcct[2], parentIpIds, licenseTermsIds, address(pilTemplate), "", 0, 100e6);
 
         uint256 anotherTermsId = pilTemplate.registerLicenseTerms(
             PILFlavors.commercialUse({
@@ -367,7 +367,7 @@ contract PILicenseTemplateTest is BaseTest {
         uint256[] memory licenseTermsIds = new uint256[](1);
         licenseTermsIds[0] = commNoReciprocalTermsId;
         vm.prank(ipOwner[2]);
-        licensingModule.registerDerivative(ipAcct[2], parentIpIds, licenseTermsIds, address(pilTemplate), "", 0);
+        licensingModule.registerDerivative(ipAcct[2], parentIpIds, licenseTermsIds, address(pilTemplate), "", 0, 100e6);
 
         bool result = pilTemplate.verifyMintLicenseToken(commNoReciprocalTermsId, ipOwner[3], ipAcct[2], 1);
         assertFalse(result);
@@ -428,7 +428,7 @@ contract PILicenseTemplateTest is BaseTest {
         uint256[] memory licenseTermsIds = new uint256[](1);
         licenseTermsIds[0] = socialRemixTermsId;
         vm.prank(ipOwner[2]);
-        licensingModule.registerDerivative(ipAcct[2], parentIpIds, licenseTermsIds, address(pilTemplate), "", 0);
+        licensingModule.registerDerivative(ipAcct[2], parentIpIds, licenseTermsIds, address(pilTemplate), "", 0, 100e6);
 
         // checking register derivative of derivative, expect false
         bool result = pilTemplate.verifyRegisterDerivative(ipAcct[3], ipAcct[2], socialRemixTermsId, ipOwner[3]);

--- a/test/foundry/modules/royalty/LAP/RoyaltyPolicyLAP.t.sol
+++ b/test/foundry/modules/royalty/LAP/RoyaltyPolicyLAP.t.sol
@@ -55,7 +55,7 @@ contract TestRoyaltyPolicyLAP is BaseTest {
         parentRoyalties[1] = uint32(10 * 10 ** 6);
         parentRoyalties[2] = uint32(7 * 10 ** 6);
         ipGraph.addParentIp(address(40), parents);
-        royaltyModule.onLinkToParents(address(40), parents, licenseRoyaltyPolicies, parentRoyalties, "");
+        royaltyModule.onLinkToParents(address(40), parents, licenseRoyaltyPolicies, parentRoyalties, "", 100e6);
 
         // mint license for 40
         royaltyModule.onLicenseMinting(address(40), address(royaltyPolicyLRP), uint32(5 * 10 ** 6), "");
@@ -68,7 +68,7 @@ contract TestRoyaltyPolicyLAP is BaseTest {
         licenseRoyaltyPolicies[0] = address(royaltyPolicyLRP);
         parentRoyalties[0] = uint32(5 * 10 ** 6);
         ipGraph.addParentIp(address(50), parents);
-        royaltyModule.onLinkToParents(address(50), parents, licenseRoyaltyPolicies, parentRoyalties, "");
+        royaltyModule.onLinkToParents(address(50), parents, licenseRoyaltyPolicies, parentRoyalties, "", 100e6);
 
         // mint license for 50
         royaltyModule.onLicenseMinting(address(50), address(royaltyPolicyLRP), uint32(15 * 10 ** 6), "");
@@ -81,7 +81,7 @@ contract TestRoyaltyPolicyLAP is BaseTest {
         licenseRoyaltyPolicies[0] = address(royaltyPolicyLRP);
         parentRoyalties[0] = uint32(15 * 10 ** 6);
         ipGraph.addParentIp(address(60), parents);
-        royaltyModule.onLinkToParents(address(60), parents, licenseRoyaltyPolicies, parentRoyalties, "");
+        royaltyModule.onLinkToParents(address(60), parents, licenseRoyaltyPolicies, parentRoyalties, "", 100e6);
 
         // mint license for 60
         royaltyModule.onLicenseMinting(address(60), address(mockExternalRoyaltyPolicy1), uint32(12 * 10 ** 6), "");
@@ -94,7 +94,7 @@ contract TestRoyaltyPolicyLAP is BaseTest {
         licenseRoyaltyPolicies[0] = address(mockExternalRoyaltyPolicy1);
         parentRoyalties[0] = uint32(12 * 10 ** 6);
         ipGraph.addParentIp(address(70), parents);
-        royaltyModule.onLinkToParents(address(70), parents, licenseRoyaltyPolicies, parentRoyalties, "");
+        royaltyModule.onLinkToParents(address(70), parents, licenseRoyaltyPolicies, parentRoyalties, "", 100e6);
 
         // mint license for 10 + 60 + 70
         royaltyModule.onLicenseMinting(address(10), address(royaltyPolicyLAP), uint32(5 * 10 ** 6), "");
@@ -158,7 +158,7 @@ contract TestRoyaltyPolicyLAP is BaseTest {
         ipGraph.addParentIp(address(80), parents);
 
         vm.startPrank(address(licensingModule));
-        royaltyModule.onLinkToParents(address(80), parents, licenseRoyaltyPolicies, parentRoyalties, "");
+        royaltyModule.onLinkToParents(address(80), parents, licenseRoyaltyPolicies, parentRoyalties, "", 100e6);
 
         address ipRoyaltyVault = royaltyModule.ipRoyaltyVaults(address(80));
 
@@ -194,7 +194,7 @@ contract TestRoyaltyPolicyLAP is BaseTest {
         ipGraph.addParentIp(address(80), parents);
 
         vm.startPrank(address(licensingModule));
-        royaltyModule.onLinkToParents(address(80), parents, licenseRoyaltyPolicies, parentRoyalties, "");
+        royaltyModule.onLinkToParents(address(80), parents, licenseRoyaltyPolicies, parentRoyalties, "", 100e6);
 
         // make payment to ip 80
         uint256 royaltyAmount = 100 * 10 ** 6;
@@ -227,7 +227,7 @@ contract TestRoyaltyPolicyLAP is BaseTest {
         ipGraph.addParentIp(address(80), parents);
 
         vm.startPrank(address(licensingModule));
-        royaltyModule.onLinkToParents(address(80), parents, licenseRoyaltyPolicies, parentRoyalties, "");
+        royaltyModule.onLinkToParents(address(80), parents, licenseRoyaltyPolicies, parentRoyalties, "", 100e6);
 
         // make payment to ip 80
         uint256 royaltyAmount = 100 * 10 ** 6;
@@ -260,7 +260,7 @@ contract TestRoyaltyPolicyLAP is BaseTest {
         ipGraph.addParentIp(address(80), parents);
 
         vm.startPrank(address(licensingModule));
-        royaltyModule.onLinkToParents(address(80), parents, licenseRoyaltyPolicies, parentRoyalties, "");
+        royaltyModule.onLinkToParents(address(80), parents, licenseRoyaltyPolicies, parentRoyalties, "", 100e6);
 
         // make payment to ip 80
         uint256 royaltyAmount = 100 * 10 ** 6;

--- a/test/foundry/modules/royalty/LRP/RoyaltyPolicyLRP.t.sol
+++ b/test/foundry/modules/royalty/LRP/RoyaltyPolicyLRP.t.sol
@@ -55,7 +55,7 @@ contract TestRoyaltyPolicyLRP is BaseTest {
         parentRoyalties[1] = uint32(10 * 10 ** 6);
         parentRoyalties[2] = uint32(7 * 10 ** 6);
         ipGraph.addParentIp(address(40), parents);
-        royaltyModule.onLinkToParents(address(40), parents, licenseRoyaltyPolicies, parentRoyalties, "");
+        royaltyModule.onLinkToParents(address(40), parents, licenseRoyaltyPolicies, parentRoyalties, "", 100e6);
 
         // mint license for 40
         royaltyModule.onLicenseMinting(address(40), address(royaltyPolicyLRP), uint32(5 * 10 ** 6), "");
@@ -68,7 +68,7 @@ contract TestRoyaltyPolicyLRP is BaseTest {
         licenseRoyaltyPolicies[0] = address(royaltyPolicyLRP);
         parentRoyalties[0] = uint32(5 * 10 ** 6);
         ipGraph.addParentIp(address(50), parents);
-        royaltyModule.onLinkToParents(address(50), parents, licenseRoyaltyPolicies, parentRoyalties, "");
+        royaltyModule.onLinkToParents(address(50), parents, licenseRoyaltyPolicies, parentRoyalties, "", 100e6);
 
         // mint license for 50
         royaltyModule.onLicenseMinting(address(50), address(royaltyPolicyLRP), uint32(15 * 10 ** 6), "");
@@ -81,7 +81,7 @@ contract TestRoyaltyPolicyLRP is BaseTest {
         licenseRoyaltyPolicies[0] = address(royaltyPolicyLRP);
         parentRoyalties[0] = uint32(15 * 10 ** 6);
         ipGraph.addParentIp(address(60), parents);
-        royaltyModule.onLinkToParents(address(60), parents, licenseRoyaltyPolicies, parentRoyalties, "");
+        royaltyModule.onLinkToParents(address(60), parents, licenseRoyaltyPolicies, parentRoyalties, "", 100e6);
 
         // mint license for 60
         royaltyModule.onLicenseMinting(address(60), address(mockExternalRoyaltyPolicy1), uint32(12 * 10 ** 6), "");
@@ -94,7 +94,7 @@ contract TestRoyaltyPolicyLRP is BaseTest {
         licenseRoyaltyPolicies[0] = address(mockExternalRoyaltyPolicy1);
         parentRoyalties[0] = uint32(12 * 10 ** 6);
         ipGraph.addParentIp(address(70), parents);
-        royaltyModule.onLinkToParents(address(70), parents, licenseRoyaltyPolicies, parentRoyalties, "");
+        royaltyModule.onLinkToParents(address(70), parents, licenseRoyaltyPolicies, parentRoyalties, "", 100e6);
     }
 
     function test_RoyaltyPolicyLRP_constructor_revert_ZeroRoyaltyModule() public {
@@ -153,7 +153,7 @@ contract TestRoyaltyPolicyLRP is BaseTest {
         ipGraph.addParentIp(address(80), parents);
 
         vm.startPrank(address(licensingModule));
-        royaltyModule.onLinkToParents(address(80), parents, licenseRoyaltyPolicies, parentRoyalties, "");
+        royaltyModule.onLinkToParents(address(80), parents, licenseRoyaltyPolicies, parentRoyalties, "", 100e6);
 
         address ipRoyaltyVault = royaltyModule.ipRoyaltyVaults(address(80));
 
@@ -193,7 +193,7 @@ contract TestRoyaltyPolicyLRP is BaseTest {
         ipGraph.addParentIp(address(80), parents);
 
         vm.startPrank(address(licensingModule));
-        royaltyModule.onLinkToParents(address(80), parents, licenseRoyaltyPolicies, parentRoyalties, "");
+        royaltyModule.onLinkToParents(address(80), parents, licenseRoyaltyPolicies, parentRoyalties, "", 100e6);
 
         // make payment to ip 80
         uint256 royaltyAmount = 100 * 10 ** 6;
@@ -226,7 +226,7 @@ contract TestRoyaltyPolicyLRP is BaseTest {
         ipGraph.addParentIp(address(80), parents);
 
         vm.startPrank(address(licensingModule));
-        royaltyModule.onLinkToParents(address(80), parents, licenseRoyaltyPolicies, parentRoyalties, "");
+        royaltyModule.onLinkToParents(address(80), parents, licenseRoyaltyPolicies, parentRoyalties, "", 100e6);
 
         // make payment to ip 80
         uint256 royaltyAmount = 100 * 10 ** 6;
@@ -260,7 +260,7 @@ contract TestRoyaltyPolicyLRP is BaseTest {
         ipGraph.addParentIp(address(80), parents);
 
         vm.startPrank(address(licensingModule));
-        royaltyModule.onLinkToParents(address(80), parents, licenseRoyaltyPolicies, parentRoyalties, "");
+        royaltyModule.onLinkToParents(address(80), parents, licenseRoyaltyPolicies, parentRoyalties, "", 100e6);
 
         // make payment to ip 80
         uint256 royaltyAmount = 100 * 10 ** 6;

--- a/test/foundry/modules/royalty/RoyaltyModule.t.sol
+++ b/test/foundry/modules/royalty/RoyaltyModule.t.sol
@@ -665,7 +665,7 @@ contract TestRoyaltyModule is BaseTest {
         royaltyModule.onLinkToParents(address(80), parents, licenseRoyaltyPolicies, parentRoyalties, "", 100e6);
     }
 
-    function test_RoyaltyModule_onLinkToParents_revert_AboveAcumulatedRoyaltyPoliciesLimit() public {
+    function test_RoyaltyModule_onLinkToParents_revert_AboveAccumulatedRoyaltyPoliciesLimit() public {
         vm.startPrank(u.admin);
         royaltyModule.setIpGraphLimits(8, 1024, 3);
         vm.stopPrank();

--- a/test/foundry/modules/royalty/RoyaltyModule.t.sol
+++ b/test/foundry/modules/royalty/RoyaltyModule.t.sol
@@ -629,41 +629,6 @@ contract TestRoyaltyModule is BaseTest {
         royaltyModule.onLinkToParents(address(80), parents, licenseRoyaltyPolicies, parentRoyalties, "");
     }
 
-    function test_RoyaltyModule_onLinkToParents_revert_AboveMaxPercent() public {
-        address[] memory parents = new address[](3);
-        address[] memory licenseRoyaltyPolicies = new address[](3);
-        uint32[] memory parentRoyalties = new uint32[](3);
-
-        // link 80 to 10 + 60 + 70
-        parents = new address[](3);
-        licenseRoyaltyPolicies = new address[](3);
-        parentRoyalties = new uint32[](3);
-        parents[0] = address(10);
-        parents[1] = address(60);
-        parents[2] = address(70);
-        licenseRoyaltyPolicies[0] = address(royaltyPolicyLAP);
-        licenseRoyaltyPolicies[1] = address(royaltyPolicyLRP);
-        licenseRoyaltyPolicies[2] = address(mockExternalRoyaltyPolicy1);
-        parentRoyalties[0] = uint32(500 * 10 ** 6);
-        parentRoyalties[1] = uint32(17 * 10 ** 6);
-        parentRoyalties[2] = uint32(24 * 10 ** 6);
-
-        vm.startPrank(address(licensingModule));
-        ipGraph.addParentIp(address(80), parents);
-
-        // tests royalty stack above 100%
-        vm.expectRevert(Errors.RoyaltyModule__AboveMaxPercent.selector);
-        royaltyModule.onLinkToParents(address(80), parents, licenseRoyaltyPolicies, parentRoyalties, "");
-
-        parentRoyalties[0] = uint32(50 * 10 ** 6);
-        parentRoyalties[1] = uint32(17 * 10 ** 6);
-        parentRoyalties[2] = uint32(240 * 10 ** 6);
-
-        // tests royalty token supply above 100%
-        vm.expectRevert(Errors.RoyaltyModule__AboveMaxPercent.selector);
-        royaltyModule.onLinkToParents(address(80), parents, licenseRoyaltyPolicies, parentRoyalties, "");
-    }
-
     function test_RoyaltyModule_onLinkToParents_revert_RoyaltyModule_NotWhitelistedOrRegisteredRoyaltyPolicy() public {
         address[] memory parents = new address[](3);
         address[] memory licenseRoyaltyPolicies = new address[](3);
@@ -773,22 +738,22 @@ contract TestRoyaltyModule is BaseTest {
         address[] memory accRoyaltyPolicies80After = royaltyModule.accumulatedRoyaltyPolicies(address(80));
         assertEq(accRoyaltyPolicies80After[0], address(royaltyPolicyLAP));
         assertEq(accRoyaltyPolicies80After[1], address(royaltyPolicyLRP));
-        assertEq(accRoyaltyPolicies80After[2], address(mockExternalRoyaltyPolicy1));
-        assertEq(accRoyaltyPolicies80After[3], address(mockExternalRoyaltyPolicy2));
+        assertEq(accRoyaltyPolicies80After[2], address(mockExternalRoyaltyPolicy2));
+        assertEq(accRoyaltyPolicies80After[3], address(mockExternalRoyaltyPolicy1));
 
         address[] memory accRoyaltyPolicies10After = royaltyModule.accumulatedRoyaltyPolicies(address(10));
-        assertEq(accRoyaltyPolicies10After[0], address(royaltyPolicyLAP));
+        assertEq(accRoyaltyPolicies10After.length, 0);
 
         address[] memory accRoyaltyPolicies60After = royaltyModule.accumulatedRoyaltyPolicies(address(60));
         assertEq(accRoyaltyPolicies60After[0], address(royaltyPolicyLAP));
         assertEq(accRoyaltyPolicies60After[1], address(royaltyPolicyLRP));
-        assertEq(accRoyaltyPolicies60After[2], address(mockExternalRoyaltyPolicy1));
+        assertEq(accRoyaltyPolicies60After.length, 2);
 
         address[] memory accRoyaltyPolicies70After = royaltyModule.accumulatedRoyaltyPolicies(address(70));
-        assertEq(accRoyaltyPolicies70After[0], address(royaltyPolicyLAP));
-        assertEq(accRoyaltyPolicies70After[1], address(royaltyPolicyLRP));
-        assertEq(accRoyaltyPolicies70After[2], address(mockExternalRoyaltyPolicy1));
-        assertEq(accRoyaltyPolicies70After[3], address(mockExternalRoyaltyPolicy2));
+        assertEq(accRoyaltyPolicies70After[0], address(mockExternalRoyaltyPolicy1));
+        assertEq(accRoyaltyPolicies70After[1], address(royaltyPolicyLAP));
+        assertEq(accRoyaltyPolicies70After[2], address(royaltyPolicyLRP));
+        assertEq(accRoyaltyPolicies70After.length, 3);
     }
 
     function test_RoyaltyModule_onLinkToParents_group() public {

--- a/test/foundry/modules/royalty/RoyaltyModule.t.sol
+++ b/test/foundry/modules/royalty/RoyaltyModule.t.sol
@@ -140,7 +140,7 @@ contract TestRoyaltyModule is BaseTest {
         parentRoyalties[1] = uint32(10 * 10 ** 6);
         parentRoyalties[2] = uint32(7 * 10 ** 6);
         ipGraph.addParentIp(address(40), parents);
-        royaltyModule.onLinkToParents(address(40), parents, licenseRoyaltyPolicies, parentRoyalties, "");
+        royaltyModule.onLinkToParents(address(40), parents, licenseRoyaltyPolicies, parentRoyalties, "", 100e6);
 
         // mint license for 40
         royaltyModule.onLicenseMinting(address(40), address(royaltyPolicyLRP), uint32(5 * 10 ** 6), "");
@@ -153,7 +153,7 @@ contract TestRoyaltyModule is BaseTest {
         licenseRoyaltyPolicies[0] = address(royaltyPolicyLRP);
         parentRoyalties[0] = uint32(5 * 10 ** 6);
         ipGraph.addParentIp(address(50), parents);
-        royaltyModule.onLinkToParents(address(50), parents, licenseRoyaltyPolicies, parentRoyalties, "");
+        royaltyModule.onLinkToParents(address(50), parents, licenseRoyaltyPolicies, parentRoyalties, "", 100e6);
 
         // mint license for 50
         royaltyModule.onLicenseMinting(address(50), address(royaltyPolicyLRP), uint32(15 * 10 ** 6), "");
@@ -166,7 +166,7 @@ contract TestRoyaltyModule is BaseTest {
         licenseRoyaltyPolicies[0] = address(royaltyPolicyLRP);
         parentRoyalties[0] = uint32(15 * 10 ** 6);
         ipGraph.addParentIp(address(60), parents);
-        royaltyModule.onLinkToParents(address(60), parents, licenseRoyaltyPolicies, parentRoyalties, "");
+        royaltyModule.onLinkToParents(address(60), parents, licenseRoyaltyPolicies, parentRoyalties, "", 100e6);
 
         // mint license for 60
         royaltyModule.onLicenseMinting(address(60), address(mockExternalRoyaltyPolicy1), uint32(12 * 10 ** 6), "");
@@ -179,7 +179,7 @@ contract TestRoyaltyModule is BaseTest {
         licenseRoyaltyPolicies[0] = address(mockExternalRoyaltyPolicy1);
         parentRoyalties[0] = uint32(12 * 10 ** 6);
         ipGraph.addParentIp(address(70), parents);
-        royaltyModule.onLinkToParents(address(70), parents, licenseRoyaltyPolicies, parentRoyalties, "");
+        royaltyModule.onLinkToParents(address(70), parents, licenseRoyaltyPolicies, parentRoyalties, "", 100e6);
 
         // mint license for 10 + 60 + 70
         royaltyModule.onLicenseMinting(address(10), address(royaltyPolicyLAP), uint32(5 * 10 ** 6), "");
@@ -500,7 +500,7 @@ contract TestRoyaltyModule is BaseTest {
 
     function test_RoyaltyModule_onLinkToParents_revert_NotAllowedCaller() public {
         vm.expectRevert(Errors.RoyaltyModule__NotAllowedCaller.selector);
-        royaltyModule.onLinkToParents(address(1), new address[](0), new address[](0), new uint32[](0), "");
+        royaltyModule.onLinkToParents(address(1), new address[](0), new address[](0), new uint32[](0), "", 100e6);
     }
 
     function test_RoyaltyModule_onLinkToParents_revert_ZeroRoyaltyPolicy() public {
@@ -524,7 +524,7 @@ contract TestRoyaltyModule is BaseTest {
 
         vm.startPrank(address(licensingModule));
         vm.expectRevert(Errors.RoyaltyModule__ZeroRoyaltyPolicy.selector);
-        royaltyModule.onLinkToParents(address(80), parents, licenseRoyaltyPolicies, parentRoyalties, "");
+        royaltyModule.onLinkToParents(address(80), parents, licenseRoyaltyPolicies, parentRoyalties, "", 100e6);
     }
 
     function test_RoyaltyModule_onLinkToParents_revert_UnlinkableToParents() public {
@@ -549,7 +549,7 @@ contract TestRoyaltyModule is BaseTest {
         vm.startPrank(address(licensingModule));
         royaltyModule.onLicenseMinting(address(80), address(royaltyPolicyLAP), uint32(10 * 10 ** 6), "");
         vm.expectRevert(Errors.RoyaltyModule__UnlinkableToParents.selector);
-        royaltyModule.onLinkToParents(address(80), parents, licenseRoyaltyPolicies, parentRoyalties, "");
+        royaltyModule.onLinkToParents(address(80), parents, licenseRoyaltyPolicies, parentRoyalties, "", 100e6);
     }
 
     function test_RoyaltyModule_onLinkToParents_revert_NoParentsOnLinking() public {
@@ -573,7 +573,14 @@ contract TestRoyaltyModule is BaseTest {
 
         vm.startPrank(address(licensingModule));
         vm.expectRevert(Errors.RoyaltyModule__NoParentsOnLinking.selector);
-        royaltyModule.onLinkToParents(address(80), new address[](0), licenseRoyaltyPolicies, parentRoyalties, "");
+        royaltyModule.onLinkToParents(
+            address(80),
+            new address[](0),
+            licenseRoyaltyPolicies,
+            parentRoyalties,
+            "",
+            100e6
+        );
     }
 
     function test_RoyaltyModule_onLinkToParents_revert_RoyaltyModule_AboveParentLimit() public {
@@ -597,7 +604,7 @@ contract TestRoyaltyModule is BaseTest {
 
         vm.startPrank(address(licensingModule));
         vm.expectRevert(Errors.RoyaltyModule__AboveParentLimit.selector);
-        royaltyModule.onLinkToParents(address(80), parents, licenseRoyaltyPolicies, parentRoyalties, "");
+        royaltyModule.onLinkToParents(address(80), parents, licenseRoyaltyPolicies, parentRoyalties, "", 100e6);
     }
 
     function test_RoyaltyModule_onLinkToParents_revert_AboveAncestorsLimit() public {
@@ -626,7 +633,7 @@ contract TestRoyaltyModule is BaseTest {
         vm.startPrank(address(licensingModule));
         ipGraph.addParentIp(address(80), parents);
         vm.expectRevert(Errors.RoyaltyModule__AboveAncestorsLimit.selector);
-        royaltyModule.onLinkToParents(address(80), parents, licenseRoyaltyPolicies, parentRoyalties, "");
+        royaltyModule.onLinkToParents(address(80), parents, licenseRoyaltyPolicies, parentRoyalties, "", 100e6);
     }
 
     function test_RoyaltyModule_onLinkToParents_revert_RoyaltyModule_NotWhitelistedOrRegisteredRoyaltyPolicy() public {
@@ -654,7 +661,7 @@ contract TestRoyaltyModule is BaseTest {
         ipGraph.addParentIp(address(80), parents);
 
         vm.expectRevert(Errors.RoyaltyModule__NotWhitelistedOrRegisteredRoyaltyPolicy.selector);
-        royaltyModule.onLinkToParents(address(80), parents, licenseRoyaltyPolicies, parentRoyalties, "");
+        royaltyModule.onLinkToParents(address(80), parents, licenseRoyaltyPolicies, parentRoyalties, "", 100e6);
     }
 
     function test_RoyaltyModule_onLinkToParents_revert_AboveAccumulatedRoyaltyPoliciesLimit() public {
@@ -684,7 +691,7 @@ contract TestRoyaltyModule is BaseTest {
         ipGraph.addParentIp(address(80), parents);
 
         vm.expectRevert(Errors.RoyaltyModule__AboveAccumulatedRoyaltyPoliciesLimit.selector);
-        royaltyModule.onLinkToParents(address(80), parents, licenseRoyaltyPolicies, parentRoyalties, "");
+        royaltyModule.onLinkToParents(address(80), parents, licenseRoyaltyPolicies, parentRoyalties, "", 100e6);
     }
 
     function test_RoyaltyModule_onLinkToParents() public {
@@ -714,7 +721,7 @@ contract TestRoyaltyModule is BaseTest {
         vm.expectEmit(true, true, true, true, address(royaltyModule));
         emit LinkedToParents(address(80), parents, licenseRoyaltyPolicies, parentRoyalties, "");
 
-        royaltyModule.onLinkToParents(address(80), parents, licenseRoyaltyPolicies, parentRoyalties, "");
+        royaltyModule.onLinkToParents(address(80), parents, licenseRoyaltyPolicies, parentRoyalties, "", 100e6);
 
         address ipRoyaltyVault80 = royaltyModule.ipRoyaltyVaults(address(80));
         uint256 ipId80RtLAPBalAfter = IERC20(ipRoyaltyVault80).balanceOf(address(royaltyPolicyLAP));
@@ -781,7 +788,7 @@ contract TestRoyaltyModule is BaseTest {
 
         assertEq(royaltyModule.ipRoyaltyVaults(groupId), address(0));
 
-        royaltyModule.onLinkToParents(groupId, parents, licenseRoyaltyPolicies, parentRoyalties, "");
+        royaltyModule.onLinkToParents(groupId, parents, licenseRoyaltyPolicies, parentRoyalties, "", 100e6);
 
         address ipRoyaltyVault80 = royaltyModule.ipRoyaltyVaults(groupId);
         uint256 ipId80RtLAPBalAfter = IERC20(ipRoyaltyVault80).balanceOf(address(royaltyPolicyLAP));

--- a/test/foundry/modules/royalty/RoyaltyModule.t.sol
+++ b/test/foundry/modules/royalty/RoyaltyModule.t.sol
@@ -694,6 +694,33 @@ contract TestRoyaltyModule is BaseTest {
         royaltyModule.onLinkToParents(address(80), parents, licenseRoyaltyPolicies, parentRoyalties, "", 100e6);
     }
 
+    function test_RoyaltyModule_onLinkToParents_revert_AboveMaxRts() public {address[] memory parents = new address[](3);
+        address[] memory licenseRoyaltyPolicies = new address[](3);
+        uint32[] memory parentRoyalties = new uint32[](3);
+
+        // link 80 to 10 + 60 + 70
+        parents = new address[](3);
+        licenseRoyaltyPolicies = new address[](3);
+        parentRoyalties = new uint32[](3);
+        parents[0] = address(10);
+        parents[1] = address(60);
+        parents[2] = address(70);
+        licenseRoyaltyPolicies[0] = address(royaltyPolicyLAP);
+        licenseRoyaltyPolicies[1] = address(royaltyPolicyLRP);
+        licenseRoyaltyPolicies[2] = address(mockExternalRoyaltyPolicy2);
+        parentRoyalties[0] = uint32(5 * 10 ** 6);
+        parentRoyalties[1] = uint32(17 * 10 ** 6);
+        parentRoyalties[2] = uint32(24 * 10 ** 6);
+
+        vm.startPrank(address(licensingModule));
+        ipGraph.addParentIp(address(80), parents);
+
+        assertEq(royaltyModule.ipRoyaltyVaults(address(80)), address(0));
+
+        vm.expectRevert(Errors.RoyaltyModule__AboveMaxRts.selector);
+        royaltyModule.onLinkToParents(address(80), parents, licenseRoyaltyPolicies, parentRoyalties, "", 1e5);
+    }
+
     function test_RoyaltyModule_onLinkToParents() public {
         address[] memory parents = new address[](3);
         address[] memory licenseRoyaltyPolicies = new address[](3);

--- a/test/foundry/modules/royalty/RoyaltyModule.t.sol
+++ b/test/foundry/modules/royalty/RoyaltyModule.t.sol
@@ -694,7 +694,8 @@ contract TestRoyaltyModule is BaseTest {
         royaltyModule.onLinkToParents(address(80), parents, licenseRoyaltyPolicies, parentRoyalties, "", 100e6);
     }
 
-    function test_RoyaltyModule_onLinkToParents_revert_AboveMaxRts() public {address[] memory parents = new address[](3);
+    function test_RoyaltyModule_onLinkToParents_revert_AboveMaxRts() public {
+        address[] memory parents = new address[](3);
         address[] memory licenseRoyaltyPolicies = new address[](3);
         uint32[] memory parentRoyalties = new uint32[](3);
 

--- a/test/foundry/registries/LicenseRegistry.t.sol
+++ b/test/foundry/registries/LicenseRegistry.t.sol
@@ -175,7 +175,7 @@ contract LicenseRegistryTest is BaseTest {
         uint256[] memory licenseTermsIds = new uint256[](1);
         licenseTermsIds[0] = socialRemixTermsId;
         vm.prank(ipOwner[2]);
-        licensingModule.registerDerivative(ipAcct[2], parentIpIds, licenseTermsIds, address(pilTemplate), "", 0);
+        licensingModule.registerDerivative(ipAcct[2], parentIpIds, licenseTermsIds, address(pilTemplate), "", 0, 100e6);
 
         uint256 defaultTermsId = pilTemplate.registerLicenseTerms(PILFlavors.defaultValuesLicenseTerms());
         vm.expectRevert(Errors.LicensingModule__DerivativesCannotAddLicenseTerms.selector);
@@ -212,7 +212,7 @@ contract LicenseRegistryTest is BaseTest {
         uint256[] memory licenseTermsIds = new uint256[](1);
         licenseTermsIds[0] = socialRemixTermsId;
         vm.prank(ipOwner[2]);
-        licensingModule.registerDerivative(ipAcct[2], parentIpIds, licenseTermsIds, address(pilTemplate), "", 0);
+        licensingModule.registerDerivative(ipAcct[2], parentIpIds, licenseTermsIds, address(pilTemplate), "", 0, 100e6);
 
         vm.expectRevert(abi.encodeWithSelector(Errors.LicenseRegistry__IndexOutOfBounds.selector, ipAcct[1], 1, 1));
         licenseRegistry.getDerivativeIp(ipAcct[1], 1);
@@ -228,7 +228,7 @@ contract LicenseRegistryTest is BaseTest {
         uint256[] memory licenseTermsIds = new uint256[](1);
         licenseTermsIds[0] = socialRemixTermsId;
         vm.prank(ipOwner[2]);
-        licensingModule.registerDerivative(ipAcct[2], parentIpIds, licenseTermsIds, address(pilTemplate), "", 0);
+        licensingModule.registerDerivative(ipAcct[2], parentIpIds, licenseTermsIds, address(pilTemplate), "", 0, 100e6);
 
         vm.expectRevert(abi.encodeWithSelector(Errors.LicenseRegistry__IndexOutOfBounds.selector, ipAcct[2], 1, 1));
         licenseRegistry.getParentIp(ipAcct[2], 1);


### PR DESCRIPTION
## Description
Adds a new variable `maxRts` defined by the user when registering a derivative to ensure that the royalty tokens distributed to royalty policies does not go over the specified limit.