### PR TITLE
Enforce Licensing Config to Only Increase Royalty Percentage

### DIFF
--- a/contracts/modules/licensing/PILicenseTemplate.sol
+++ b/contracts/modules/licensing/PILicenseTemplate.sol
@@ -302,7 +302,7 @@ contract PILicenseTemplate is
     function canOverrideRoyaltyPercent(uint256 licenseTermsId, uint32 newRoyaltyPercent) external view returns (bool) {
         if (licenseTermsId == 0 || newRoyaltyPercent == 0) return false;
         PILTerms memory terms = _getPILicenseTemplateStorage().licenseTerms[licenseTermsId];
-        return terms.commercialUse;
+        return terms.commercialUse && newRoyaltyPercent >= terms.commercialRevShare;
     }
 
     /// @notice checks the contract whether supports the given interface.

--- a/test/foundry/modules/licensing/LicensingModule.t.sol
+++ b/test/foundry/modules/licensing/LicensingModule.t.sol
@@ -1937,14 +1937,14 @@ contract LicensingModuleTest is BaseTest {
     }
 
     function test_LicensingModule_setLicensingConfig_revert_newRoyaltyPercentLessThanLicenseTerms() public {
-        uint256 commRemixTermsId = pilTemplate.registerLicenseTerms(PILFlavors.commercialRemix(
-            {
+        uint256 commRemixTermsId = pilTemplate.registerLicenseTerms(
+            PILFlavors.commercialRemix({
                 mintingFee: 0,
                 commercialRevShare: 20_000_000,
                 royaltyPolicy: address(royaltyPolicyLRP),
                 currencyToken: address(erc20)
-            }
-        ));
+            })
+        );
         MockLicensingHook licensingHook = new MockLicensingHook();
         vm.prank(admin);
         moduleRegistry.registerModule("MockLicensingHook", address(licensingHook));

--- a/test/foundry/modules/licensing/LicensingModule.t.sol
+++ b/test/foundry/modules/licensing/LicensingModule.t.sol
@@ -1936,6 +1936,39 @@ contract LicensingModuleTest is BaseTest {
         licensingModule.setLicensingConfig(ipId1, address(pilTemplate), socialRemixTermsId, licensingConfig);
     }
 
+    function test_LicensingModule_setLicensingConfig_revert_newRoyaltyPercentLessThanLicenseTerms() public {
+        uint256 commRemixTermsId = pilTemplate.registerLicenseTerms(PILFlavors.commercialRemix(
+            {
+                mintingFee: 0,
+                commercialRevShare: 20_000_000,
+                royaltyPolicy: address(royaltyPolicyLRP),
+                currencyToken: address(erc20)
+            }
+        ));
+        MockLicensingHook licensingHook = new MockLicensingHook();
+        vm.prank(admin);
+        moduleRegistry.registerModule("MockLicensingHook", address(licensingHook));
+        Licensing.LicensingConfig memory licensingConfig = Licensing.LicensingConfig({
+            isSet: true,
+            mintingFee: 100,
+            licensingHook: address(licensingHook),
+            hookData: abi.encode(address(0x123)),
+            commercialRevShare: 10_000_000,
+            disabled: false
+        });
+
+        vm.expectRevert(
+            abi.encodeWithSelector(
+                Errors.LicensingModule__CurrentLicenseNotAllowOverrideRoyaltyPercent.selector,
+                address(pilTemplate),
+                commRemixTermsId,
+                10_000_000
+            )
+        );
+        vm.prank(ipOwner1);
+        licensingModule.setLicensingConfig(ipId1, address(pilTemplate), commRemixTermsId, licensingConfig);
+    }
+
     function test_LicensingModule_setLicensingConfig_revert_invalidLicensingHook() public {
         uint256 socialRemixTermsId = pilTemplate.registerLicenseTerms(PILFlavors.nonCommercialSocialRemixing());
         // unregistered the licensing hook


### PR DESCRIPTION
## Description

This PR adds a check to ensure that the `licensingConfig` can only increase the royalty percentage compared to the royalty percentage defined in the license terms. This prevents child IPs from overriding parent IPs' royalty percentages with unreasonably low percentages, maintaining fair royalty distribution.

## Key Changes

- **Royalty Percentage Check**: Added logic to verify that the new royalty percentage in `licensingConfig` is not lower than the royalty percentage defined in the license terms.

