### PR TITLE
Enforce Group IPA to Attach Non-Default License Terms for Adding IPs

### DIFF
--- a/contracts/lib/Errors.sol
+++ b/contracts/lib/Errors.sol
@@ -139,6 +139,9 @@ library Errors {
     /// @notice Cannot add IP which has expiration to group.
     error GroupingModule__CannotAddIpWithExpirationToGroup(address ipId);
 
+    /// @notice Group IP should attach non default license terms.
+    error GroupingModule__GroupIPShouldHasNonDefaultLicenseTerms(address groupId);
+
     ////////////////////////////////////////////////////////////////////////////
     //                            IP Asset Registry                           //
     ////////////////////////////////////////////////////////////////////////////

--- a/contracts/modules/grouping/GroupingModule.sol
+++ b/contracts/modules/grouping/GroupingModule.sol
@@ -146,6 +146,13 @@ contract GroupingModule is
             groupIpId,
             0
         );
+        // Group must attache a non-default license terms to add IP
+        (address defaultLicenseTemplate, uint256 defaultLicenseTermsId) = LICENSE_REGISTRY.getDefaultLicenseTerms();
+
+        if (groupLicenseTemplate == defaultLicenseTemplate && groupLicenseTermsId == defaultLicenseTermsId) {
+            revert Errors.GroupingModule__GroupIPShouldHasNonDefaultLicenseTerms(groupIpId);
+        }
+
         PILTerms memory groupLicenseTerms = IPILicenseTemplate(groupLicenseTemplate).getLicenseTerms(
             groupLicenseTermsId
         );


### PR DESCRIPTION
## Description

This PR introduces a check to ensure that Group IPAs must attach non-default license terms before adding IPs into the group. This enhancement ensures that all IPs within a group adhere to specific licensing terms.

## Key Changes

- **Non-Default License Terms Check**: Added logic to verify that Group IPAs have non-default license terms attached before allowing IPs to be added to the group.

