### PR TITLE
Introduce License Configurations for Group Restrictions

### DIFF
--- a/contracts/interfaces/modules/grouping/IGroupRewardPool.sol
+++ b/contracts/interfaces/modules/grouping/IGroupRewardPool.sol
@@ -23,7 +23,13 @@ interface IGroupRewardPool {
     /// @notice Adds an IP to the group pool
     /// @param groupId The group ID
     /// @param ipId The IP ID
-    function addIp(address groupId, address ipId) external;
+    /// @param minimumGroupRewardShare The minimum group reward share the IP expects to be added to the group
+    /// @return totalGroupRewardShare The total group reward share after adding the IP
+    function addIp(
+        address groupId,
+        address ipId,
+        uint256 minimumGroupRewardShare
+    ) external returns (uint256 totalGroupRewardShare);
 
     /// @notice Removes an IP from the group pool
     /// @param groupId The group ID

--- a/contracts/interfaces/registries/ILicenseRegistry.sol
+++ b/contracts/interfaces/registries/ILicenseRegistry.sol
@@ -83,6 +83,23 @@ interface ILicenseRegistry {
         bool isMintedByIpOwner
     ) external view returns (Licensing.LicensingConfig memory);
 
+    /// @notice Verifies the group can add given IP.
+    /// @param groupId The address of the group.
+    /// @param groupRewardPool The address of the reward pool of the group.
+    /// @param ipId The address of the IP to be added to the group.
+    /// @param groupLicenseTemplate the address of the license template attached to the group.
+    /// the IP must have this license template.
+    /// @param groupLicenseTermsId The ID of the license terms attached to the group.
+    /// the IP must have this license terms.
+    /// @return ipLicensingConfig The configuration for license attached to the IP.
+    function verifyGroupAddIp(
+        address groupId,
+        address groupRewardPool,
+        address ipId,
+        address groupLicenseTemplate,
+        uint256 groupLicenseTermsId
+    ) external view returns (Licensing.LicensingConfig memory ipLicensingConfig);
+
     /// @notice Attaches license terms to an IP.
     /// @param ipId The address of the IP to which the license terms are attached.
     /// @param licenseTemplate The address of the license template.

--- a/contracts/lib/Errors.sol
+++ b/contracts/lib/Errors.sol
@@ -142,6 +142,31 @@ library Errors {
     /// @notice Group IP should attach non default license terms.
     error GroupingModule__GroupIPShouldHasNonDefaultLicenseTerms(address groupId);
 
+    /// @notice The license of IP to be added to a group is disabled
+    error GroupingModule__IpLicenseDisabled(address ipId, address licenseTemplate, uint256 licenseTermsId);
+
+    /// @notice The IP does not set expected group reward pool to be added,
+    /// means the IP is not allowed to be added to any group.
+    error GroupingModule__IpExpectGroupRewardPoolNotSet(address ipId);
+
+    /// @notice The expected group reward pool of IP does not match the group reward pool of the group.
+    /// Means the IP is not allowed to be added to the group.
+    error GroupingModule__IpExpectGroupRewardPoolNotMatch(
+        address ipId,
+        address expectGroupRewardPool,
+        address groupId,
+        address groupRewardPool
+    );
+
+    /// @notice The total group reward share exceeds 100% when adding IP to the group.
+    /// means the IP is not allowed to be added to the group.
+    error GroupingModule__TotalGroupRewardShareExceeds100Percent(
+        address groupId,
+        uint256 totalGroupRewardShare,
+        address ipId,
+        uint256 expectGroupRewardShare
+    );
+
     ////////////////////////////////////////////////////////////////////////////
     //                            IP Asset Registry                           //
     ////////////////////////////////////////////////////////////////////////////

--- a/contracts/lib/Errors.sol
+++ b/contracts/lib/Errors.sol
@@ -112,9 +112,6 @@ library Errors {
     /// @notice The group ip has no attached any license terms.
     error GroupingModule__GroupIPHasNoLicenseTerms(address groupId);
 
-    /// @notice The IP has no attached the same license terms of Group IPA.
-    error GroupingModule__IpHasNoGroupLicenseTerms(address groupId, address licenseTemplate, uint256 licenseTermsId);
-
     /// @notice The Royalty Vault has not been created.
     error GroupingModule__GroupRoyaltyVaultNotCreated(address groupId);
 
@@ -136,27 +133,8 @@ library Errors {
     /// @notice The Group IP has been frozen due to already mint license tokens.
     error GroupingModule__GroupFrozenDueToAlreadyMintLicenseTokens(address groupId);
 
-    /// @notice Cannot add IP which has expiration to group.
-    error GroupingModule__CannotAddIpWithExpirationToGroup(address ipId);
-
     /// @notice Group IP should attach non default license terms.
     error GroupingModule__GroupIPShouldHasNonDefaultLicenseTerms(address groupId);
-
-    /// @notice The license of IP to be added to a group is disabled
-    error GroupingModule__IpLicenseDisabled(address ipId, address licenseTemplate, uint256 licenseTermsId);
-
-    /// @notice The IP does not set expected group reward pool to be added,
-    /// means the IP is not allowed to be added to any group.
-    error GroupingModule__IpExpectGroupRewardPoolNotSet(address ipId);
-
-    /// @notice The expected group reward pool of IP does not match the group reward pool of the group.
-    /// Means the IP is not allowed to be added to the group.
-    error GroupingModule__IpExpectGroupRewardPoolNotMatch(
-        address ipId,
-        address expectGroupRewardPool,
-        address groupId,
-        address groupRewardPool
-    );
 
     /// @notice The total group reward share exceeds 100% when adding IP to the group.
     /// means the IP is not allowed to be added to the group.
@@ -282,6 +260,28 @@ library Errors {
 
     /// @notice Zero address provided for IP Graph ACL.
     error LicenseRegistry__ZeroIPGraphACL();
+
+    /// @notice The license of IP to be added to a group is disabled
+    error LicenseRegistry__IpLicenseDisabled(address ipId, address licenseTemplate, uint256 licenseTermsId);
+
+    /// @notice The IP does not set expected group reward pool to be added,
+    /// means the IP is not allowed to be added to any group.
+    error LicenseRegistry__IpExpectGroupRewardPoolNotSet(address ipId);
+
+    /// @notice The expected group reward pool of IP does not match the group reward pool of the group.
+    /// Means the IP is not allowed to be added to the group.
+    error LicenseRegistry__IpExpectGroupRewardPoolNotMatch(
+        address ipId,
+        address expectGroupRewardPool,
+        address groupId,
+        address groupRewardPool
+    );
+
+    /// @notice Cannot add IP which has expiration to group.
+    error LicenseRegistry__CannotAddIpWithExpirationToGroup(address ipId);
+
+    /// @notice The IP has no attached the same license terms of Group IPA.
+    error LicenseRegistry__IpHasNoGroupLicenseTerms(address groupId, address licenseTemplate, uint256 licenseTermsId);
 
     /// @notice When Set LicenseConfig the license template cannot be Zero address if royalty percentage is not Zero.
     error LicensingModule__LicenseTemplateCannotBeZeroAddressToOverrideRoyaltyPercent();

--- a/contracts/lib/Licensing.sol
+++ b/contracts/lib/Licensing.sol
@@ -17,6 +17,13 @@ library Licensing {
     /// @param hookData The data to be used by the licensing hook.
     /// @param commercialRevShare The commercial revenue share percentage.
     /// @param disabled Whether the license is disabled or not.
+    /// @param expectMinimumGroupRewardShare The minimum percentage of the group’s reward share
+    /// (from 0 to 100%, represented as 100 * 10 ** 6) that can be allocated to the IP when it is added to the group.
+    /// If the remaining reward share in the group is less than the minimumGroupRewardShare,
+    /// the IP cannot be added to the group.
+    /// @param expectGroupRewardPool The address of the expected group reward pool.
+    /// The IP can only be added to a group with this specified reward pool address,
+    /// or address(0) if the IP does not want to be added to any group.
     struct LicensingConfig {
         bool isSet;
         uint256 mintingFee;
@@ -24,5 +31,7 @@ library Licensing {
         bytes hookData;
         uint32 commercialRevShare;
         bool disabled;
+        uint32 expectMinimumGroupRewardShare;
+        address expectGroupRewardPool;
     }
 }

--- a/contracts/registries/LicenseRegistry.sol
+++ b/contracts/registries/LicenseRegistry.sol
@@ -319,17 +319,17 @@ contract LicenseRegistry is ILicenseRegistry, AccessManagedUpgradeable, UUPSUpgr
     ) external view returns (Licensing.LicensingConfig memory ipLicensingConfig) {
         // check if the IP has the same license terms as the group
         if (!_hasIpAttachedLicenseTerms(ipId, groupLicenseTemplate, groupLicenseTermsId)) {
-            revert Errors.GroupingModule__IpHasNoGroupLicenseTerms(ipId, groupLicenseTemplate, groupLicenseTermsId);
+            revert Errors.LicenseRegistry__IpHasNoGroupLicenseTerms(ipId, groupLicenseTemplate, groupLicenseTermsId);
         }
         Licensing.LicensingConfig memory lct = _getLicensingConfig(ipId, groupLicenseTemplate, groupLicenseTermsId);
         if (lct.disabled) {
-            revert Errors.GroupingModule__IpLicenseDisabled(ipId, groupLicenseTemplate, groupLicenseTermsId);
+            revert Errors.LicenseRegistry__IpLicenseDisabled(ipId, groupLicenseTemplate, groupLicenseTermsId);
         }
         if (lct.expectGroupRewardPool == address(0)) {
-            revert Errors.GroupingModule__IpExpectGroupRewardPoolNotSet(ipId);
+            revert Errors.LicenseRegistry__IpExpectGroupRewardPoolNotSet(ipId);
         }
         if (lct.expectGroupRewardPool != address(groupRewardPool)) {
-            revert Errors.GroupingModule__IpExpectGroupRewardPoolNotMatch(
+            revert Errors.LicenseRegistry__IpExpectGroupRewardPoolNotMatch(
                 ipId,
                 lct.expectGroupRewardPool,
                 groupId,
@@ -338,7 +338,7 @@ contract LicenseRegistry is ILicenseRegistry, AccessManagedUpgradeable, UUPSUpgr
         }
         // IP must not have expiration time to be added to group
         if (_getExpireTime(ipId) != 0) {
-            revert Errors.GroupingModule__CannotAddIpWithExpirationToGroup(ipId);
+            revert Errors.LicenseRegistry__CannotAddIpWithExpirationToGroup(ipId);
         }
         ipLicensingConfig = lct;
     }

--- a/contracts/registries/LicenseRegistry.sol
+++ b/contracts/registries/LicenseRegistry.sol
@@ -149,7 +149,9 @@ contract LicenseRegistry is ILicenseRegistry, AccessManagedUpgradeable, UUPSUpgr
             licensingHook: licensingConfig.licensingHook,
             hookData: licensingConfig.hookData,
             commercialRevShare: licensingConfig.commercialRevShare,
-            disabled: licensingConfig.disabled
+            disabled: licensingConfig.disabled,
+            expectMinimumGroupRewardShare: licensingConfig.expectMinimumGroupRewardShare,
+            expectGroupRewardPool: licensingConfig.expectGroupRewardPool
         });
 
         emit LicensingConfigSetForLicense(ipId, licenseTemplate, licenseTermsId, licensingConfig);
@@ -171,7 +173,9 @@ contract LicenseRegistry is ILicenseRegistry, AccessManagedUpgradeable, UUPSUpgr
             licensingHook: licensingConfig.licensingHook,
             hookData: licensingConfig.hookData,
             commercialRevShare: licensingConfig.commercialRevShare,
-            disabled: licensingConfig.disabled
+            disabled: licensingConfig.disabled,
+            expectMinimumGroupRewardShare: licensingConfig.expectMinimumGroupRewardShare,
+            expectGroupRewardPool: licensingConfig.expectGroupRewardPool
         });
         emit LicensingConfigSetForIP(ipId, licensingConfig);
     }

--- a/contracts/registries/LicenseRegistry.sol
+++ b/contracts/registries/LicenseRegistry.sol
@@ -301,6 +301,48 @@ contract LicenseRegistry is ILicenseRegistry, AccessManagedUpgradeable, UUPSUpgr
         return _getLicensingConfig(licensorIpId, licenseTemplate, licenseTermsId);
     }
 
+    /// @notice Verifies the group can add given IP.
+    /// @param groupId The address of the group.
+    /// @param groupRewardPool The address of the reward pool of the group.
+    /// @param ipId The address of the IP to be added to the group.
+    /// @param groupLicenseTemplate the address of the license template attached to the group.
+    /// the IP must have this license template.
+    /// @param groupLicenseTermsId The ID of the license terms attached to the group.
+    /// the IP must have this license terms.
+    /// @return ipLicensingConfig The configuration for license attached to the IP.
+    function verifyGroupAddIp(
+        address groupId,
+        address groupRewardPool,
+        address ipId,
+        address groupLicenseTemplate,
+        uint256 groupLicenseTermsId
+    ) external view returns (Licensing.LicensingConfig memory ipLicensingConfig) {
+        // check if the IP has the same license terms as the group
+        if (!_hasIpAttachedLicenseTerms(ipId, groupLicenseTemplate, groupLicenseTermsId)) {
+            revert Errors.GroupingModule__IpHasNoGroupLicenseTerms(ipId, groupLicenseTemplate, groupLicenseTermsId);
+        }
+        Licensing.LicensingConfig memory lct = _getLicensingConfig(ipId, groupLicenseTemplate, groupLicenseTermsId);
+        if (lct.disabled) {
+            revert Errors.GroupingModule__IpLicenseDisabled(ipId, groupLicenseTemplate, groupLicenseTermsId);
+        }
+        if (lct.expectGroupRewardPool == address(0)) {
+            revert Errors.GroupingModule__IpExpectGroupRewardPoolNotSet(ipId);
+        }
+        if (lct.expectGroupRewardPool != address(groupRewardPool)) {
+            revert Errors.GroupingModule__IpExpectGroupRewardPoolNotMatch(
+                ipId,
+                lct.expectGroupRewardPool,
+                groupId,
+                address(groupRewardPool)
+            );
+        }
+        // IP must not have expiration time to be added to group
+        if (_getExpireTime(ipId) != 0) {
+            revert Errors.GroupingModule__CannotAddIpWithExpirationToGroup(ipId);
+        }
+        ipLicensingConfig = lct;
+    }
+
     /// @notice Checks if a license template is registered.
     /// @param licenseTemplate The address of the license template to check.
     /// @return Whether the license template is registered.

--- a/test/foundry/integration/flows/grouping/Grouping.t.sol
+++ b/test/foundry/integration/flows/grouping/Grouping.t.sol
@@ -9,6 +9,7 @@ import { ERC20 } from "@openzeppelin/contracts/token/ERC20/ERC20.sol";
 // contracts
 // solhint-disable-next-line max-line-length
 import { PILFlavors } from "../../../../../contracts/lib/PILFlavors.sol";
+import { Licensing } from "../../../../../contracts/lib/Licensing.sol";
 import { IGroupingModule } from "../../../../../contracts/interfaces/modules/grouping/IGroupingModule.sol";
 import { IGroupIPAssetRegistry } from "../../../../../contracts/interfaces/registries/IGroupIPAssetRegistry.sol";
 
@@ -56,6 +57,17 @@ contract Flows_Integration_Grouping is BaseIntegration {
 
     function test_Integration_Grouping() public {
         // create a group
+        Licensing.LicensingConfig memory licensingConfig = Licensing.LicensingConfig({
+            isSet: true,
+            mintingFee: 0,
+            licensingHook: address(0),
+            hookData: "",
+            commercialRevShare: 10 * 10 ** 6,
+            disabled: false,
+            expectMinimumGroupRewardShare: 0,
+            expectGroupRewardPool: address(evenSplitGroupPool)
+        });
+
         {
             vm.startPrank(groupOwner);
             groupId = groupingModule.registerGroup(address(evenSplitGroupPool));
@@ -68,6 +80,7 @@ contract Flows_Integration_Grouping is BaseIntegration {
             ipAcct[1] = registerIpAccount(mockNFT, 1, u.alice);
             vm.label(ipAcct[1], "IPAccount1");
             licensingModule.attachLicenseTerms(ipAcct[1], address(pilTemplate), commRemixTermsId);
+            licensingModule.setLicensingConfig(ipAcct[1], address(pilTemplate), commRemixTermsId, licensingConfig);
             vm.stopPrank();
         }
 
@@ -76,6 +89,7 @@ contract Flows_Integration_Grouping is BaseIntegration {
             ipAcct[2] = registerIpAccount(mockNFT, 2, u.bob);
             vm.label(ipAcct[2], "IPAccount2");
             licensingModule.attachLicenseTerms(ipAcct[2], address(pilTemplate), commRemixTermsId);
+            licensingModule.setLicensingConfig(ipAcct[2], address(pilTemplate), commRemixTermsId, licensingConfig);
             vm.stopPrank();
         }
 

--- a/test/foundry/modules/grouping/EvenSplitGroupPool.t.sol
+++ b/test/foundry/modules/grouping/EvenSplitGroupPool.t.sol
@@ -62,9 +62,9 @@ contract EvenSplitGroupPoolTest is BaseTest {
     function test_EvenSplitGroupPool_AddIp() public {
         vm.startPrank(address(groupingModule));
 
-        rewardPool.addIp(group1, ipId1);
-        rewardPool.addIp(group1, ipId2);
-        rewardPool.addIp(group1, ipId3);
+        rewardPool.addIp(group1, ipId1, 0);
+        rewardPool.addIp(group1, ipId2, 0);
+        rewardPool.addIp(group1, ipId3, 0);
         assertNotEq(rewardPool.getIpAddedTime(group1, ipId1), 0);
         assertNotEq(rewardPool.getIpAddedTime(group1, ipId2), 0);
         assertNotEq(rewardPool.getIpAddedTime(group1, ipId3), 0);
@@ -78,7 +78,7 @@ contract EvenSplitGroupPoolTest is BaseTest {
         assertFalse(rewardPool.isIPAdded(group1, ipId1));
 
         // add ip again
-        rewardPool.addIp(group1, ipId1);
+        rewardPool.addIp(group1, ipId1, 0);
         assertNotEq(rewardPool.getIpAddedTime(group1, ipId1), 0);
         assertTrue(rewardPool.isIPAdded(group1, ipId1));
 
@@ -88,7 +88,7 @@ contract EvenSplitGroupPoolTest is BaseTest {
     function test_EvenSplitGroupPool_RemoveIp() public {
         vm.startPrank(address(groupingModule));
 
-        rewardPool.addIp(group1, ipId1);
+        rewardPool.addIp(group1, ipId1, 0);
         rewardPool.removeIp(group1, ipId1);
         assertEq(rewardPool.getIpAddedTime(group1, ipId1), 0);
         assertFalse(rewardPool.isIPAdded(group1, ipId1));
@@ -96,6 +96,41 @@ contract EvenSplitGroupPoolTest is BaseTest {
         rewardPool.removeIp(group1, ipId1);
         assertEq(rewardPool.getIpAddedTime(group1, ipId1), 0);
         assertFalse(rewardPool.isIPAdded(group1, ipId1));
+    }
+
+    function test_EvenSplitGroupPool_RemoveIp_withMinimumGroupRewardShare() public {
+        vm.startPrank(address(groupingModule));
+
+        rewardPool.addIp(group1, ipId1, 10 * 10 ** 6);
+        rewardPool.addIp(group1, ipId2, 20 * 10 ** 6);
+        rewardPool.addIp(group1, ipId3, 60 * 10 ** 6);
+        assertEq(rewardPool.getTotalMinimumRewardShare(group1), 90 * 10 ** 6);
+        assertEq(rewardPool.getMinimumRewardShare(group1, ipId1), 10 * 10 ** 6);
+        assertEq(rewardPool.getMinimumRewardShare(group1, ipId2), 20 * 10 ** 6);
+        assertEq(rewardPool.getMinimumRewardShare(group1, ipId3), 60 * 10 ** 6);
+
+        // add ip again
+        rewardPool.addIp(group1, ipId1, 10 * 10 ** 6);
+        assertEq(rewardPool.getTotalMinimumRewardShare(group1), 90 * 10 ** 6);
+        assertEq(rewardPool.getMinimumRewardShare(group1, ipId1), 10 * 10 ** 6);
+        assertEq(rewardPool.getMinimumRewardShare(group1, ipId2), 20 * 10 ** 6);
+        assertEq(rewardPool.getMinimumRewardShare(group1, ipId3), 60 * 10 ** 6);
+
+        rewardPool.removeIp(group1, ipId1);
+        assertEq(rewardPool.getIpAddedTime(group1, ipId1), 0);
+        assertFalse(rewardPool.isIPAdded(group1, ipId1));
+        assertEq(rewardPool.getTotalMinimumRewardShare(group1), 80 * 10 ** 6);
+        assertEq(rewardPool.getMinimumRewardShare(group1, ipId1), 0);
+        assertEq(rewardPool.getMinimumRewardShare(group1, ipId2), 20 * 10 ** 6);
+        assertEq(rewardPool.getMinimumRewardShare(group1, ipId3), 60 * 10 ** 6);
+        // remove again
+        rewardPool.removeIp(group1, ipId1);
+        assertEq(rewardPool.getIpAddedTime(group1, ipId1), 0);
+        assertFalse(rewardPool.isIPAdded(group1, ipId1));
+        assertEq(rewardPool.getTotalMinimumRewardShare(group1), 80 * 10 ** 6);
+        assertEq(rewardPool.getMinimumRewardShare(group1, ipId1), 0);
+        assertEq(rewardPool.getMinimumRewardShare(group1, ipId2), 20 * 10 ** 6);
+        assertEq(rewardPool.getMinimumRewardShare(group1, ipId3), 60 * 10 ** 6);
     }
 
     // test add and remove ip from pool
@@ -111,8 +146,8 @@ contract EvenSplitGroupPoolTest is BaseTest {
     function test_EvenSplitGroupPool_AddIpTwice() public {
         vm.startPrank(address(groupingModule));
 
-        rewardPool.addIp(group1, ipId1);
-        rewardPool.addIp(group1, ipId1);
+        rewardPool.addIp(group1, ipId1, 0);
+        rewardPool.addIp(group1, ipId1, 0);
         assertNotEq(rewardPool.getIpAddedTime(group1, ipId1), 0);
         assertTrue(rewardPool.isIPAdded(group1, ipId1));
 
@@ -122,8 +157,8 @@ contract EvenSplitGroupPoolTest is BaseTest {
     function test_EvenSplitGroupPool_AddIpToMultiplePools() public {
         vm.startPrank(address(groupingModule));
 
-        rewardPool.addIp(group1, ipId1);
-        rewardPool.addIp(group2, ipId1);
+        rewardPool.addIp(group1, ipId1, 0);
+        rewardPool.addIp(group2, ipId1, 0);
         assertNotEq(rewardPool.getIpAddedTime(group1, ipId1), 0);
         assertNotEq(rewardPool.getIpAddedTime(group2, ipId1), 0);
         assertTrue(rewardPool.isIPAdded(group1, ipId1));
@@ -135,8 +170,8 @@ contract EvenSplitGroupPoolTest is BaseTest {
     function test_EvenSplitGroupPool_RemoveIpFromMultiplePools() public {
         vm.startPrank(address(groupingModule));
 
-        rewardPool.addIp(group1, ipId1);
-        rewardPool.addIp(group2, ipId1);
+        rewardPool.addIp(group1, ipId1, 0);
+        rewardPool.addIp(group2, ipId1, 0);
         rewardPool.removeIp(group1, ipId1);
         assertEq(rewardPool.getIpAddedTime(group1, ipId1), 0);
         assertNotEq(rewardPool.getIpAddedTime(group2, ipId1), 0);
@@ -172,7 +207,7 @@ contract EvenSplitGroupPoolTest is BaseTest {
         licensingModule.mintLicenseTokens(ipId1, address(pilTemplate), commRemixTermsId, 1, address(this), "", 0);
 
         vm.prank(address(groupingModule));
-        rewardPool.addIp(group1, ipId1);
+        rewardPool.addIp(group1, ipId1, 0);
 
         vm.startPrank(address(groupingModule));
         erc20.mint(address(rewardPool), 100);
@@ -211,7 +246,7 @@ contract EvenSplitGroupPoolTest is BaseTest {
         vm.expectRevert(
             abi.encodeWithSelector(Errors.EvenSplitGroupPool__CallerIsNotGroupingModule.selector, address(0x123))
         );
-        rewardPool.addIp(group1, ipId1);
+        rewardPool.addIp(group1, ipId1, 0);
 
         vm.expectRevert(
             abi.encodeWithSelector(Errors.EvenSplitGroupPool__CallerIsNotGroupingModule.selector, address(0x123))
@@ -241,8 +276,8 @@ contract EvenSplitGroupPoolTest is BaseTest {
         licensingModule.mintLicenseTokens(ipId2, address(pilTemplate), commRemixTermsId, 1, address(this), "", 0);
 
         vm.startPrank(address(groupingModule));
-        rewardPool.addIp(group1, ipId1);
-        rewardPool.addIp(group1, ipId2);
+        rewardPool.addIp(group1, ipId1, 0);
+        rewardPool.addIp(group1, ipId2, 0);
         vm.stopPrank();
 
         vm.startPrank(address(groupingModule));

--- a/test/foundry/modules/grouping/GroupingModule.t.sol
+++ b/test/foundry/modules/grouping/GroupingModule.t.sol
@@ -387,7 +387,7 @@ contract GroupingModuleTest is BaseTest {
         ipIds[0] = ipId1;
         vm.expectRevert(
             abi.encodeWithSelector(
-                Errors.GroupingModule__IpLicenseDisabled.selector,
+                Errors.LicenseRegistry__IpLicenseDisabled.selector,
                 ipId1,
                 address(pilTemplate),
                 termsId
@@ -435,7 +435,7 @@ contract GroupingModuleTest is BaseTest {
         ipIds[0] = ipId1;
         vm.expectRevert(
             abi.encodeWithSelector(
-                Errors.GroupingModule__IpExpectGroupRewardPoolNotMatch.selector,
+                Errors.LicenseRegistry__IpExpectGroupRewardPoolNotMatch.selector,
                 ipId1,
                 address(0x123),
                 groupId1,
@@ -482,7 +482,7 @@ contract GroupingModuleTest is BaseTest {
 
         address[] memory ipIds = new address[](1);
         ipIds[0] = ipId1;
-        vm.expectRevert(abi.encodeWithSelector(Errors.GroupingModule__IpExpectGroupRewardPoolNotSet.selector, ipId1));
+        vm.expectRevert(abi.encodeWithSelector(Errors.LicenseRegistry__IpExpectGroupRewardPoolNotSet.selector, ipId1));
         vm.prank(alice);
         groupingModule.addIp(groupId1, ipIds);
 
@@ -590,7 +590,7 @@ contract GroupingModuleTest is BaseTest {
         address[] memory ipIds = new address[](1);
         ipIds[0] = ipId2;
         vm.expectRevert(
-            abi.encodeWithSelector(Errors.GroupingModule__CannotAddIpWithExpirationToGroup.selector, ipId2)
+            abi.encodeWithSelector(Errors.LicenseRegistry__CannotAddIpWithExpirationToGroup.selector, ipId2)
         );
         vm.prank(alice);
         groupingModule.addIp(groupId1, ipIds);

--- a/test/foundry/modules/grouping/GroupingModule.t.sol
+++ b/test/foundry/modules/grouping/GroupingModule.t.sol
@@ -6,6 +6,7 @@ import { Strings } from "@openzeppelin/contracts/utils/Strings.sol";
 
 // contracts
 import { Errors } from "../../../../contracts/lib/Errors.sol";
+import { Licensing } from "../../../../contracts/lib/Licensing.sol";
 import { IGroupingModule } from "../../../../contracts/interfaces/modules/grouping/IGroupingModule.sol";
 import { IIPAssetRegistry } from "../../../../contracts/interfaces/registries/IIPAssetRegistry.sol";
 import { PILFlavors } from "../../../../contracts/lib/PILFlavors.sol";
@@ -135,10 +136,25 @@ contract GroupingModuleTest is BaseTest {
             })
         );
 
-        vm.prank(ipOwner1);
+        Licensing.LicensingConfig memory licensingConfig = Licensing.LicensingConfig({
+            isSet: true,
+            mintingFee: 0,
+            licensingHook: address(0),
+            hookData: "",
+            commercialRevShare: 10 * 10 ** 6,
+            disabled: false,
+            expectMinimumGroupRewardShare: 0,
+            expectGroupRewardPool: address(evenSplitGroupPool)
+        });
+
+        vm.startPrank(ipOwner1);
         licensingModule.attachLicenseTerms(ipId1, address(pilTemplate), termsId);
-        vm.prank(ipOwner2);
+        licensingModule.setLicensingConfig(ipId1, address(pilTemplate), termsId, licensingConfig);
+        vm.stopPrank();
+        vm.startPrank(ipOwner2);
         licensingModule.attachLicenseTerms(ipId2, address(pilTemplate), termsId);
+        licensingModule.setLicensingConfig(ipId2, address(pilTemplate), termsId, licensingConfig);
+        vm.stopPrank();
 
         vm.startPrank(alice);
         licensingModule.attachLicenseTerms(groupId, address(pilTemplate), termsId);
@@ -166,10 +182,25 @@ contract GroupingModuleTest is BaseTest {
             })
         );
 
-        vm.prank(ipOwner1);
+        Licensing.LicensingConfig memory licensingConfig = Licensing.LicensingConfig({
+            isSet: true,
+            mintingFee: 0,
+            licensingHook: address(0),
+            hookData: "",
+            commercialRevShare: 10 * 10 ** 6,
+            disabled: false,
+            expectMinimumGroupRewardShare: 0,
+            expectGroupRewardPool: address(evenSplitGroupPool)
+        });
+
+        vm.startPrank(ipOwner1);
         licensingModule.attachLicenseTerms(ipId1, address(pilTemplate), termsId);
-        vm.prank(ipOwner2);
+        licensingModule.setLicensingConfig(ipId1, address(pilTemplate), termsId, licensingConfig);
+        vm.stopPrank();
+        vm.startPrank(ipOwner2);
         licensingModule.attachLicenseTerms(ipId2, address(pilTemplate), termsId);
+        licensingModule.setLicensingConfig(ipId2, address(pilTemplate), termsId, licensingConfig);
+        vm.stopPrank();
 
         vm.startPrank(alice);
         licensingModule.attachLicenseTerms(groupId, address(pilTemplate), termsId);
@@ -199,12 +230,27 @@ contract GroupingModuleTest is BaseTest {
             })
         );
 
-        vm.prank(ipOwner1);
+        Licensing.LicensingConfig memory licensingConfig = Licensing.LicensingConfig({
+            isSet: true,
+            mintingFee: 0,
+            licensingHook: address(0),
+            hookData: "",
+            commercialRevShare: 10 * 10 ** 6,
+            disabled: false,
+            expectMinimumGroupRewardShare: 10 * 10 ** 6,
+            expectGroupRewardPool: address(evenSplitGroupPool)
+        });
+
+        vm.startPrank(ipOwner1);
         licensingModule.attachLicenseTerms(ipId1, address(pilTemplate), termsId);
+        licensingModule.setLicensingConfig(ipId1, address(pilTemplate), termsId, licensingConfig);
+        vm.stopPrank();
         licensingModule.mintLicenseTokens(ipId1, address(pilTemplate), termsId, 1, address(this), "", 0);
-        vm.prank(ipOwner2);
+        vm.startPrank(ipOwner2);
         licensingModule.attachLicenseTerms(ipId2, address(pilTemplate), termsId);
+        licensingModule.setLicensingConfig(ipId2, address(pilTemplate), termsId, licensingConfig);
         licensingModule.mintLicenseTokens(ipId2, address(pilTemplate), termsId, 1, address(this), "", 0);
+        vm.stopPrank();
 
         vm.startPrank(alice);
         licensingModule.attachLicenseTerms(groupId, address(pilTemplate), termsId);
@@ -307,6 +353,202 @@ contract GroupingModuleTest is BaseTest {
         assertEq(rewardPool.getIpAddedTime(groupId1, ipId1), 0);
     }
 
+    function test_GroupingModule_addIp_revert_licenseDisabled() public {
+        uint256 termsId = pilTemplate.registerLicenseTerms(
+            PILFlavors.commercialRemix({
+                mintingFee: 0,
+                commercialRevShare: 10,
+                currencyToken: address(erc20),
+                royaltyPolicy: address(royaltyPolicyLAP)
+            })
+        );
+        vm.startPrank(alice);
+        address groupId1 = groupingModule.registerGroup(address(rewardPool));
+        licensingModule.attachLicenseTerms(groupId1, address(pilTemplate), termsId);
+        vm.stopPrank();
+
+        Licensing.LicensingConfig memory licensingConfig = Licensing.LicensingConfig({
+            isSet: true,
+            mintingFee: 0,
+            licensingHook: address(0),
+            hookData: "",
+            commercialRevShare: 10 * 10 ** 6,
+            disabled: true,
+            expectMinimumGroupRewardShare: 0,
+            expectGroupRewardPool: address(evenSplitGroupPool)
+        });
+
+        vm.startPrank(ipOwner1);
+        licensingModule.attachLicenseTerms(ipId1, address(pilTemplate), termsId);
+        licensingModule.setLicensingConfig(ipId1, address(pilTemplate), termsId, licensingConfig);
+        vm.stopPrank();
+
+        address[] memory ipIds = new address[](1);
+        ipIds[0] = ipId1;
+        vm.expectRevert(
+            abi.encodeWithSelector(
+                Errors.GroupingModule__IpLicenseDisabled.selector,
+                ipId1,
+                address(pilTemplate),
+                termsId
+            )
+        );
+        vm.prank(alice);
+        groupingModule.addIp(groupId1, ipIds);
+
+        assertEq(ipAssetRegistry.totalMembers(groupId1), 0);
+        assertEq(rewardPool.getTotalIps(groupId1), 0);
+        assertEq(rewardPool.getIpAddedTime(groupId1, ipId1), 0);
+    }
+
+    function test_GroupingModule_addIp_revert_IpExpectedGroupRewardPoolNotMatchGroupPool() public {
+        uint256 termsId = pilTemplate.registerLicenseTerms(
+            PILFlavors.commercialRemix({
+                mintingFee: 0,
+                commercialRevShare: 10,
+                currencyToken: address(erc20),
+                royaltyPolicy: address(royaltyPolicyLAP)
+            })
+        );
+        vm.startPrank(alice);
+        address groupId1 = groupingModule.registerGroup(address(rewardPool));
+        licensingModule.attachLicenseTerms(groupId1, address(pilTemplate), termsId);
+        vm.stopPrank();
+
+        Licensing.LicensingConfig memory licensingConfig = Licensing.LicensingConfig({
+            isSet: true,
+            mintingFee: 0,
+            licensingHook: address(0),
+            hookData: "",
+            commercialRevShare: 10 * 10 ** 6,
+            disabled: false,
+            expectMinimumGroupRewardShare: 0,
+            expectGroupRewardPool: address(0x123)
+        });
+
+        vm.startPrank(ipOwner1);
+        licensingModule.attachLicenseTerms(ipId1, address(pilTemplate), termsId);
+        licensingModule.setLicensingConfig(ipId1, address(pilTemplate), termsId, licensingConfig);
+        vm.stopPrank();
+
+        address[] memory ipIds = new address[](1);
+        ipIds[0] = ipId1;
+        vm.expectRevert(
+            abi.encodeWithSelector(
+                Errors.GroupingModule__IpExpectGroupRewardPoolNotMatch.selector,
+                ipId1,
+                address(0x123),
+                groupId1,
+                address(rewardPool)
+            )
+        );
+        vm.prank(alice);
+        groupingModule.addIp(groupId1, ipIds);
+
+        assertEq(ipAssetRegistry.totalMembers(groupId1), 0);
+        assertEq(rewardPool.getTotalIps(groupId1), 0);
+        assertEq(rewardPool.getIpAddedTime(groupId1, ipId1), 0);
+    }
+
+    function test_GroupingModule_addIp_revert_IpNotSetExpectedGroupRewardPool() public {
+        uint256 termsId = pilTemplate.registerLicenseTerms(
+            PILFlavors.commercialRemix({
+                mintingFee: 0,
+                commercialRevShare: 10,
+                currencyToken: address(erc20),
+                royaltyPolicy: address(royaltyPolicyLAP)
+            })
+        );
+        vm.startPrank(alice);
+        address groupId1 = groupingModule.registerGroup(address(rewardPool));
+        licensingModule.attachLicenseTerms(groupId1, address(pilTemplate), termsId);
+        vm.stopPrank();
+
+        Licensing.LicensingConfig memory licensingConfig = Licensing.LicensingConfig({
+            isSet: true,
+            mintingFee: 0,
+            licensingHook: address(0),
+            hookData: "",
+            commercialRevShare: 10 * 10 ** 6,
+            disabled: false,
+            expectMinimumGroupRewardShare: 0,
+            expectGroupRewardPool: address(0)
+        });
+
+        vm.startPrank(ipOwner1);
+        licensingModule.attachLicenseTerms(ipId1, address(pilTemplate), termsId);
+        licensingModule.setLicensingConfig(ipId1, address(pilTemplate), termsId, licensingConfig);
+        vm.stopPrank();
+
+        address[] memory ipIds = new address[](1);
+        ipIds[0] = ipId1;
+        vm.expectRevert(abi.encodeWithSelector(Errors.GroupingModule__IpExpectGroupRewardPoolNotSet.selector, ipId1));
+        vm.prank(alice);
+        groupingModule.addIp(groupId1, ipIds);
+
+        assertEq(ipAssetRegistry.totalMembers(groupId1), 0);
+        assertEq(rewardPool.getTotalIps(groupId1), 0);
+        assertEq(rewardPool.getIpAddedTime(groupId1, ipId1), 0);
+    }
+
+    function test_GroupingModule_addIp_revert_TotalGroupRewardShareExceed100Percent() public {
+        uint256 termsId = pilTemplate.registerLicenseTerms(
+            PILFlavors.commercialRemix({
+                mintingFee: 0,
+                commercialRevShare: 10,
+                currencyToken: address(erc20),
+                royaltyPolicy: address(royaltyPolicyLAP)
+            })
+        );
+        vm.startPrank(alice);
+        address groupId1 = groupingModule.registerGroup(address(rewardPool));
+        licensingModule.attachLicenseTerms(groupId1, address(pilTemplate), termsId);
+        vm.stopPrank();
+
+        Licensing.LicensingConfig memory licensingConfig = Licensing.LicensingConfig({
+            isSet: true,
+            mintingFee: 0,
+            licensingHook: address(0),
+            hookData: "",
+            commercialRevShare: 10 * 10 ** 6,
+            disabled: false,
+            expectMinimumGroupRewardShare: 60 * 10 ** 6,
+            expectGroupRewardPool: address(rewardPool)
+        });
+
+        vm.startPrank(ipOwner1);
+        licensingModule.attachLicenseTerms(ipId1, address(pilTemplate), termsId);
+        licensingModule.setLicensingConfig(ipId1, address(pilTemplate), termsId, licensingConfig);
+        vm.stopPrank();
+
+        vm.startPrank(ipOwner2);
+        licensingModule.attachLicenseTerms(ipId2, address(pilTemplate), termsId);
+        licensingModule.setLicensingConfig(ipId2, address(pilTemplate), termsId, licensingConfig);
+        vm.stopPrank();
+
+        address[] memory ipIds = new address[](1);
+        ipIds[0] = ipId1;
+        vm.prank(alice);
+        groupingModule.addIp(groupId1, ipIds);
+
+        ipIds[0] = ipId2;
+        vm.expectRevert(
+            abi.encodeWithSelector(
+                Errors.GroupingModule__TotalGroupRewardShareExceeds100Percent.selector,
+                groupId1,
+                120 * 10 ** 6,
+                ipId2,
+                60 * 10 ** 6
+            )
+        );
+        vm.prank(alice);
+        groupingModule.addIp(groupId1, ipIds);
+
+        assertEq(ipAssetRegistry.totalMembers(groupId1), 1);
+        assertEq(rewardPool.getTotalIps(groupId1), 1);
+        assertEq(rewardPool.getIpAddedTime(groupId1, ipId1), block.timestamp);
+    }
+
     function test_GroupingModule_addIp_revert_ipWithExpiration() public {
         PILTerms memory expiredTerms = PILFlavors.commercialRemix({
             mintingFee: 0,
@@ -316,6 +558,17 @@ contract GroupingModuleTest is BaseTest {
         });
         expiredTerms.expiration = 10 days;
         uint256 termsId = pilTemplate.registerLicenseTerms(expiredTerms);
+
+        Licensing.LicensingConfig memory licensingConfig = Licensing.LicensingConfig({
+            isSet: true,
+            mintingFee: 0,
+            licensingHook: address(0),
+            hookData: "",
+            commercialRevShare: 10 * 10 ** 6,
+            disabled: false,
+            expectMinimumGroupRewardShare: 0,
+            expectGroupRewardPool: address(evenSplitGroupPool)
+        });
 
         vm.startPrank(alice);
         address groupId1 = groupingModule.registerGroup(address(rewardPool));
@@ -329,8 +582,10 @@ contract GroupingModuleTest is BaseTest {
         parentIpIds[0] = ipId1;
         uint256[] memory licenseTermsIds = new uint256[](1);
         licenseTermsIds[0] = termsId;
-        vm.prank(ipOwner2);
+        vm.startPrank(ipOwner2);
         licensingModule.registerDerivative(ipId2, parentIpIds, licenseTermsIds, address(pilTemplate), "", 0, 100e6);
+        licensingModule.setLicensingConfig(ipId2, address(pilTemplate), termsId, licensingConfig);
+        vm.stopPrank();
 
         address[] memory ipIds = new address[](1);
         ipIds[0] = ipId2;
@@ -398,10 +653,25 @@ contract GroupingModuleTest is BaseTest {
             })
         );
 
-        vm.prank(ipOwner1);
+        Licensing.LicensingConfig memory licensingConfig = Licensing.LicensingConfig({
+            isSet: true,
+            mintingFee: 0,
+            licensingHook: address(0),
+            hookData: "",
+            commercialRevShare: 10 * 10 ** 6,
+            disabled: false,
+            expectMinimumGroupRewardShare: 0,
+            expectGroupRewardPool: address(evenSplitGroupPool)
+        });
+
+        vm.startPrank(ipOwner1);
         licensingModule.attachLicenseTerms(ipId1, address(pilTemplate), termsId);
-        vm.prank(ipOwner2);
+        licensingModule.setLicensingConfig(ipId1, address(pilTemplate), termsId, licensingConfig);
+        vm.stopPrank();
+        vm.startPrank(ipOwner2);
         licensingModule.attachLicenseTerms(ipId2, address(pilTemplate), termsId);
+        licensingModule.setLicensingConfig(ipId2, address(pilTemplate), termsId, licensingConfig);
+        vm.stopPrank();
 
         vm.startPrank(alice);
         address groupId = groupingModule.registerGroup(address(rewardPool));

--- a/test/foundry/modules/licensing/LicensingModule.t.sol
+++ b/test/foundry/modules/licensing/LicensingModule.t.sol
@@ -1690,7 +1690,9 @@ contract LicensingModuleTest is BaseTest {
             licensingHook: address(licensingHook),
             hookData: abi.encode(address(0x123)),
             commercialRevShare: 0,
-            disabled: false
+            disabled: false,
+            expectMinimumGroupRewardShare: 0,
+            expectGroupRewardPool: address(0)
         });
         vm.prank(ipOwner1);
         licensingModule.setLicensingConfig(ipId1, address(pilTemplate), socialRemixTermsId, licensingConfig);
@@ -1741,7 +1743,9 @@ contract LicensingModuleTest is BaseTest {
             licensingHook: address(licensingHook),
             hookData: abi.encode(address(0x123)),
             commercialRevShare: 10_000_000,
-            disabled: false
+            disabled: false,
+            expectMinimumGroupRewardShare: 0,
+            expectGroupRewardPool: address(0)
         });
         vm.prank(ipOwner1);
         licensingModule.setLicensingConfig(ipId1, address(pilTemplate), commercialRemixTermsId, licensingConfig);
@@ -1791,7 +1795,9 @@ contract LicensingModuleTest is BaseTest {
             licensingHook: address(0),
             hookData: "",
             commercialRevShare: 10_000_000,
-            disabled: false
+            disabled: false,
+            expectMinimumGroupRewardShare: 0,
+            expectGroupRewardPool: address(0)
         });
         vm.prank(ipOwner2);
         licensingModule.setLicensingConfig(ipId2, address(pilTemplate), termsId, licensingConfig);
@@ -1831,7 +1837,9 @@ contract LicensingModuleTest is BaseTest {
             licensingHook: address(licensingHook),
             hookData: abi.encode(address(0x123)),
             commercialRevShare: 0,
-            disabled: false
+            disabled: false,
+            expectMinimumGroupRewardShare: 0,
+            expectGroupRewardPool: address(0)
         });
         vm.prank(ipOwner1);
         licensingModule.setLicensingConfig(ipId1, address(pilTemplate), socialRemixTermsId, licensingConfig);
@@ -1882,7 +1890,9 @@ contract LicensingModuleTest is BaseTest {
             licensingHook: address(licensingHook),
             hookData: abi.encode(address(0x123)),
             commercialRevShare: 0,
-            disabled: false
+            disabled: false,
+            expectMinimumGroupRewardShare: 0,
+            expectGroupRewardPool: address(0)
         });
         vm.expectRevert(
             abi.encodeWithSelector(Errors.LicensingModule__InvalidLicenseTermsId.selector, address(pilTemplate), 0)
@@ -1912,7 +1922,9 @@ contract LicensingModuleTest is BaseTest {
             licensingHook: address(licensingHook),
             hookData: abi.encode(address(0x123)),
             commercialRevShare: 1000,
-            disabled: false
+            disabled: false,
+            expectMinimumGroupRewardShare: 0,
+            expectGroupRewardPool: address(0)
         });
         vm.expectRevert(
             abi.encodeWithSelector(Errors.LicenseRegistry__UnregisteredLicenseTemplate.selector, address(0x123))
@@ -1954,7 +1966,9 @@ contract LicensingModuleTest is BaseTest {
             licensingHook: address(licensingHook),
             hookData: abi.encode(address(0x123)),
             commercialRevShare: 10_000_000,
-            disabled: false
+            disabled: false,
+            expectMinimumGroupRewardShare: 0,
+            expectGroupRewardPool: address(0)
         });
 
         vm.expectRevert(
@@ -1979,7 +1993,9 @@ contract LicensingModuleTest is BaseTest {
             licensingHook: address(licensingHook),
             hookData: abi.encode(address(0x123)),
             commercialRevShare: 0,
-            disabled: false
+            disabled: false,
+            expectMinimumGroupRewardShare: 0,
+            expectGroupRewardPool: address(0)
         });
         vm.expectRevert(
             abi.encodeWithSelector(Errors.LicensingModule__InvalidLicensingHook.selector, address(licensingHook))
@@ -1998,7 +2014,9 @@ contract LicensingModuleTest is BaseTest {
             licensingHook: address(tokenGatedHook),
             hookData: abi.encode(address(0x123)),
             commercialRevShare: 0,
-            disabled: false
+            disabled: false,
+            expectMinimumGroupRewardShare: 0,
+            expectGroupRewardPool: address(0)
         });
         vm.expectRevert(
             abi.encodeWithSelector(Errors.LicensingModule__InvalidLicensingHook.selector, address(tokenGatedHook))
@@ -2021,7 +2039,9 @@ contract LicensingModuleTest is BaseTest {
             licensingHook: address(licensingHook),
             hookData: abi.encode(address(0x123)),
             commercialRevShare: 0,
-            disabled: false
+            disabled: false,
+            expectMinimumGroupRewardShare: 0,
+            expectGroupRewardPool: address(0)
         });
         vm.expectRevert(abi.encodeWithSelector(PausableUpgradeable.EnforcedPause.selector));
         vm.prank(ipOwner1);
@@ -2039,7 +2059,9 @@ contract LicensingModuleTest is BaseTest {
             licensingHook: address(licensingHook),
             hookData: abi.encode(address(0x123)),
             commercialRevShare: 0,
-            disabled: false
+            disabled: false,
+            expectMinimumGroupRewardShare: 0,
+            expectGroupRewardPool: address(0)
         });
         vm.prank(ipOwner1);
         licensingModule.setLicensingConfig(ipId1, address(pilTemplate), termsId, licensingConfig);
@@ -2067,7 +2089,9 @@ contract LicensingModuleTest is BaseTest {
             licensingHook: address(0),
             hookData: "",
             commercialRevShare: 0,
-            disabled: true
+            disabled: true,
+            expectMinimumGroupRewardShare: 0,
+            expectGroupRewardPool: address(0)
         });
         vm.prank(ipOwner1);
         licensingModule.setLicensingConfig(ipId1, address(pilTemplate), termsId, licensingConfig);
@@ -2113,7 +2137,9 @@ contract LicensingModuleTest is BaseTest {
             licensingHook: address(licensingHook),
             hookData: abi.encode(address(0x123)),
             commercialRevShare: 0,
-            disabled: false
+            disabled: false,
+            expectMinimumGroupRewardShare: 0,
+            expectGroupRewardPool: address(0)
         });
         vm.prank(ipOwner1);
         licensingModule.setLicensingConfig(ipId1, address(pilTemplate), termsId, licensingConfig);
@@ -2173,7 +2199,9 @@ contract LicensingModuleTest is BaseTest {
             licensingHook: address(0),
             hookData: abi.encode(address(0x123)),
             commercialRevShare: 0,
-            disabled: false
+            disabled: false,
+            expectMinimumGroupRewardShare: 0,
+            expectGroupRewardPool: address(0)
         });
         vm.prank(ipOwner1);
         licensingModule.setLicensingConfig(ipId1, address(pilTemplate), termsId, licensingConfig);
@@ -2285,7 +2313,9 @@ contract LicensingModuleTest is BaseTest {
             licensingHook: address(licensingHook),
             hookData: abi.encode(address(0x123)),
             commercialRevShare: 0,
-            disabled: false
+            disabled: false,
+            expectMinimumGroupRewardShare: 0,
+            expectGroupRewardPool: address(0)
         });
         vm.prank(ipOwner1);
         licensingModule.setLicensingConfig(ipId1, address(pilTemplate), termsId, licensingConfig);
@@ -2338,7 +2368,9 @@ contract LicensingModuleTest is BaseTest {
             licensingHook: address(licensingHook),
             hookData: abi.encode(address(0x123)),
             commercialRevShare: 0,
-            disabled: false
+            disabled: false,
+            expectMinimumGroupRewardShare: 0,
+            expectGroupRewardPool: address(0)
         });
         vm.prank(ipOwner1);
         licensingModule.setLicensingConfig(ipId1, address(pilTemplate), termsId, licensingConfig);
@@ -2392,7 +2424,9 @@ contract LicensingModuleTest is BaseTest {
             licensingHook: address(licensingHook),
             hookData: abi.encode(address(0x123)),
             commercialRevShare: 0,
-            disabled: false
+            disabled: false,
+            expectMinimumGroupRewardShare: 0,
+            expectGroupRewardPool: address(0)
         });
         vm.prank(ipOwner1);
         licensingModule.setLicensingConfig(ipId1, address(pilTemplate), termsId, licensingConfig);
@@ -2433,7 +2467,9 @@ contract LicensingModuleTest is BaseTest {
             licensingHook: address(0),
             hookData: abi.encode(address(0)),
             commercialRevShare: 0,
-            disabled: false
+            disabled: false,
+            expectMinimumGroupRewardShare: 0,
+            expectGroupRewardPool: address(0)
         });
         vm.prank(ipOwner1);
         licensingModule.setLicensingConfig(ipId1, address(pilTemplate), termsId, licensingConfig2);
@@ -2465,7 +2501,9 @@ contract LicensingModuleTest is BaseTest {
             licensingHook: address(licensingHook),
             hookData: abi.encode(address(ipOwner2)),
             commercialRevShare: 0,
-            disabled: false
+            disabled: false,
+            expectMinimumGroupRewardShare: 0,
+            expectGroupRewardPool: address(0)
         });
         vm.prank(ipOwner1);
         licensingModule.setLicensingConfig(ipId1, address(pilTemplate), termsId, licensingConfig);
@@ -2497,7 +2535,9 @@ contract LicensingModuleTest is BaseTest {
             licensingHook: address(0),
             hookData: "",
             commercialRevShare: 0,
-            disabled: true
+            disabled: true,
+            expectMinimumGroupRewardShare: 0,
+            expectGroupRewardPool: address(0)
         });
         vm.prank(ipOwner1);
         licensingModule.setLicensingConfig(ipId1, address(pilTemplate), termsId, licensingConfig);

--- a/test/foundry/registries/LicenseRegistry.t.sol
+++ b/test/foundry/registries/LicenseRegistry.t.sol
@@ -104,7 +104,9 @@ contract LicenseRegistryTest is BaseTest {
             licensingHook: address(0),
             hookData: "",
             commercialRevShare: 0,
-            disabled: false
+            disabled: false,
+            expectMinimumGroupRewardShare: 0,
+            expectGroupRewardPool: address(0)
         });
 
         vm.prank(address(licensingModule));
@@ -133,7 +135,9 @@ contract LicenseRegistryTest is BaseTest {
             licensingHook: address(0),
             hookData: "",
             commercialRevShare: 0,
-            disabled: false
+            disabled: false,
+            expectMinimumGroupRewardShare: 0,
+            expectGroupRewardPool: address(0)
         });
 
         vm.expectRevert(
@@ -151,7 +155,9 @@ contract LicenseRegistryTest is BaseTest {
             licensingHook: address(0),
             hookData: "",
             commercialRevShare: 0,
-            disabled: false
+            disabled: false,
+            expectMinimumGroupRewardShare: 0,
+            expectGroupRewardPool: address(0)
         });
 
         vm.prank(address(licensingModule));


### PR DESCRIPTION
## Description

This PR introduces two new license configuration items for groups: `expectMinimumGroupRewardShare` and `expectGroupRewardPool`. These configurations allow individual IPs to define restrictions for being added to a group. 

- `expectMinimumGroupRewardShare`: Specifies the minimum percentage of the group’s reward share that must be allocated to the IP.
- `expectGroupRewardPool`: Specifies that the IP can only be added to a group with a specific reward pool. If set to `address(0)`, the IP cannot be added to any group.

## Key Changes

- **New License Configurations**: Added `expectMinimumGroupRewardShare` and `expectGroupRewardPool` to the `LicensingConfig` struct.
- **Validation Logic**: Implemented checks to enforce the new configurations when adding IPs to groups.

## Objectives

- **Restrict Group Addition**: Allow IPs to define specific conditions for being added to groups.
- **Ensure Compliance**: Ensure that IPs are only added to groups that meet their specified reward share and pool requirements.

## Implementation Steps

1. **Update `LicensingConfig` Struct**: Add `expectMinimumGroupRewardShare` and `expectGroupRewardPool` fields.
2. **Modify Group Addition Logic**: Implement checks to enforce the new configurations when adding IPs to groups.
3. **Testing**: Add tests to verify that the new configurations are correctly enforced.
