### PR TITLE
Fix on license minting restriction

### DIFF
--- a/contracts/lib/Errors.sol
+++ b/contracts/lib/Errors.sol
@@ -672,6 +672,9 @@ library Errors {
     /// @notice Zero address provided for Royalty Module.
     error RoyaltyPolicyLRP__ZeroRoyaltyModule();
 
+    /// @notice Zero address provided for Royalty Policy LAP.
+    error RoyaltyPolicyLRP__ZeroRoyaltyPolicyLAP();
+
     /// @notice Zero address provided for Access Manager in initializer.
     error RoyaltyPolicyLRP__ZeroAccessManager();
 

--- a/contracts/modules/royalty/policies/LRP/RoyaltyPolicyLRP.sol
+++ b/contracts/modules/royalty/policies/LRP/RoyaltyPolicyLRP.sol
@@ -66,6 +66,10 @@ contract RoyaltyPolicyLRP is
     /// @custom:oz-upgrades-unsafe-allow state-variable-immutable
     IRoyaltyModule public immutable ROYALTY_MODULE;
 
+    /// @notice Returns the RoyaltyPolicyLAP address
+    /// @custom:oz-upgrades-unsafe-allow state-variable-immutable
+    IGraphAwareRoyaltyPolicy public immutable ROYALTY_POLICY_LAP;
+
     /// @notice IPGraphACL address
     /// @custom:oz-upgrades-unsafe-allow state-variable-immutable
     IPGraphACL public immutable IP_GRAPH_ACL;
@@ -78,13 +82,16 @@ contract RoyaltyPolicyLRP is
 
     /// @notice Constructor
     /// @param royaltyModule The RoyaltyModule address
+    /// @param royaltyPolicyLAP The RoyaltyPolicyLAP address
     /// @param ipGraphAcl The IPGraphACL address
     /// @custom:oz-upgrades-unsafe-allow constructor
-    constructor(address royaltyModule, address ipGraphAcl) {
+    constructor(address royaltyModule, address royaltyPolicyLAP, address ipGraphAcl) {
         if (royaltyModule == address(0)) revert Errors.RoyaltyPolicyLRP__ZeroRoyaltyModule();
+        if (royaltyPolicyLAP == address(0)) revert Errors.RoyaltyPolicyLRP__ZeroRoyaltyPolicyLAP();
         if (ipGraphAcl == address(0)) revert Errors.RoyaltyPolicyLRP__ZeroIPGraphACL();
 
         ROYALTY_MODULE = IRoyaltyModule(royaltyModule);
+        ROYALTY_POLICY_LAP = IGraphAwareRoyaltyPolicy(royaltyPolicyLAP);
         IP_GRAPH_ACL = IPGraphACL(ipGraphAcl);
 
         _disableInitializers();
@@ -108,8 +115,7 @@ contract RoyaltyPolicyLRP is
         uint32 licensePercent,
         bytes calldata
     ) external onlyRoyaltyModule nonReentrant {
-        IRoyaltyModule royaltyModule = ROYALTY_MODULE;
-        if (royaltyModule.globalRoyaltyStack(ipId) + licensePercent > royaltyModule.maxPercent())
+        if (ROYALTY_POLICY_LAP.getPolicyRoyaltyStack(ipId) + licensePercent > ROYALTY_MODULE.maxPercent())
             revert Errors.RoyaltyPolicyLRP__AboveMaxPercent();
     }
 

--- a/script/foundry/utils/DeployHelper.sol
+++ b/script/foundry/utils/DeployHelper.sol
@@ -567,6 +567,7 @@ contract DeployHelper is Script, BroadcastManager, JsonDeploymentHandler, Storag
         _predeploy("RoyaltyPolicyLRP");
         impl = address(new RoyaltyPolicyLRP(
             address(royaltyModule),
+            address(royaltyPolicyLAP),
             newDeployedIpGraphACL ? _getDeployedAddress(type(IPGraphACL).name) : address(ipGraphACL)
         ));
         royaltyPolicyLRP = RoyaltyPolicyLRP(

--- a/test/foundry/modules/royalty/LRP/RoyaltyPolicyLRP.t.sol
+++ b/test/foundry/modules/royalty/LRP/RoyaltyPolicyLRP.t.sol
@@ -105,21 +105,26 @@ contract TestRoyaltyPolicyLRP is BaseTest {
 
     function test_RoyaltyPolicyLRP_constructor_revert_ZeroRoyaltyModule() public {
         vm.expectRevert(Errors.RoyaltyPolicyLRP__ZeroRoyaltyModule.selector);
-        new RoyaltyPolicyLRP(address(0), address(ipGraphACL));
+        new RoyaltyPolicyLRP(address(0), address(royaltyPolicyLAP), address(ipGraphACL));
+    }
+
+    function test_RoyaltyPolicyLRP_constructor_revert_ZeroRoyaltyPolicyLAP() public {
+        vm.expectRevert(Errors.RoyaltyPolicyLRP__ZeroRoyaltyPolicyLAP.selector);
+        new RoyaltyPolicyLRP(address(royaltyModule), address(0), address(ipGraphACL));
     }
 
     function test_RoyaltyPolicyLRP_constructor_revert_ZeroIPGraphACL() public {
         vm.expectRevert(Errors.RoyaltyPolicyLRP__ZeroIPGraphACL.selector);
-        new RoyaltyPolicyLRP(address(royaltyModule), address(0));
+        new RoyaltyPolicyLRP(address(royaltyModule), address(royaltyPolicyLAP), address(0));
     }
 
     function test_RoyaltyPolicyLRP_constructor() public {
-        testRoyaltyPolicyLRP = new RoyaltyPolicyLRP(address(royaltyModule), address(ipGraphACL));
+        testRoyaltyPolicyLRP = new RoyaltyPolicyLRP(address(royaltyModule), address(royaltyPolicyLAP), address(ipGraphACL));
         assertEq(address(testRoyaltyPolicyLRP.ROYALTY_MODULE()), address(royaltyModule));
     }
 
     function test_RoyaltyPolicyLRP_initialize_revert_ZeroAccessManager() public {
-        address impl = address(new RoyaltyPolicyLRP(address(royaltyModule), address(ipGraphACL)));
+        address impl = address(new RoyaltyPolicyLRP(address(royaltyModule), address(royaltyPolicyLAP), address(ipGraphACL)));
         vm.expectRevert(Errors.RoyaltyPolicyLRP__ZeroAccessManager.selector);
         RoyaltyPolicyLRP(
             TestProxyHelper.deployUUPSProxy(impl, abi.encodeCall(RoyaltyPolicyLRP.initialize, (address(0))))

--- a/test/foundry/modules/royalty/LRP/RoyaltyPolicyLRP.t.sol
+++ b/test/foundry/modules/royalty/LRP/RoyaltyPolicyLRP.t.sol
@@ -119,12 +119,18 @@ contract TestRoyaltyPolicyLRP is BaseTest {
     }
 
     function test_RoyaltyPolicyLRP_constructor() public {
-        testRoyaltyPolicyLRP = new RoyaltyPolicyLRP(address(royaltyModule), address(royaltyPolicyLAP), address(ipGraphACL));
+        testRoyaltyPolicyLRP = new RoyaltyPolicyLRP(
+            address(royaltyModule),
+            address(royaltyPolicyLAP),
+            address(ipGraphACL)
+        );
         assertEq(address(testRoyaltyPolicyLRP.ROYALTY_MODULE()), address(royaltyModule));
     }
 
     function test_RoyaltyPolicyLRP_initialize_revert_ZeroAccessManager() public {
-        address impl = address(new RoyaltyPolicyLRP(address(royaltyModule), address(royaltyPolicyLAP), address(ipGraphACL)));
+        address impl = address(
+            new RoyaltyPolicyLRP(address(royaltyModule), address(royaltyPolicyLAP), address(ipGraphACL))
+        );
         vm.expectRevert(Errors.RoyaltyPolicyLRP__ZeroAccessManager.selector);
         RoyaltyPolicyLRP(
             TestProxyHelper.deployUUPSProxy(impl, abi.encodeCall(RoyaltyPolicyLRP.initialize, (address(0))))


### PR DESCRIPTION
## Description
Fixes the LRP royalty policy minting restriction to not include LRP royalty stack given it's not necessary.