### PR TITLE
Propagate dispute tags with parent arbitration policy

### DIFF
--- a/contracts/modules/dispute/DisputeModule.sol
+++ b/contracts/modules/dispute/DisputeModule.sol
@@ -290,16 +290,13 @@ contract DisputeModule is
         Dispute memory parentDispute = $.disputes[parentDisputeId];
         if (parentDispute.targetIpId != parentIpId) revert Errors.DisputeModule__ParentIpIdMismatch();
 
-        // a dispute current tag prior to being resolved can be in 3 states:
+        // a dispute current tag can be in 3 states:
         // IN_DISPUTE, 0, or a tag (ie. "IMPROPER_REGISTRATION")
-        // by restricting IN_DISPUTE and 0 - it is ensured the parent has been tagged before resolving dispute
+        // by restricting IN_DISPUTE and 0 - it is ensured the parent has been tagged before tagging the derivative
         if (parentDispute.currentTag == IN_DISPUTE || parentDispute.currentTag == bytes32(0))
             revert Errors.DisputeModule__ParentNotTagged();
 
         if (!LICENSE_REGISTRY.isParentIp(parentIpId, derivativeIpId)) revert Errors.DisputeModule__NotDerivative();
-
-        address arbitrationPolicy = $.arbitrationPolicies[derivativeIpId];
-        if (!$.isWhitelistedArbitrationPolicy[arbitrationPolicy]) arbitrationPolicy = $.baseArbitrationPolicy;
 
         uint256 disputeId = ++$.disputeCounter;
         uint256 disputeTimestamp = block.timestamp;
@@ -308,7 +305,7 @@ contract DisputeModule is
             targetIpId: derivativeIpId,
             disputeInitiator: msg.sender,
             disputeTimestamp: disputeTimestamp,
-            arbitrationPolicy: arbitrationPolicy,
+            arbitrationPolicy: parentDispute.arbitrationPolicy,
             disputeEvidenceHash: "",
             targetTag: parentDispute.currentTag,
             currentTag: parentDispute.currentTag,

--- a/test/foundry/modules/dispute/DisputeModule.t.sol
+++ b/test/foundry/modules/dispute/DisputeModule.t.sol
@@ -565,7 +565,7 @@ contract DisputeModuleTest is BaseTest {
         assertEq(licenseRegistry.isParentIp(ipAddr, ipAddr2), true);
 
         // child ip changes arbitration policy
-        vm.startPrank(address(1));
+        vm.startPrank(address(ipAddr2));
         disputeModule.setArbitrationPolicy(ipAddr2, address(mockArbitrationPolicy2));
         vm.warp(block.timestamp + disputeModule.arbitrationPolicyCooldown() + 1);
         disputeModule.updateActiveArbitrationPolicy(ipAddr2);

--- a/test/foundry/modules/dispute/DisputeModule.t.sol
+++ b/test/foundry/modules/dispute/DisputeModule.t.sol
@@ -564,6 +564,14 @@ contract DisputeModuleTest is BaseTest {
 
         assertEq(licenseRegistry.isParentIp(ipAddr, ipAddr2), true);
 
+        // child ip changes arbitration policy
+        vm.startPrank(address(1));
+        disputeModule.setArbitrationPolicy(ipAddr2, address(mockArbitrationPolicy2));
+        vm.warp(block.timestamp + disputeModule.arbitrationPolicyCooldown() + 1);
+        disputeModule.updateActiveArbitrationPolicy(ipAddr2);
+        assertEq(disputeModule.arbitrationPolicies(ipAddr2), address(mockArbitrationPolicy2));
+        vm.stopPrank();
+
         // tag child ip
         vm.startPrank(address(1));
         vm.expectEmit(true, true, true, true, address(disputeModule));

--- a/test/foundry/modules/dispute/policies/UMA/ArbitrationPolicyUMA.t.sol
+++ b/test/foundry/modules/dispute/policies/UMA/ArbitrationPolicyUMA.t.sol
@@ -42,13 +42,13 @@ contract ArbitrationPolicyUMATest is BaseTest {
 
     function setUp() public virtual override {
         // Fork the desired network where UMA contracts are deployed
-        uint256 forkId = vm.createFork("https://testnet.storyrpc.io");
+        uint256 forkId = vm.createFork("https://odyssey.storyrpc.io/");
         vm.selectFork(forkId);
 
-        // Illiad chain 1513
+        // Odyssey testnet
         newOOV3 = 0x3CA11702f7c0F28e0b4e03C31F7492969862C569;
         mockAncillary = 0x3baD7AD0728f9917d1Bf08af5782dCbD516cDd96;
-        susd = 0x91f6F05B08c16769d3c85867548615d270C42fC7;
+        susd = 0xC0F6E387aC0B324Ec18EAcf22EE7271207dCE3d5;
 
         // deploy mock ip asset registry
         mockIpAssetRegistry = new MockIpAssetRegistry();


### PR DESCRIPTION
## Description
When propagating a dispute tag to derivatives - with this change - the dispute created in `tagDerivativeIfParentInfringed` now uses the same arbitration policy as the original dispute that is being propagated.