### PR TITLE
Add _updateActiveArbitrationPolicy() is setArbitrationPolicy()

### DIFF
--- a/contracts/modules/dispute/DisputeModule.sol
+++ b/contracts/modules/dispute/DisputeModule.sol
@@ -173,6 +173,10 @@ contract DisputeModule is
         if (!$.isWhitelistedArbitrationPolicy[nextArbitrationPolicy])
             revert Errors.DisputeModule__NotWhitelistedArbitrationPolicy();
 
+        // if applicable updates the active arbitration policy to the queued arbitration policy
+        // before setting the new next arbitration policy
+        _updateActiveArbitrationPolicy(ipId);
+
         $.nextArbitrationPolicies[ipId] = nextArbitrationPolicy;
 
         uint256 nextArbitrationUpdateTimestamp = block.timestamp + $.arbitrationPolicyCooldown;


### PR DESCRIPTION
## Description
Adds `updateActiveArbitrationPolicy()` call to `setArbitrationPolicy()` to update the arbitration policy for an IP in case there is an existing queued arbitration policy with cooldown time that has passed.