### PR TITLE
Adds ERC165 check for external royalty policy registration

### DIFF
--- a/contracts/interfaces/modules/royalty/policies/IExternalRoyaltyPolicy.sol
+++ b/contracts/interfaces/modules/royalty/policies/IExternalRoyaltyPolicy.sol
@@ -1,11 +1,8 @@
 // SPDX-License-Identifier: BUSL-1.1
 pragma solidity 0.8.26;
 
+import { IERC165 } from "@openzeppelin/contracts/utils/introspection/IERC165.sol";
+import { IExternalRoyaltyPolicyBase } from "./IExternalRoyaltyPolicyBase.sol";
+
 /// @title IExternalRoyaltyPolicy interface
-interface IExternalRoyaltyPolicy {
-    /// @notice Returns the amount of royalty tokens required to link a child to a given IP asset
-    /// @param ipId The ipId of the IP asset
-    /// @param licensePercent The percentage of the license
-    /// @return The amount of royalty tokens required to link a child to a given IP asset
-    function getPolicyRtsRequiredToLink(address ipId, uint32 licensePercent) external view returns (uint32);
-}
+interface IExternalRoyaltyPolicy is IExternalRoyaltyPolicyBase, IERC165 {}

--- a/contracts/interfaces/modules/royalty/policies/IExternalRoyaltyPolicyBase.sol
+++ b/contracts/interfaces/modules/royalty/policies/IExternalRoyaltyPolicyBase.sol
@@ -1,0 +1,11 @@
+// SPDX-License-Identifier: BUSL-1.1
+pragma solidity 0.8.26;
+
+/// @title IExternalRoyaltyPolicyBase interface
+interface IExternalRoyaltyPolicyBase {
+    /// @notice Returns the amount of royalty tokens required to link a child to a given IP asset
+    /// @param ipId The ipId of the IP asset
+    /// @param licensePercent The percentage of the license
+    /// @return The amount of royalty tokens required to link a child to a given IP asset
+    function getPolicyRtsRequiredToLink(address ipId, uint32 licensePercent) external view returns (uint32);
+}

--- a/contracts/interfaces/modules/royalty/policies/IRoyaltyPolicy.sol
+++ b/contracts/interfaces/modules/royalty/policies/IRoyaltyPolicy.sol
@@ -1,10 +1,10 @@
 // SPDX-License-Identifier: BUSL-1.1
 pragma solidity 0.8.26;
 
-import { IExternalRoyaltyPolicy } from "./IExternalRoyaltyPolicy.sol";
+import { IExternalRoyaltyPolicyBase } from "./IExternalRoyaltyPolicyBase.sol";
 
 /// @title RoyaltyPolicy interface
-interface IRoyaltyPolicy is IExternalRoyaltyPolicy {
+interface IRoyaltyPolicy is IExternalRoyaltyPolicyBase {
     /// @notice Executes royalty related logic on minting a license
     /// @dev Enforced to be only callable by RoyaltyModule
     /// @param ipId The ipId whose license is being minted (licensor)

--- a/contracts/lib/Errors.sol
+++ b/contracts/lib/Errors.sol
@@ -616,6 +616,9 @@ library Errors {
     /// @notice IP is expired.
     error RoyaltyModule__IpExpired();
 
+    /// @notice Invalid external royalty policy.
+    error RoyaltyModule__InvalidExternalRoyaltyPolicy();
+
     ////////////////////////////////////////////////////////////////////////////
     //                            Royalty Policy LAP                          //
     ////////////////////////////////////////////////////////////////////////////

--- a/test/foundry/mocks/policy/MockExternalRoyaltyPolicy1.sol
+++ b/test/foundry/mocks/policy/MockExternalRoyaltyPolicy1.sol
@@ -1,11 +1,18 @@
 // SPDX-License-Identifier: BUSL-1.1
 pragma solidity 0.8.26;
 
+import { IERC165, ERC165 } from "@openzeppelin/contracts/utils/introspection/ERC165.sol";
+
 // solhint-disable-next-line max-line-length
 import { IExternalRoyaltyPolicy } from "../../../../contracts/interfaces/modules/royalty/policies/IExternalRoyaltyPolicy.sol";
 
-contract MockExternalRoyaltyPolicy1 is IExternalRoyaltyPolicy {
+contract MockExternalRoyaltyPolicy1 is ERC165, IExternalRoyaltyPolicy {
     function getPolicyRtsRequiredToLink(address ipId, uint32 licensePercent) external view returns (uint32) {
         return licensePercent * 2;
+    }
+
+    /// @notice IERC165 interface support
+    function supportsInterface(bytes4 interfaceId) public override(ERC165, IERC165) view returns (bool) {
+        return interfaceId == this.getPolicyRtsRequiredToLink.selector || super.supportsInterface(interfaceId);
     }
 }

--- a/test/foundry/mocks/policy/MockExternalRoyaltyPolicy1.sol
+++ b/test/foundry/mocks/policy/MockExternalRoyaltyPolicy1.sol
@@ -12,7 +12,7 @@ contract MockExternalRoyaltyPolicy1 is ERC165, IExternalRoyaltyPolicy {
     }
 
     /// @notice IERC165 interface support
-    function supportsInterface(bytes4 interfaceId) public override(ERC165, IERC165) view returns (bool) {
+    function supportsInterface(bytes4 interfaceId) public view override(ERC165, IERC165) returns (bool) {
         return interfaceId == this.getPolicyRtsRequiredToLink.selector || super.supportsInterface(interfaceId);
     }
 }

--- a/test/foundry/mocks/policy/MockExternalRoyaltyPolicy2.sol
+++ b/test/foundry/mocks/policy/MockExternalRoyaltyPolicy2.sol
@@ -12,7 +12,7 @@ contract MockExternalRoyaltyPolicy2 is ERC165, IExternalRoyaltyPolicy {
     }
 
     /// @notice IERC165 interface support
-    function supportsInterface(bytes4 interfaceId) public override(ERC165, IERC165) view returns (bool) {
+    function supportsInterface(bytes4 interfaceId) public view override(ERC165, IERC165) returns (bool) {
         return interfaceId == this.getPolicyRtsRequiredToLink.selector || super.supportsInterface(interfaceId);
     }
 }

--- a/test/foundry/mocks/policy/MockExternalRoyaltyPolicy2.sol
+++ b/test/foundry/mocks/policy/MockExternalRoyaltyPolicy2.sol
@@ -1,11 +1,18 @@
 // SPDX-License-Identifier: BUSL-1.1
 pragma solidity 0.8.26;
 
+import { IERC165, ERC165 } from "@openzeppelin/contracts/utils/introspection/ERC165.sol";
+
 // solhint-disable-next-line max-line-length
 import { IExternalRoyaltyPolicy } from "../../../../contracts/interfaces/modules/royalty/policies/IExternalRoyaltyPolicy.sol";
 
-contract MockExternalRoyaltyPolicy2 is IExternalRoyaltyPolicy {
+contract MockExternalRoyaltyPolicy2 is ERC165, IExternalRoyaltyPolicy {
     function getPolicyRtsRequiredToLink(address ipId, uint32 licensePercent) external view returns (uint32) {
         return 10 * 10 ** 6;
+    }
+
+    /// @notice IERC165 interface support
+    function supportsInterface(bytes4 interfaceId) public override(ERC165, IERC165) view returns (bool) {
+        return interfaceId == this.getPolicyRtsRequiredToLink.selector || super.supportsInterface(interfaceId);
     }
 }

--- a/test/foundry/modules/royalty/RoyaltyModule.t.sol
+++ b/test/foundry/modules/royalty/RoyaltyModule.t.sol
@@ -380,6 +380,11 @@ contract TestRoyaltyModule is BaseTest {
         royaltyModule.registerExternalRoyaltyPolicy(address(royaltyPolicyLAP));
     }
 
+    function test_RoyaltyModule_registerExternalRoyaltyPolicy_revert_InvalidExternalRoyaltyPolicy() public {
+        vm.expectRevert(Errors.RoyaltyModule__InvalidExternalRoyaltyPolicy.selector);
+        royaltyModule.registerExternalRoyaltyPolicy(address(1));
+    }
+
     function test_RoyaltyModule_registerExternalRoyaltyPolicy() public {
         address externalRoyaltyPolicy = address(new MockExternalRoyaltyPolicy1());
         assertEq(royaltyModule.isRegisteredExternalRoyaltyPolicy(externalRoyaltyPolicy), false);


### PR DESCRIPTION
## Description
Adds ERC165 for external royalty policy registration to check if it implements the function `getPolicyRtsRequiredToLink` - check is made via the function selector.