### PR TITLE
Fixer mixer

### DIFF
--- a/contracts/interfaces/modules/base/IViewModule.sol
+++ b/contracts/interfaces/modules/base/IViewModule.sol
@@ -10,7 +10,7 @@ import { IModule } from "./IModule.sol";
 /// they can display simple/base/core metadata, book specific metadata, license details metadata,
 /// or even IP graph data for the same IPAccount using different View Modules.
 /// This module offers flexibility in selecting which data to display and how to present it.
-/// @dev View Module can read data from IPAccount and from multiple namesapces to combine data for display.
+/// @dev View Module can read data from IPAccount and from multiple namespaces to combine data for display.
 interface IViewModule is IModule {
     /// @notice check whether the view module is supported for the given IP account
     function isSupported(address ipAccount) external returns (bool);

--- a/contracts/interfaces/registries/ILicenseRegistry.sol
+++ b/contracts/interfaces/registries/ILicenseRegistry.sol
@@ -163,7 +163,7 @@ interface ILicenseRegistry {
 
     /// @notice Gets the count of parent IPs.
     /// @param childIpId The address of the childIP.
-    /// @return The count o parent IPs.
+    /// @return The count of parent IPs.
     function getParentIpCount(address childIpId) external view returns (uint256);
 
     /// @notice Retrieves the minting license configuration for a given license terms of the IP.

--- a/contracts/lib/AccessPermission.sol
+++ b/contracts/lib/AccessPermission.sol
@@ -5,7 +5,7 @@ pragma solidity 0.8.26;
 /// @notice Library for IPAccount access control permissions.
 ///         These permissions are used by the AccessController.
 library AccessPermission {
-    /// @notice ABSTAIN means having not enough information to make decision at current level, deferred decision to up
+    /// @notice ABSTAIN means not having enough information to make a decision at the current level, the deferred decision to up
     /// level permission.
     uint8 public constant ABSTAIN = 0;
 

--- a/contracts/lib/Errors.sol
+++ b/contracts/lib/Errors.sol
@@ -109,7 +109,7 @@ library Errors {
     /// @notice The group ip has derivative IPs.
     error GroupingModule__GroupFrozenDueToHasDerivativeIps(address groupId);
 
-    /// @notice The group ip has no attached any license terms.
+    /// @notice The group ip has not attached any license terms.
     error GroupingModule__GroupIPHasNoLicenseTerms(address groupId);
 
     /// @notice The Royalty Vault has not been created.
@@ -384,7 +384,7 @@ library Errors {
         address licensorIpId
     );
 
-    /// @notice Licensing hook is invalid either not support ILicensingHook interface or not registered as module
+    /// @notice Licensing hook is invalid either does not support ILicensingHook interface or not registered as module
     error LicensingModule__InvalidLicensingHook(address hook);
 
     /// @notice The license terms ID is invalid or license template doesn't exist.
@@ -574,7 +574,7 @@ library Errors {
     /// @notice Parent IP list for linking is empty.
     error RoyaltyModule__NoParentsOnLinking();
 
-    /// @notice IP is dipute tagged.
+    /// @notice IP is dispute tagged.
     error RoyaltyModule__IpIsTagged();
 
     /// @notice Last position IP is not able to mint more licenses.
@@ -767,7 +767,7 @@ library Errors {
     /// @notice Provided module name is empty string.
     error ModuleRegistry__NameEmptyString();
 
-    /// @notice Provided module name is already regsitered.
+    /// @notice Provided module name is already registered.
     error ModuleRegistry__NameAlreadyRegistered();
 
     /// @notice Module name does not match the given name.


### PR DESCRIPTION
## Description
This pull request addresses several minor typos across multiple files in the project. It includes:

1. **IViewModule.sol**: Corrected a typo in the `namesapces` comment to `namespaces`.
2. **ILicenseRegistry.sol**: Fixed a typo in the return description `count o parent IPs` to `count of parent IPs`.
3. **AccessPermission.sol**: Adjusted phrasing in a comment from `having not enough information` to `not having enough information` for better readability.
4. **Errors.sol**: Corrected multiple typos in comments, including:
   - `has no attached any license terms` -> `has not attached any license terms`
   - `Licensing hook is invalid either not support` -> `Licensing hook is invalid either does not support`
   - `IP is dipute tagged` -> `IP is dispute tagged`
   - `module name is already regsitered` -> `module name is already registered`

---

## Test Plan
To verify the changes:

1. Review the corrected comments to ensure grammatical and typographical accuracy.
2. Validate that no functional changes were made to the codebase.
3. Confirm through linting or automated tests that no unintended errors are introduced due to these corrections.

---

## Related Issue
None explicitly reported, but this PR improves overall code quality by resolving minor documentation errors.

---

## Notes
- These changes are focused on improving readability and reducing ambiguity in code documentation.
- No functional code was modified.

---

### Allow Edits by Maintainers
✔️ Yes