### PR TITLE
Fix nonReentrant modifier order

### DIFF
--- a/contracts/modules/dispute/policies/UMA/ArbitrationPolicyUMA.sol
+++ b/contracts/modules/dispute/policies/UMA/ArbitrationPolicyUMA.sol
@@ -124,7 +124,7 @@ contract ArbitrationPolicyUMA is
     /// @dev Enforced to be only callable by the DisputeModule
     /// @param caller Address of the caller
     /// @param data The arbitrary data used to raise the dispute
-    function onRaiseDispute(address caller, bytes calldata data) external onlyDisputeModule nonReentrant whenNotPaused {
+    function onRaiseDispute(address caller, bytes calldata data) external nonReentrant onlyDisputeModule whenNotPaused {
         (bytes memory claim, uint64 liveness, address currency, uint256 bond, bytes32 identifier) = abi.decode(
             data,
             (bytes, uint64, address, uint256, bytes32)

--- a/contracts/modules/licensing/LicensingModule.sol
+++ b/contracts/modules/licensing/LicensingModule.sol
@@ -165,7 +165,7 @@ contract LicensingModule is
         address receiver,
         bytes calldata royaltyContext,
         uint256 maxMintingFee
-    ) external whenNotPaused nonReentrant returns (uint256 startLicenseTokenId) {
+    ) external nonReentrant whenNotPaused returns (uint256 startLicenseTokenId) {
         if (amount == 0) {
             revert Errors.LicensingModule__MintAmountZero();
         }
@@ -256,7 +256,7 @@ contract LicensingModule is
         bytes calldata royaltyContext,
         uint256 maxMintingFee,
         uint32 maxRts
-    ) external whenNotPaused nonReentrant verifyPermission(childIpId) {
+    ) external nonReentrant whenNotPaused verifyPermission(childIpId) {
         if (parentIpIds.length != licenseTermsIds.length) {
             revert Errors.LicensingModule__LicenseTermsLengthMismatch(parentIpIds.length, licenseTermsIds.length);
         }

--- a/contracts/modules/royalty/policies/LAP/RoyaltyPolicyLAP.sol
+++ b/contracts/modules/royalty/policies/LAP/RoyaltyPolicyLAP.sol
@@ -86,7 +86,7 @@ contract RoyaltyPolicyLAP is
         address ipId,
         uint32 licensePercent,
         bytes calldata
-    ) external onlyRoyaltyModule nonReentrant {
+    ) external nonReentrant onlyRoyaltyModule {
         IRoyaltyModule royaltyModule = ROYALTY_MODULE;
         if (royaltyModule.globalRoyaltyStack(ipId) + licensePercent > royaltyModule.maxPercent())
             revert Errors.RoyaltyPolicyLAP__AboveMaxPercent();
@@ -104,7 +104,7 @@ contract RoyaltyPolicyLAP is
         address[] memory licenseRoyaltyPolicies,
         uint32[] calldata licensesPercent,
         bytes calldata
-    ) external onlyRoyaltyModule nonReentrant returns (uint32 newRoyaltyStackLAP) {
+    ) external nonReentrant onlyRoyaltyModule returns (uint32 newRoyaltyStackLAP) {
         IP_GRAPH_ACL.allow();
         for (uint256 i = 0; i < parentIpIds.length; i++) {
             // when a parent is linking through a different royalty policy, the royalty amount is zero

--- a/contracts/modules/royalty/policies/LRP/RoyaltyPolicyLRP.sol
+++ b/contracts/modules/royalty/policies/LRP/RoyaltyPolicyLRP.sol
@@ -114,7 +114,7 @@ contract RoyaltyPolicyLRP is
         address ipId,
         uint32 licensePercent,
         bytes calldata
-    ) external onlyRoyaltyModule nonReentrant {
+    ) external nonReentrant onlyRoyaltyModule {
         if (ROYALTY_POLICY_LAP.getPolicyRoyaltyStack(ipId) + licensePercent > ROYALTY_MODULE.maxPercent())
             revert Errors.RoyaltyPolicyLRP__AboveMaxPercent();
     }
@@ -131,7 +131,7 @@ contract RoyaltyPolicyLRP is
         address[] memory licenseRoyaltyPolicies,
         uint32[] calldata licensesPercent,
         bytes calldata
-    ) external onlyRoyaltyModule nonReentrant returns (uint32 newRoyaltyStackLRP) {
+    ) external nonReentrant onlyRoyaltyModule returns (uint32 newRoyaltyStackLRP) {
         IP_GRAPH_ACL.allow();
         for (uint256 i = 0; i < parentIpIds.length; i++) {
             // when a parent is linking through a different royalty policy, the royalty amount is zero


### PR DESCRIPTION
## Description
Fix to ensure that when used - the nonReentrant modifier - is the first modifier as it's the best practice.