### PR TITLE
Prevent Duplicate Parent IPs When Registering Derivative IP

### DIFF
--- a/contracts/lib/Errors.sol
+++ b/contracts/lib/Errors.sol
@@ -249,9 +249,6 @@ library Errors {
     /// @notice Provided license template does not match the IP's current license template.
     error LicenseRegistry__UnmatchedLicenseTemplate(address ipId, address licenseTemplate, address newLicenseTemplate);
 
-    /// @notice Provided license template and terms ID is a duplicate.
-    error LicenseRegistry__DuplicateLicense(address ipId, address licenseTemplate, uint256 licenseTermsId);
-
     /// @notice Zero address provided for License Template.
     error LicenseRegistry__ZeroLicenseTemplate();
 

--- a/contracts/lib/Errors.sol
+++ b/contracts/lib/Errors.sol
@@ -283,6 +283,9 @@ library Errors {
     /// @notice The IP has no attached the same license terms of Group IPA.
     error LicenseRegistry__IpHasNoGroupLicenseTerms(address groupId, address licenseTemplate, uint256 licenseTermsId);
 
+    /// @notice The IP has already linked to the same parent IP.
+    error LicenseRegistry__DuplicateParentIp(address ipId, address parentIpId);
+
     /// @notice When Set LicenseConfig the license template cannot be Zero address if royalty percentage is not Zero.
     error LicensingModule__LicenseTemplateCannotBeZeroAddressToOverrideRoyaltyPercent();
 

--- a/contracts/registries/LicenseRegistry.sol
+++ b/contracts/registries/LicenseRegistry.sol
@@ -249,12 +249,12 @@ contract LicenseRegistry is ILicenseRegistry, AccessManagedUpgradeable, UUPSUpgr
                 isUsingLicenseToken
             );
             $.childIps[parentIpIds[i]].add(childIpId);
-            // determine if duplicate license terms
+            // determine if duplicate parent IP
             bool isNewParent = $.parentIps[childIpId].add(parentIpIds[i]);
-            bool isNewTerms = $.attachedLicenseTerms[childIpId].add(licenseTermsIds[i]);
-            if (!isNewParent && !isNewTerms) {
-                revert Errors.LicenseRegistry__DuplicateLicense(parentIpIds[i], licenseTemplate, licenseTermsIds[i]);
+            if (!isNewParent) {
+                revert Errors.LicenseRegistry__DuplicateParentIp(childIpId, parentIpIds[i]);
             }
+            $.attachedLicenseTerms[childIpId].add(licenseTermsIds[i]);
             // link child IP to parent IP with license terms
             $.parentLicenseTerms[childIpId][parentIpIds[i]] = licenseTermsIds[i];
         }

--- a/test/foundry/integration/flows/royalty/Royalty.t.sol
+++ b/test/foundry/integration/flows/royalty/Royalty.t.sol
@@ -89,11 +89,7 @@ contract Flows_Integration_Disputes is BaseIntegration {
             ipAcct[2] = registerIpAccount(address(mockNFT), 2, u.bob);
 
             vm.expectRevert(
-                abi.encodeWithSelector(
-                    Errors.LicenseRegistry__DuplicateParentIp.selector,
-                    ipAcct[2],
-                    ipAcct[1]
-                )
+                abi.encodeWithSelector(Errors.LicenseRegistry__DuplicateParentIp.selector, ipAcct[2], ipAcct[1])
             );
             licensingModule.registerDerivativeWithLicenseTokens(ipAcct[2], licenseIds, "", 100e6);
 

--- a/test/foundry/integration/flows/royalty/Royalty.t.sol
+++ b/test/foundry/integration/flows/royalty/Royalty.t.sol
@@ -90,10 +90,9 @@ contract Flows_Integration_Disputes is BaseIntegration {
 
             vm.expectRevert(
                 abi.encodeWithSelector(
-                    Errors.LicenseRegistry__DuplicateLicense.selector,
-                    ipAcct[1],
-                    address(pilTemplate),
-                    commRemixTermsId
+                    Errors.LicenseRegistry__DuplicateParentIp.selector,
+                    ipAcct[2],
+                    ipAcct[1]
                 )
             );
             licensingModule.registerDerivativeWithLicenseTokens(ipAcct[2], licenseIds, "", 100e6);

--- a/test/foundry/registries/LicenseRegistry.t.sol
+++ b/test/foundry/registries/LicenseRegistry.t.sol
@@ -409,8 +409,18 @@ contract LicenseRegistryTest is BaseTest {
         });
     }
 
-    function test_LicenseRegistry_registerDerivativeIp_revert_DuplicateLicense() public {
+    function test_LicenseRegistry_registerDerivativeIp_revert_DuplicateParents() public {
         uint256 socialRemixTermsId = pilTemplate.registerLicenseTerms(PILFlavors.nonCommercialSocialRemixing());
+        uint256 commRemixTermsId = pilTemplate.registerLicenseTerms(PILFlavors.commercialRemix(
+            0,
+            10,
+            address(royaltyPolicyLAP),
+            address(erc20)
+        ));
+
+        vm.prank(ipOwner[1]);
+        licensingModule.attachLicenseTerms(ipAcct[1], address(pilTemplate), commRemixTermsId);
+
         vm.prank(ipOwner[1]);
         vm.expectRevert(
             abi.encodeWithSelector(
@@ -427,13 +437,12 @@ contract LicenseRegistryTest is BaseTest {
         parentIpIds[1] = ipAcct[1];
         uint256[] memory licenseTermsIds = new uint256[](2);
         licenseTermsIds[0] = socialRemixTermsId;
-        licenseTermsIds[1] = socialRemixTermsId;
+        licenseTermsIds[1] = commRemixTermsId;
         vm.expectRevert(
             abi.encodeWithSelector(
-                Errors.LicenseRegistry__DuplicateLicense.selector,
-                ipAcct[1],
-                address(pilTemplate),
-                socialRemixTermsId
+                Errors.LicenseRegistry__DuplicateParentIp.selector,
+                ipAcct[2],
+                ipAcct[1]
             )
         );
         vm.prank(address(licensingModule));

--- a/test/foundry/registries/LicenseRegistry.t.sol
+++ b/test/foundry/registries/LicenseRegistry.t.sol
@@ -411,12 +411,9 @@ contract LicenseRegistryTest is BaseTest {
 
     function test_LicenseRegistry_registerDerivativeIp_revert_DuplicateParents() public {
         uint256 socialRemixTermsId = pilTemplate.registerLicenseTerms(PILFlavors.nonCommercialSocialRemixing());
-        uint256 commRemixTermsId = pilTemplate.registerLicenseTerms(PILFlavors.commercialRemix(
-            0,
-            10,
-            address(royaltyPolicyLAP),
-            address(erc20)
-        ));
+        uint256 commRemixTermsId = pilTemplate.registerLicenseTerms(
+            PILFlavors.commercialRemix(0, 10, address(royaltyPolicyLAP), address(erc20))
+        );
 
         vm.prank(ipOwner[1]);
         licensingModule.attachLicenseTerms(ipAcct[1], address(pilTemplate), commRemixTermsId);
@@ -439,11 +436,7 @@ contract LicenseRegistryTest is BaseTest {
         licenseTermsIds[0] = socialRemixTermsId;
         licenseTermsIds[1] = commRemixTermsId;
         vm.expectRevert(
-            abi.encodeWithSelector(
-                Errors.LicenseRegistry__DuplicateParentIp.selector,
-                ipAcct[2],
-                ipAcct[1]
-            )
+            abi.encodeWithSelector(Errors.LicenseRegistry__DuplicateParentIp.selector, ipAcct[2], ipAcct[1])
         );
         vm.prank(address(licensingModule));
         licenseRegistry.registerDerivativeIp({


### PR DESCRIPTION
## Description
This PR introduces a check to prevent derivative IPs from being linked to the same parent IPs when registering derivatives. It ensures that there are no duplicate parent IPs passed in when registering a derivative with multiple parents.

## Key Changes

- **Duplicate Parent IP Check**: Added logic to verify that there are no duplicate parent IPs when registering a derivative IP.

Closes https://github.com/storyprotocol/trust-protocol-contracts-v1/issues/14