### PR TITLE
Change to only 1 relayer address per arbitration policy

### DIFF
--- a/contracts/interfaces/modules/dispute/IDisputeModule.sol
+++ b/contracts/interfaces/modules/dispute/IDisputeModule.sol
@@ -33,11 +33,10 @@ interface IDisputeModule {
     /// @param allowed Indicates if the arbitration policy is whitelisted
     event ArbitrationPolicyWhitelistUpdated(address arbitrationPolicy, bool allowed);
 
-    /// @notice Event emitted when an arbitration relayer whitelist status is updated
+    /// @notice Event emitted when an arbitration relayer address is updated
     /// @param arbitrationPolicy The address of the arbitration policy
     /// @param arbitrationRelayer The address of the arbitration relayer
-    /// @param allowed Indicates if the arbitration relayer is whitelisted
-    event ArbitrationRelayerWhitelistUpdated(address arbitrationPolicy, address arbitrationRelayer, bool allowed);
+    event ArbitrationRelayerUpdated(address arbitrationPolicy, address arbitrationRelayer);
 
     /// @notice Event emitted when the base arbitration policy is set
     /// @param arbitrationPolicy The address of the arbitration policy
@@ -145,14 +144,10 @@ interface IDisputeModule {
     /// @return allowed Indicates if the arbitration policy is whitelisted
     function isWhitelistedArbitrationPolicy(address arbitrationPolicy) external view returns (bool allowed);
 
-    /// @notice Indicates if an arbitration relayer is whitelisted for a given arbitration policy
+    /// @notice Returns the arbitration relayer for a given arbitration policy
     /// @param arbitrationPolicy The address of the arbitration policy
-    /// @param arbitrationRelayer The address of the arbitration relayer
-    /// @return allowed Indicates if the arbitration relayer is whitelisted
-    function isWhitelistedArbitrationRelayer(
-        address arbitrationPolicy,
-        address arbitrationRelayer
-    ) external view returns (bool allowed);
+    /// @return arbitrationRelayer The address of the arbitration relayer
+    function arbitrationRelayer(address arbitrationPolicy) external view returns (address arbitrationRelayer);
 
     /// @notice Arbitration policy for a given ipId
     /// @param ipId The ipId
@@ -169,11 +164,10 @@ interface IDisputeModule {
     /// @param allowed Indicates if the arbitration policy is whitelisted or not
     function whitelistArbitrationPolicy(address arbitrationPolicy, bool allowed) external;
 
-    /// @notice Whitelists an arbitration relayer for a given arbitration policy
+    /// @notice Sets the arbitration relayer for a given arbitration policy
     /// @param arbitrationPolicy The address of the arbitration policy
     /// @param arbPolicyRelayer The address of the arbitration relayer
-    /// @param allowed Indicates if the arbitration relayer is whitelisted or not
-    function whitelistArbitrationRelayer(address arbitrationPolicy, address arbPolicyRelayer, bool allowed) external;
+    function setArbitrationRelayer(address arbitrationPolicy, address arbPolicyRelayer) external;
 
     /// @notice Sets the base arbitration policy
     /// @param arbitrationPolicy The address of the arbitration policy

--- a/contracts/lib/Errors.sol
+++ b/contracts/lib/Errors.sol
@@ -392,9 +392,6 @@ library Errors {
     /// @notice Zero address provided for Arbitration Policy.
     error DisputeModule__ZeroArbitrationPolicy();
 
-    /// @notice Zero address provided for Arbitration Relayer.
-    error DisputeModule__ZeroArbitrationRelayer();
-
     /// @notice Zero bytes provided for Dispute Tag.
     error DisputeModule__ZeroDisputeTag();
 
@@ -407,8 +404,8 @@ library Errors {
     /// @notice Not a whitelisted arbitration policy.
     error DisputeModule__NotWhitelistedArbitrationPolicy();
 
-    /// @notice Not a whitelisted arbitration relayer.
-    error DisputeModule__NotWhitelistedArbitrationRelayer();
+    /// @notice Not the arbitration relayer.
+    error DisputeModule__NotArbitrationRelayer();
 
     /// @notice Not a whitelisted dispute tag.
     error DisputeModule__NotWhitelistedDisputeTag();

--- a/script/foundry/utils/DeployHelper.sol
+++ b/script/foundry/utils/DeployHelper.sol
@@ -757,7 +757,7 @@ contract DeployHelper is Script, BroadcastManager, JsonDeploymentHandler, Storag
         disputeModule.whitelistDisputeTag("IMPROPER_PAYMENT", true);
         disputeModule.whitelistDisputeTag("CONTENT_STANDARDS_VIOLATION", true);
         disputeModule.whitelistArbitrationPolicy(address(arbitrationPolicyUMA), true);
-        disputeModule.whitelistArbitrationRelayer(address(arbitrationPolicyUMA), address(arbitrationPolicyUMA), true);
+        disputeModule.setArbitrationRelayer(address(arbitrationPolicyUMA), address(arbitrationPolicyUMA));
         disputeModule.setBaseArbitrationPolicy(address(arbitrationPolicyUMA));
         arbitrationPolicyUMA.setOOV3(address(oov3));
         arbitrationPolicyUMA.setLiveness(30 days, 365 days, 66_666_666);

--- a/test/foundry/modules/dispute/DisputeModule.t.sol
+++ b/test/foundry/modules/dispute/DisputeModule.t.sol
@@ -16,7 +16,7 @@ import { MockArbitrationPolicy } from "test/foundry/mocks/dispute/MockArbitratio
 contract DisputeModuleTest is BaseTest {
     event TagWhitelistUpdated(bytes32 tag, bool allowed);
     event ArbitrationPolicyWhitelistUpdated(address arbitrationPolicy, bool allowed);
-    event ArbitrationRelayerWhitelistUpdated(address arbitrationPolicy, address arbitrationRelayer, bool allowed);
+    event ArbitrationRelayerUpdated(address arbitrationPolicy, address arbitrationRelayer);
     event DisputeRaised(
         uint256 disputeId,
         address targetIpId,
@@ -156,26 +156,20 @@ contract DisputeModuleTest is BaseTest {
         assertEq(disputeModule.isWhitelistedArbitrationPolicy(address(1)), true);
     }
 
-    function test_DisputeModule_whitelistArbitrationRelayer_revert_ZeroArbitrationPolicy() public {
+    function test_DisputeModule_setArbitrationRelayer_revert_ZeroArbitrationPolicy() public {
         vm.startPrank(u.admin);
         vm.expectRevert(Errors.DisputeModule__ZeroArbitrationPolicy.selector);
-        disputeModule.whitelistArbitrationRelayer(address(0), arbitrationRelayer, true);
+        disputeModule.setArbitrationRelayer(address(0), arbitrationRelayer);
     }
 
-    function test_DisputeModule_whitelistArbitrationRelayer_revert_ZeroArbitrationRelayer() public {
-        vm.startPrank(u.admin);
-        vm.expectRevert(Errors.DisputeModule__ZeroArbitrationRelayer.selector);
-        disputeModule.whitelistArbitrationRelayer(address(mockArbitrationPolicy), address(0), true);
-    }
-
-    function test_DisputeModule_whitelistArbitrationRelayer() public {
+    function test_DisputeModule_setArbitrationRelayer() public {
         vm.startPrank(u.admin);
         vm.expectEmit(true, true, true, true, address(disputeModule));
-        emit ArbitrationRelayerWhitelistUpdated(address(mockArbitrationPolicy), address(1), true);
+        emit ArbitrationRelayerUpdated(address(mockArbitrationPolicy), address(1));
 
-        disputeModule.whitelistArbitrationRelayer(address(mockArbitrationPolicy), address(1), true);
+        disputeModule.setArbitrationRelayer(address(mockArbitrationPolicy), address(1));
 
-        assertEq(disputeModule.isWhitelistedArbitrationRelayer(address(mockArbitrationPolicy), address(1)), true);
+        assertEq(disputeModule.arbitrationRelayer(address(mockArbitrationPolicy)), address(1));
     }
 
     function test_DisputeModule_setBaseArbitrationPolicy_revert_NotWhitelistedArbitrationPolicy() public {
@@ -414,7 +408,7 @@ contract DisputeModuleTest is BaseTest {
         disputeModule.raiseDispute(ipAddr, disputeEvidenceHashExample, "IMPROPER_REGISTRATION", "");
         vm.stopPrank();
 
-        vm.expectRevert(Errors.DisputeModule__NotWhitelistedArbitrationRelayer.selector);
+        vm.expectRevert(Errors.DisputeModule__NotArbitrationRelayer.selector);
         disputeModule.setDisputeJudgement(1, true, "");
     }
 

--- a/test/foundry/modules/dispute/policies/UMA/ArbitrationPolicyUMA.t.sol
+++ b/test/foundry/modules/dispute/policies/UMA/ArbitrationPolicyUMA.t.sol
@@ -88,11 +88,7 @@ contract ArbitrationPolicyUMATest is BaseTest {
         // whitelist dispute tag, arbitration policy and arbitration relayer
         newDisputeModule.whitelistDisputeTag("IMPROPER_REGISTRATION", true);
         newDisputeModule.whitelistArbitrationPolicy(address(newArbitrationPolicyUMA), true);
-        newDisputeModule.whitelistArbitrationRelayer(
-            address(newArbitrationPolicyUMA),
-            address(newArbitrationPolicyUMA),
-            true
-        );
+        newDisputeModule.setArbitrationRelayer(address(newArbitrationPolicyUMA), address(newArbitrationPolicyUMA));
         newDisputeModule.setBaseArbitrationPolicy(address(newArbitrationPolicyUMA));
 
         vm.label(newOOV3, "newOOV3");

--- a/test/foundry/utils/BaseTest.t.sol
+++ b/test/foundry/utils/BaseTest.t.sol
@@ -107,7 +107,7 @@ contract BaseTest is Test, DeployHelper, LicensingHelper {
         mockArbitrationPolicy = new MockArbitrationPolicy(address(disputeModule), address(USDC), ARBITRATION_PRICE);
         vm.startPrank(u.admin);
         disputeModule.whitelistArbitrationPolicy(address(mockArbitrationPolicy), true);
-        disputeModule.whitelistArbitrationRelayer(address(mockArbitrationPolicy), address(u.relayer), true);
+        disputeModule.setArbitrationRelayer(address(mockArbitrationPolicy), address(u.relayer));
         disputeModule.setBaseArbitrationPolicy(address(mockArbitrationPolicy));
         mockArbitrationPolicy.setTreasury(TREASURY_ADDRESS);
         vm.stopPrank();


### PR DESCRIPTION
## Description
As a simplification and to avoid possible edge cases, each arbitration policy will only have only 1 relayer address.