### PR TITLE
Replaces amountToTransfer by maxAmount

### DIFF
--- a/contracts/modules/royalty/policies/LAP/RoyaltyPolicyLAP.sol
+++ b/contracts/modules/royalty/policies/LAP/RoyaltyPolicyLAP.sol
@@ -149,7 +149,7 @@ contract RoyaltyPolicyLAP is
         uint256 amountToTransfer = Math.min(maxAmount - transferredAmount, IERC20(token).balanceOf(address(this)));
 
         // make the revenue token transfer
-        $.transferredTokenLAP[ipId][ancestorIpId][token] += amountToTransfer;
+        $.transferredTokenLAP[ipId][ancestorIpId][token] += maxAmount;
         address ancestorIpRoyaltyVault = royaltyModule.ipRoyaltyVaults(ancestorIpId);
         IIpRoyaltyVault(ancestorIpRoyaltyVault).updateVaultBalance(token, amountToTransfer);
         IERC20(token).safeTransfer(ancestorIpRoyaltyVault, amountToTransfer);

--- a/contracts/modules/royalty/policies/LRP/RoyaltyPolicyLRP.sol
+++ b/contracts/modules/royalty/policies/LRP/RoyaltyPolicyLRP.sol
@@ -176,7 +176,7 @@ contract RoyaltyPolicyLRP is
         uint256 amountToTransfer = Math.min(maxAmount - transferredAmount, IERC20(token).balanceOf(address(this)));
 
         // make the revenue token transfer
-        $.transferredTokenLRP[ipId][ancestorIpId][token] += amountToTransfer;
+        $.transferredTokenLRP[ipId][ancestorIpId][token] += maxAmount;
         address ancestorIpRoyaltyVault = royaltyModule.ipRoyaltyVaults(ancestorIpId);
         IIpRoyaltyVault(ancestorIpRoyaltyVault).updateVaultBalance(token, amountToTransfer);
         IERC20(token).safeTransfer(ancestorIpRoyaltyVault, amountToTransfer);


### PR DESCRIPTION
## Description
As audit recommendation, in order to not carry over rounding error `maxAmount` is assigned instead of `amountToTransfer`.