### PR TITLE
Initialize Dynamic Results Array for Group Members

### DIFF
--- a/contracts/registries/GroupIPAssetRegistry.sol
+++ b/contracts/registries/GroupIPAssetRegistry.sol
@@ -145,9 +145,10 @@ abstract contract GroupIPAssetRegistry is IGroupIPAssetRegistry, ProtocolPausabl
     ) external view returns (address[] memory results) {
         EnumerableSet.AddressSet storage allMemberIpIds = _getGroupIPAssetRegistryStorage().groups[groupId];
         uint256 totalSize = allMemberIpIds.length();
-        if (startIndex >= totalSize) return results;
+        if (startIndex >= totalSize) return new address[](0);
 
         uint256 resultsSize = (startIndex + size) > totalSize ? size - ((startIndex + size) - totalSize) : size;
+        results = new address[](resultsSize);
         for (uint256 i = 0; i < resultsSize; i++) {
             results[i] = allMemberIpIds.at(startIndex + i);
         }


### PR DESCRIPTION
## Description

This PR updates the `getGroupMembers` function to initialize the results array dynamically based on the size of the group members. This change ensures that the results array is correctly sized to hold the group members being retrieved.

Closes https://github.com/storyprotocol/halborn-protocol-contracts-v1/issues/5

