### PR TITLE
Apply SafeERC20's `forceApprove()` for Reward Token Allowance to RoyaltyModule

### DIFF
--- a/contracts/modules/grouping/EvenSplitGroupPool.sol
+++ b/contracts/modules/grouping/EvenSplitGroupPool.sol
@@ -147,7 +147,7 @@ contract EvenSplitGroupPool is IGroupRewardPool, ProtocolPausableUpgradeable, UU
         uint256 rewardsPerIp = _getRewardPerIp(groupId, token);
         uint256 totalRewards = rewardsPerIp * ipIds.length;
         if (totalRewards == 0) return rewards;
-        IERC20(token).approve(address(ROYALTY_MODULE), totalRewards);
+        IERC20(token).forceApprove(address(ROYALTY_MODULE), totalRewards);
         for (uint256 i = 0; i < ipIds.length; i++) {
             if (!_isIpAdded(groupId, ipIds[i])) continue;
             // calculate pending reward for each IP


### PR DESCRIPTION
## Description

This PR updates the `EvenSplitGroupPool` contract to use SafeERC20's `forceApprove()` method to ensure the approval allowance of the reward token to the `RoyaltyModule`. This change ensures compatibility with all ERC20 tokens, including those with non-standard implementations such as USDT.

## Key Changes

- **SafeERC20 `forceApprove()`**: Updated the `distributeRewards` function to use SafeERC20's `forceApprove()` method for setting the allowance of the reward token to the `RoyaltyModule`.


Closes https://github.com/storyprotocol/halborn-protocol-contracts-v1/issues/9

