### PR TITLE
Emit Events for Whitelist and Revoke Address in IPGraphACL

### DIFF
--- a/contracts/access/IPGraphACL.sol
+++ b/contracts/access/IPGraphACL.sol
@@ -3,13 +3,14 @@ pragma solidity 0.8.26;
 
 import { AccessManaged } from "@openzeppelin/contracts/access/manager/AccessManaged.sol";
 import { Errors } from "../lib/Errors.sol";
+import { IIPGraphACL } from "../interfaces/access/IIPGraphACL.sol";
 
 /// @title IPGraphACL
 /// @notice This contract is used to manage access to the IPGraph contract.
 /// It allows the access manager to whitelist addresses that can allow or disallow access to the IPGraph contract.
 /// It allows whitelisted addresses to allow or disallow access to the IPGraph contract.
 /// IPGraph precompiled check if the IPGraphACL contract allows access to the IPGraph.
-contract IPGraphACL is AccessManaged {
+contract IPGraphACL is AccessManaged, IIPGraphACL {
     // keccak256(abi.encode(uint256(keccak256("story-protocol.IPGraphACL")) - 1)) & ~bytes32(uint256(0xff));
     bytes32 private constant IP_GRAPH_ACL_SLOT = 0xaf99b37fdaacca72ee7240cb1435cc9e498aee6ef4edc19c8cc0cd787f4e6800;
 
@@ -61,12 +62,14 @@ contract IPGraphACL is AccessManaged {
     /// @param addr The address to whitelist.
     function whitelistAddress(address addr) external restricted {
         whitelist[addr] = true;
+        emit WhitelistedAddress(addr);
     }
 
     /// @notice Revoke whitelisted address.
     /// @param addr The address to revoke.
     function revokeWhitelistedAddress(address addr) external restricted {
         whitelist[addr] = false;
+        emit RevokedWhitelistedAddress(addr);
     }
 
     /// @notice Check if an address is whitelisted.

--- a/contracts/interfaces/access/IIPGraphACL.sol
+++ b/contracts/interfaces/access/IIPGraphACL.sol
@@ -1,0 +1,33 @@
+// SPDX-License-Identifier: BUSL-1.1
+pragma solidity 0.8.26;
+
+interface IIPGraphACL {
+    /// @notice Emitted when whitelisted address which can control allowed or disallowed to access the IPGraph contract.
+    /// @param addr The address that was whitelisted.
+    event WhitelistedAddress(address addr);
+
+    /// @notice Emitted when whitelisted address is revoked.
+    /// @param addr The address that was revoked.
+    event RevokedWhitelistedAddress(address addr);
+
+    /// @notice Allow access to the IPGraph contract.
+    function allow() external;
+
+    /// @notice Disallow access to the IPGraph contract.
+    function disallow() external;
+
+    /// @notice Check if access to the IPGraph contract is allowed.
+    function isAllowed() external view returns (bool);
+
+    /// @notice Whitelist an address that can allow or disallow access to the IPGraph contract.
+    /// @param addr The address to whitelist.
+    function whitelistAddress(address addr) external;
+
+    /// @notice Revoke whitelisted address.
+    /// @param addr The address to revoke.
+    function revokeWhitelistedAddress(address addr) external;
+
+    /// @notice Check if an address is whitelisted.
+    /// @param addr The address to check.
+    function isWhitelisted(address addr) external view returns (bool);
+}

--- a/test/foundry/access/IPGraphACL.t.sol
+++ b/test/foundry/access/IPGraphACL.t.sol
@@ -3,6 +3,7 @@ pragma solidity 0.8.26;
 
 import { Errors } from "../../../contracts/lib/Errors.sol";
 import { BaseTest } from "../utils/BaseTest.t.sol";
+import { IIPGraphACL } from "../../../contracts/interfaces/access/IIPGraphACL.sol";
 
 contract IPGraphACLTest is BaseTest {
     function setUp() public override {
@@ -31,6 +32,8 @@ contract IPGraphACLTest is BaseTest {
 
     function test_IPGraphACL_addToWhitelist() public {
         vm.prank(admin);
+        vm.expectEmit();
+        emit IIPGraphACL.WhitelistedAddress(address(0x123));
         ipGraphACL.whitelistAddress(address(0x123));
         vm.prank(address(0x123));
         ipGraphACL.allow();
@@ -44,6 +47,8 @@ contract IPGraphACLTest is BaseTest {
         ipGraphACL.allow();
         assertTrue(ipGraphACL.isAllowed());
         vm.prank(admin);
+        vm.expectEmit();
+        emit IIPGraphACL.RevokedWhitelistedAddress(address(0x123));
         ipGraphACL.revokeWhitelistedAddress(address(0x123));
         vm.prank(address(0x123));
         vm.expectRevert(abi.encodeWithSelector(Errors.IPGraphACL__NotWhitelisted.selector, address(0x123)));


### PR DESCRIPTION
## Description

This PR updates the `IPGraphACL` contract to emit events when an address is whitelisted or revoked. 

## Key Changes

- **Emit Whitelist Event**: Added an event emission when an address is whitelisted.
- **Emit Revoke Event**: Added an event emission when an address is revoked from the whitelist.

Closes https://github.com/storyprotocol/trust-protocol-contracts-v1/issues/42