### PR TITLE
Prevent Royalty Commercial Revenue Share Over 100% When Minting License Tokens

### DIFF
--- a/contracts/LicenseToken.sol
+++ b/contracts/LicenseToken.sol
@@ -27,6 +27,9 @@ contract LicenseToken is ILicenseToken, ERC721EnumerableUpgradeable, AccessManag
     /// @custom:oz-upgrades-unsafe-allow state-variable-immutable
     IDisputeModule public immutable DISPUTE_MODULE;
 
+    /// @notice Max Royalty percentage is 100_000_000 means 100%.
+    uint32 public constant MAX_COMMERCIAL_REVENUE_SHARE = 100_000_000;
+
     /// @notice Emitted for metadata updates, per EIP-4906
     event BatchMetadataUpdate(uint256 _fromTokenId, uint256 _toTokenId);
 
@@ -102,6 +105,14 @@ contract LicenseToken is ILicenseToken, ERC721EnumerableUpgradeable, AccessManag
             commercialRevShare: LICENSE_REGISTRY.getRoyaltyPercent(licensorIpId, licenseTemplate, licenseTermsId)
         });
 
+        if (ltm.commercialRevShare > MAX_COMMERCIAL_REVENUE_SHARE) {
+            revert Errors.LicenseToken__InvalidRoyaltyPercent(
+                ltm.commercialRevShare,
+                licensorIpId,
+                licenseTemplate,
+                licenseTermsId
+            );
+        }
         LicenseTokenStorage storage $ = _getLicenseTokenStorage();
         startLicenseTokenId = $.totalMintedTokens;
         $.totalMintedTokens += amount;

--- a/contracts/lib/Errors.sol
+++ b/contracts/lib/Errors.sol
@@ -289,6 +289,14 @@ library Errors {
         address anotherLicenseTemplate
     );
 
+    /// @notice Royalty percentage is invalid that over 100%.
+    error LicenseToken__InvalidRoyaltyPercent(
+        uint32 invalidRoyaltyPercent,
+        address ipId,
+        address licenseTemplate,
+        uint256 licenseTermsId
+    );
+
     ////////////////////////////////////////////////////////////////////////////
     //                           Licensing Module                             //
     ////////////////////////////////////////////////////////////////////////////


### PR DESCRIPTION
## Description

This PR updates the `LicenseToken` contract to check and prevent the setting of a commercial revenue share (royalty percentage) over 100% (100,000,000) when minting license tokens. This change ensures that the royalty percentage remains within a valid range, maintaining the integrity of the licensing process.

## Key Changes

- **Royalty Percentage Check**: Added a check in the `LicenseToken` contract to prevent setting a commercial revenue share over 100% when minting license tokens.

Closes https://github.com/FuzzingLabs/story-audit-monorepo/issues/4
