### PR TITLE
Change from `_mint()` to `_safeMint()` for Minting Group NFTs

### DIFF
--- a/contracts/GroupNFT.sol
+++ b/contracts/GroupNFT.sol
@@ -74,7 +74,7 @@ contract GroupNFT is IGroupNFT, ERC721Upgradeable, AccessManagedUpgradeable, UUP
     function mintGroupNft(address minter, address receiver) external onlyGroupingModule returns (uint256 groupNftId) {
         GroupNFTStorage storage $ = _getGroupNFTStorage();
         groupNftId = $.totalSupply++;
-        _mint(receiver, groupNftId);
+        _safeMint(receiver, groupNftId);
         emit GroupNFTMinted(minter, receiver, groupNftId);
     }
 

--- a/test/foundry/modules/grouping/EvenSplitGroupPool.t.sol
+++ b/test/foundry/modules/grouping/EvenSplitGroupPool.t.sol
@@ -3,6 +3,7 @@ pragma solidity 0.8.26;
 
 // external
 import { Strings } from "@openzeppelin/contracts/utils/Strings.sol";
+import { ERC721Holder } from "@openzeppelin/contracts/token/ERC721/utils/ERC721Holder.sol";
 
 // contracts
 import { PILFlavors } from "../../../../contracts/lib/PILFlavors.sol";
@@ -12,7 +13,7 @@ import { MockERC721 } from "../../mocks/token/MockERC721.sol";
 import { BaseTest } from "../../utils/BaseTest.t.sol";
 import { Errors } from "../../../../contracts/lib/Errors.sol";
 
-contract EvenSplitGroupPoolTest is BaseTest {
+contract EvenSplitGroupPoolTest is BaseTest, ERC721Holder {
     using Strings for *;
 
     MockERC721 internal mockNft = new MockERC721("MockERC721");

--- a/test/foundry/modules/royalty/IpRoyaltyVault.t.sol
+++ b/test/foundry/modules/royalty/IpRoyaltyVault.t.sol
@@ -3,6 +3,7 @@ pragma solidity 0.8.26;
 
 import { ERC20 } from "@openzeppelin/contracts/token/ERC20/ERC20.sol";
 import { IERC20 } from "@openzeppelin/contracts/token/ERC20/IERC20.sol";
+import { ERC721Holder } from "@openzeppelin/contracts/token/ERC721/utils/ERC721Holder.sol";
 
 // contracts
 import { IpRoyaltyVault } from "../../../../contracts/modules/royalty/policies/IpRoyaltyVault.sol";
@@ -13,7 +14,7 @@ import { Errors } from "../../../../contracts/lib/Errors.sol";
 // tests
 import { BaseTest } from "../../utils/BaseTest.t.sol";
 
-contract TestIpRoyaltyVault is BaseTest {
+contract TestIpRoyaltyVault is BaseTest, ERC721Holder {
     function setUp() public override {
         super.setUp();
 

--- a/test/foundry/modules/royalty/RoyaltyModule.t.sol
+++ b/test/foundry/modules/royalty/RoyaltyModule.t.sol
@@ -4,6 +4,7 @@ pragma solidity 0.8.26;
 import { IERC20 } from "@openzeppelin/contracts/token/ERC20/IERC20.sol";
 import { ERC6551AccountLib } from "erc6551/lib/ERC6551AccountLib.sol";
 import { PausableUpgradeable } from "@openzeppelin/contracts-upgradeable/utils/PausableUpgradeable.sol";
+import { ERC721Holder } from "@openzeppelin/contracts/token/ERC721/utils/ERC721Holder.sol";
 
 // contracts
 import { Errors } from "../../../../contracts/lib/Errors.sol";
@@ -18,7 +19,7 @@ import { MockExternalRoyaltyPolicy2 } from "../../mocks/policy/MockExternalRoyal
 import { MockERC721 } from "../../mocks/token/MockERC721.sol";
 import { EvenSplitGroupPool } from "../../../../contracts/modules/grouping/EvenSplitGroupPool.sol";
 
-contract TestRoyaltyModule is BaseTest {
+contract TestRoyaltyModule is BaseTest, ERC721Holder {
     event RoyaltyPolicyWhitelistUpdated(address royaltyPolicy, bool allowed);
     event RoyaltyTokenWhitelistUpdated(address token, bool allowed);
     event RoyaltyPolicySet(address ipId, address royaltyPolicy, bytes data);
@@ -816,12 +817,12 @@ contract TestRoyaltyModule is BaseTest {
         parentRoyalties[1] = uint32(17 * 10 ** 6);
         parentRoyalties[2] = uint32(24 * 10 ** 6);
 
-        vm.startPrank(address(licensingModule));
         address groupId = groupingModule.registerGroup(address(rewardPool));
         ipGraph.addParentIp(groupId, parents);
 
         assertEq(royaltyModule.ipRoyaltyVaults(groupId), address(0));
 
+        vm.startPrank(address(licensingModule));
         royaltyModule.onLinkToParents(groupId, parents, licenseRoyaltyPolicies, parentRoyalties, "", 100e6);
 
         address ipRoyaltyVault80 = royaltyModule.ipRoyaltyVaults(groupId);


### PR DESCRIPTION
## Description

This PR updates the `GroupNFT` contract to use `_safeMint()` instead of `_mint()` when minting Group NFTs. This change ensures that the receiver can handle the NFT properly by checking if the receiver is a contract and if it implements the `IERC721Receiver` interface.

## Key Changes

- **Minting Method Update**: Replaced `_mint()` with `_safeMint()` in the `GroupingModule` contract for minting Group NFTs.

Closes https://github.com/FuzzingLabs/story-audit-monorepo/issues/3