### PR TITLE
Change from _mint() to _safeMint() for Minting License Tokens

### DIFF
--- a/contracts/LicenseToken.sol
+++ b/contracts/LicenseToken.sol
@@ -120,7 +120,7 @@ contract LicenseToken is ILicenseToken, ERC721EnumerableUpgradeable, AccessManag
         for (uint256 i = 0; i < amount; i++) {
             uint256 tokenId = startLicenseTokenId + i;
             $.licenseTokenMetadatas[tokenId] = ltm;
-            _mint(receiver, tokenId);
+            _safeMint(receiver, tokenId);
             emit LicenseTokenMinted(minter, receiver, tokenId);
         }
     }

--- a/test/foundry/integration/flows/grouping/Grouping.t.sol
+++ b/test/foundry/integration/flows/grouping/Grouping.t.sol
@@ -12,11 +12,12 @@ import { PILFlavors } from "../../../../../contracts/lib/PILFlavors.sol";
 import { Licensing } from "../../../../../contracts/lib/Licensing.sol";
 import { IGroupingModule } from "../../../../../contracts/interfaces/modules/grouping/IGroupingModule.sol";
 import { IGroupIPAssetRegistry } from "../../../../../contracts/interfaces/registries/IGroupIPAssetRegistry.sol";
+import { ERC721Holder } from "@openzeppelin/contracts/token/ERC721/utils/ERC721Holder.sol";
 
 // test
 import { BaseIntegration } from "../../BaseIntegration.t.sol";
 
-contract Flows_Integration_Grouping is BaseIntegration {
+contract Flows_Integration_Grouping is BaseIntegration, ERC721Holder {
     using EnumerableSet for EnumerableSet.UintSet;
     using Strings for *;
 

--- a/test/foundry/modules/grouping/GroupingModule.t.sol
+++ b/test/foundry/modules/grouping/GroupingModule.t.sol
@@ -4,6 +4,7 @@ pragma solidity 0.8.26;
 // external
 import { Strings } from "@openzeppelin/contracts/utils/Strings.sol";
 import { IERC20 } from "@openzeppelin/contracts/token/ERC20/IERC20.sol";
+import { ERC721Holder } from "@openzeppelin/contracts/token/ERC721/utils/ERC721Holder.sol";
 
 // contracts
 import { Errors } from "../../../../contracts/lib/Errors.sol";
@@ -17,7 +18,7 @@ import { EvenSplitGroupPool } from "../../../../contracts/modules/grouping/EvenS
 import { MockERC721 } from "../../mocks/token/MockERC721.sol";
 import { BaseTest } from "../../utils/BaseTest.t.sol";
 
-contract GroupingModuleTest is BaseTest {
+contract GroupingModuleTest is BaseTest, ERC721Holder {
     // test register group
     // test add ip to group
     // test remove ip from group


### PR DESCRIPTION
## Description

This PR updates the `LicenseToken` contract to use `_safeMint()` instead of `_mint()` when minting License Tokens. This change ensures that the receiver can handle the NFT properly by checking if the receiver is a contract and if it implements the `IERC721Receiver` interface.

## Key Changes

- **Minting Method Update**: Replaced `_mint()` with `_safeMint()` in the `LicenseToken` contract for minting License Tokens.

Closes https://github.com/FuzzingLabs/story-audit-monorepo/issues/2
