### PR TITLE
Implement Verification for Identical Royalty Policies When Registering Derivative with Multiple Parent IPs

### DIFF
--- a/contracts/lib/Errors.sol
+++ b/contracts/lib/Errors.sol
@@ -384,6 +384,9 @@ library Errors {
         uint32 newRoyaltyPercent
     );
 
+    /// @notice register derivative require all parent IP to have the same royalty policy.
+    error LicensingModule__RoyaltyPolicyMismatch(address royaltyPolicy, address anotherRoyaltyPolicy);
+
     ////////////////////////////////////////////////////////////////////////////
     //                             Dispute Module                             //
     ////////////////////////////////////////////////////////////////////////////

--- a/test/foundry/modules/licensing/LicensingModule.t.sol
+++ b/test/foundry/modules/licensing/LicensingModule.t.sol
@@ -1245,6 +1245,87 @@ contract LicensingModuleTest is BaseTest {
         licensingModule.registerDerivativeWithLicenseTokens(ipId3, licenseTokens, "", 100e6);
     }
 
+    function test_LicensingModule_registerDerivativeWithLicenseTokens_revert_royaltyPolicyMismatch() public {
+        PILTerms memory terms = PILFlavors.commercialRemix(
+            {
+                mintingFee: 0,
+                commercialRevShare: 10,
+                royaltyPolicy: address(royaltyPolicyLAP),
+                currencyToken: address(erc20)
+            }
+        );
+        terms.derivativesReciprocal = false;
+
+        uint256 termsIdLAP = pilTemplate.registerLicenseTerms(terms);
+        vm.prank(ipOwner1);
+        licensingModule.attachLicenseTerms(ipId1, address(pilTemplate), termsIdLAP);
+
+        terms.royaltyPolicy = address(royaltyPolicyLRP);
+        uint256 termsIdLRP = pilTemplate.registerLicenseTerms(terms);
+        vm.prank(ipOwner2);
+        licensingModule.attachLicenseTerms(ipId2, address(pilTemplate), termsIdLRP);
+
+        uint256 lcTokenId1 = licensingModule.mintLicenseTokens({
+            licensorIpId: ipId1,
+            licenseTemplate: address(pilTemplate),
+            licenseTermsId: termsIdLAP,
+            amount: 1,
+            receiver: ipOwner3,
+            royaltyContext: "",
+            maxMintingFee: 0
+        });
+
+        uint256 lcTokenId2 = licensingModule.mintLicenseTokens({
+            licensorIpId: ipId2,
+            licenseTemplate: address(pilTemplate),
+            licenseTermsId: termsIdLRP,
+            amount: 1,
+            receiver: ipOwner3,
+            royaltyContext: "",
+            maxMintingFee: 0
+        });
+
+        uint256[] memory licenseTokens = new uint256[](2);
+        licenseTokens[0] = lcTokenId1;
+        licenseTokens[1] = lcTokenId2;
+        vm.prank(ipOwner3);
+        vm.expectRevert(abi.encodeWithSelector(Errors.LicensingModule__RoyaltyPolicyMismatch.selector, address(royaltyPolicyLAP), address(royaltyPolicyLRP)));
+        licensingModule.registerDerivativeWithLicenseTokens(ipId3, licenseTokens, "", 100e6);
+    }
+
+    function test_LicensingModule_registerDerivative_revert_royaltyPolicyMismatch() public {
+        PILTerms memory terms = PILFlavors.commercialRemix(
+            {
+                mintingFee: 0,
+                commercialRevShare: 10,
+                royaltyPolicy: address(royaltyPolicyLAP),
+                currencyToken: address(erc20)
+            }
+        );
+        terms.derivativesReciprocal = false;
+
+        uint256 termsIdLAP = pilTemplate.registerLicenseTerms(terms);
+        vm.prank(ipOwner1);
+        licensingModule.attachLicenseTerms(ipId1, address(pilTemplate), termsIdLAP);
+
+        terms.royaltyPolicy = address(royaltyPolicyLRP);
+        uint256 termsIdLRP = pilTemplate.registerLicenseTerms(terms);
+        vm.prank(ipOwner2);
+        licensingModule.attachLicenseTerms(ipId2, address(pilTemplate), termsIdLRP);
+
+        address[] memory parentIpIds = new address[](2);
+        parentIpIds[0] = ipId1;
+        parentIpIds[1] = ipId2;
+
+        uint256[] memory licenseTermsIds = new uint256[](2);
+        licenseTermsIds[0] = termsIdLAP;
+        licenseTermsIds[1] = termsIdLRP;
+
+        vm.expectRevert(abi.encodeWithSelector(Errors.LicensingModule__RoyaltyPolicyMismatch.selector, address(royaltyPolicyLAP), address(royaltyPolicyLRP)));
+        vm.prank(ipOwner3);
+        licensingModule.registerDerivative(ipId3, parentIpIds, licenseTermsIds, address(pilTemplate), "", 0, 100e6);
+    }
+
     function test_LicensingModule_registerDerivativeWithLicenseTokens_ownedByDelegator() public {
         vm.prank(ipOwner3);
         accessController.setAllPermissions(ipId3, ipOwner2, AccessPermission.ALLOW);

--- a/test/foundry/modules/licensing/LicensingModule.t.sol
+++ b/test/foundry/modules/licensing/LicensingModule.t.sol
@@ -1246,14 +1246,12 @@ contract LicensingModuleTest is BaseTest {
     }
 
     function test_LicensingModule_registerDerivativeWithLicenseTokens_revert_royaltyPolicyMismatch() public {
-        PILTerms memory terms = PILFlavors.commercialRemix(
-            {
-                mintingFee: 0,
-                commercialRevShare: 10,
-                royaltyPolicy: address(royaltyPolicyLAP),
-                currencyToken: address(erc20)
-            }
-        );
+        PILTerms memory terms = PILFlavors.commercialRemix({
+            mintingFee: 0,
+            commercialRevShare: 10,
+            royaltyPolicy: address(royaltyPolicyLAP),
+            currencyToken: address(erc20)
+        });
         terms.derivativesReciprocal = false;
 
         uint256 termsIdLAP = pilTemplate.registerLicenseTerms(terms);
@@ -1289,19 +1287,23 @@ contract LicensingModuleTest is BaseTest {
         licenseTokens[0] = lcTokenId1;
         licenseTokens[1] = lcTokenId2;
         vm.prank(ipOwner3);
-        vm.expectRevert(abi.encodeWithSelector(Errors.LicensingModule__RoyaltyPolicyMismatch.selector, address(royaltyPolicyLAP), address(royaltyPolicyLRP)));
+        vm.expectRevert(
+            abi.encodeWithSelector(
+                Errors.LicensingModule__RoyaltyPolicyMismatch.selector,
+                address(royaltyPolicyLAP),
+                address(royaltyPolicyLRP)
+            )
+        );
         licensingModule.registerDerivativeWithLicenseTokens(ipId3, licenseTokens, "", 100e6);
     }
 
     function test_LicensingModule_registerDerivative_revert_royaltyPolicyMismatch() public {
-        PILTerms memory terms = PILFlavors.commercialRemix(
-            {
-                mintingFee: 0,
-                commercialRevShare: 10,
-                royaltyPolicy: address(royaltyPolicyLAP),
-                currencyToken: address(erc20)
-            }
-        );
+        PILTerms memory terms = PILFlavors.commercialRemix({
+            mintingFee: 0,
+            commercialRevShare: 10,
+            royaltyPolicy: address(royaltyPolicyLAP),
+            currencyToken: address(erc20)
+        });
         terms.derivativesReciprocal = false;
 
         uint256 termsIdLAP = pilTemplate.registerLicenseTerms(terms);
@@ -1321,7 +1323,13 @@ contract LicensingModuleTest is BaseTest {
         licenseTermsIds[0] = termsIdLAP;
         licenseTermsIds[1] = termsIdLRP;
 
-        vm.expectRevert(abi.encodeWithSelector(Errors.LicensingModule__RoyaltyPolicyMismatch.selector, address(royaltyPolicyLAP), address(royaltyPolicyLRP)));
+        vm.expectRevert(
+            abi.encodeWithSelector(
+                Errors.LicensingModule__RoyaltyPolicyMismatch.selector,
+                address(royaltyPolicyLAP),
+                address(royaltyPolicyLRP)
+            )
+        );
         vm.prank(ipOwner3);
         licensingModule.registerDerivative(ipId3, parentIpIds, licenseTermsIds, address(pilTemplate), "", 0, 100e6);
     }


### PR DESCRIPTION
## Description

This PR introduces a verification step to ensure that all royalty policies are identical when registering a derivative with multiple parent IPs. This change is necessary to maintain consistency and integrity in the licensing process.

## Key Changes

- **Royalty Policy Verification**: Added a check to verify that all royalty policies are identical when registering a derivative with multiple parent IPs.

Closes https://github.com/FuzzingLabs/story-audit-monorepo/issues/12