### PR TITLE
Add Note Comments for Validations Before Calling IP Graph to Add Parent IP 

### DIFF
--- a/contracts/registries/LicenseRegistry.sol
+++ b/contracts/registries/LicenseRegistry.sol
@@ -260,6 +260,11 @@ contract LicenseRegistry is ILicenseRegistry, AccessManagedUpgradeable, UUPSUpgr
         }
 
         IP_GRAPH_ACL.allow();
+        // Note: The IPGraph does not validate the parent-child relationship.
+        // It only adds the parent IP to the child IP.
+        // All the validation is done in the LicensingModule:
+        // 1. Should be no duplicate parent IP.
+        // 2. Should not addParentIp again to the same child IP.
         (bool success, ) = IP_GRAPH.call(
             abi.encodeWithSignature("addParentIp(address,address[])", childIpId, parentIpIds)
         );


### PR DESCRIPTION
## Description

This PR adds note comments to the `LicenseRegistry` contract to remind developers to perform necessary validations before calling the IP Graph to add a parent IP. Since the precompiled IP Graph does not validate the parent-child relationship, the `LicensingModule` related contracts should handle these validations to ensure data integrity.

## Key Changes

- **Note Comments**: Added comments to remind developers to validate the parent-child relationship before calling the IP Graph.

Closes https://github.com/FuzzingLabs/story-audit-monorepo/issues/6