### PR TITLE
Restrict Group from Having Derivative or Having Parents, or Minting License Tokens

### DIFF
--- a/contracts/lib/Errors.sol
+++ b/contracts/lib/Errors.sol
@@ -256,6 +256,18 @@ library Errors {
     /// @notice Call failed.
     error LicenseRegistry__CallFailed();
 
+    /// @notice Zero address provide for Group IP Asset Registry.
+    error LicenseRegistry__ZeroGroupIpRegistry();
+
+    /// @notice The empty group cannot be registered as parent IP.
+    error LicenseRegistry__ParentIpIsEmptyGroup(address groupId);
+
+    /// @notice The group cannot be registered as derivative/child IP.
+    error LicenseRegistry__GroupCannotHasParentIp(address groupId);
+
+    /// @notice The empty group cannot mint license token.
+    error LicenseRegistry__EmptyGroupCannotMintLicenseToken(address groupId);
+
     ////////////////////////////////////////////////////////////////////////////
     //                             License Token                              //
     ////////////////////////////////////////////////////////////////////////////

--- a/script/foundry/utils/DeployHelper.sol
+++ b/script/foundry/utils/DeployHelper.sol
@@ -325,6 +325,7 @@ contract DeployHelper is Script, BroadcastManager, JsonDeploymentHandler, Storag
         _predeploy(contractKey);
         impl = address(
             new LicenseRegistry(
+                address(ipAssetRegistry),
                 _getDeployedAddress(type(LicensingModule).name),
                 _getDeployedAddress(type(DisputeModule).name),
                 newDeployedIpGraphACL ? _getDeployedAddress(type(IPGraphACL).name) : address(ipGraphACL)

--- a/test/foundry/mocks/module/LicenseRegistryHarness.sol
+++ b/test/foundry/mocks/module/LicenseRegistryHarness.sol
@@ -5,10 +5,11 @@ import { LicenseRegistry } from "../../../../contracts/registries/LicenseRegistr
 
 contract LicenseRegistryHarness is LicenseRegistry {
     constructor(
+        address _groupIpAssetRegistry,
         address _erc721Registry,
         address _erc1155Registry,
         address _ipGraphAcl
-    ) LicenseRegistry(_erc721Registry, _erc1155Registry, _ipGraphAcl) {}
+    ) LicenseRegistry(_groupIpAssetRegistry, _erc721Registry, _erc1155Registry, _ipGraphAcl) {}
 
     function setExpirationTime(address ipId, uint256 expireTime) external {
         _setExpirationTime(ipId, expireTime);

--- a/test/foundry/modules/grouping/GroupingModule.t.sol
+++ b/test/foundry/modules/grouping/GroupingModule.t.sol
@@ -664,6 +664,24 @@ contract GroupingModuleTest is BaseTest, ERC721Holder {
         vm.prank(ipOwner2);
         licensingModule.attachLicenseTerms(ipId2, address(pilTemplate), termsId);
 
+        Licensing.LicensingConfig memory licensingConfig = Licensing.LicensingConfig({
+            isSet: true,
+            mintingFee: 0,
+            licensingHook: address(0),
+            hookData: "",
+            commercialRevShare: 10 * 10 ** 6,
+            disabled: false,
+            expectMinimumGroupRewardShare: 0,
+            expectGroupRewardPool: address(evenSplitGroupPool)
+        });
+        vm.prank(ipOwner1);
+        licensingModule.setLicensingConfig(ipId1, address(pilTemplate), termsId, licensingConfig);
+
+        address[] memory ipIds = new address[](1);
+        ipIds[0] = ipId1;
+        vm.prank(alice);
+        groupingModule.addIp(groupId, ipIds);
+
         vm.startPrank(ipOwner3);
         address[] memory parentIpIds = new address[](1);
         uint256[] memory licenseTermsIds = new uint256[](1);
@@ -673,18 +691,99 @@ contract GroupingModuleTest is BaseTest, ERC721Holder {
         licensingModule.registerDerivative(ipId3, parentIpIds, licenseTermsIds, address(pilTemplate), "", 0, 100e6);
         vm.stopPrank();
 
-        address[] memory ipIds = new address[](2);
-        ipIds[0] = ipId1;
-        ipIds[1] = ipId2;
+        ipIds = new address[](1);
+        ipIds[0] = ipId2;
         vm.expectRevert(
             abi.encodeWithSelector(Errors.GroupingModule__GroupFrozenDueToHasDerivativeIps.selector, groupId)
         );
         vm.prank(alice);
         groupingModule.addIp(groupId, ipIds);
 
-        assertEq(ipAssetRegistry.totalMembers(groupId), 0);
-        assertEq(rewardPool.getTotalIps(groupId), 0);
-        assertEq(rewardPool.getIpAddedTime(groupId, ipId1), 0);
+        assertEq(ipAssetRegistry.totalMembers(groupId), 1);
+        assertEq(rewardPool.getTotalIps(groupId), 1);
+        assertEq(rewardPool.getIpAddedTime(groupId, ipId1), block.timestamp);
+    }
+
+    function test_GroupingModule_registerDerivative_revert_emptyGroup() public {
+        uint256 termsId = pilTemplate.registerLicenseTerms(
+            PILFlavors.commercialRemix({
+                mintingFee: 0,
+                commercialRevShare: 10,
+                currencyToken: address(erc20),
+                royaltyPolicy: address(royaltyPolicyLAP)
+            })
+        );
+
+        vm.startPrank(alice);
+        address groupId = groupingModule.registerGroup(address(rewardPool));
+        licensingModule.attachLicenseTerms(groupId, address(pilTemplate), termsId);
+        vm.stopPrank();
+
+        vm.prank(ipOwner1);
+        licensingModule.attachLicenseTerms(ipId1, address(pilTemplate), termsId);
+        vm.prank(ipOwner2);
+        licensingModule.attachLicenseTerms(ipId2, address(pilTemplate), termsId);
+
+        vm.startPrank(ipOwner3);
+        address[] memory parentIpIds = new address[](1);
+        uint256[] memory licenseTermsIds = new uint256[](1);
+        parentIpIds[0] = groupId;
+        licenseTermsIds[0] = termsId;
+
+        vm.expectRevert(abi.encodeWithSelector(Errors.LicenseRegistry__ParentIpIsEmptyGroup.selector, groupId));
+        licensingModule.registerDerivative(ipId3, parentIpIds, licenseTermsIds, address(pilTemplate), "", 0, 100e6);
+        vm.stopPrank();
+    }
+
+    function test_GroupingModule_mintLicenseToken_revert_emptyGroup() public {
+        uint256 termsId = pilTemplate.registerLicenseTerms(
+            PILFlavors.commercialRemix({
+                mintingFee: 0,
+                commercialRevShare: 10,
+                currencyToken: address(erc20),
+                royaltyPolicy: address(royaltyPolicyLAP)
+            })
+        );
+
+        vm.startPrank(alice);
+        address groupId = groupingModule.registerGroup(address(rewardPool));
+        licensingModule.attachLicenseTerms(groupId, address(pilTemplate), termsId);
+        vm.stopPrank();
+
+        vm.startPrank(ipOwner3);
+        vm.expectRevert(
+            abi.encodeWithSelector(Errors.LicenseRegistry__EmptyGroupCannotMintLicenseToken.selector, groupId)
+        );
+        licensingModule.mintLicenseTokens(groupId, address(pilTemplate), termsId, 1, ipOwner3, "", 0);
+        vm.stopPrank();
+    }
+
+    function test_GroupingModule_registerDerivative_revert_registerGroupAsChild() public {
+        uint256 termsId = pilTemplate.registerLicenseTerms(
+            PILFlavors.commercialRemix({
+                mintingFee: 0,
+                commercialRevShare: 10,
+                currencyToken: address(erc20),
+                royaltyPolicy: address(royaltyPolicyLAP)
+            })
+        );
+
+        vm.startPrank(alice);
+        address groupId = groupingModule.registerGroup(address(rewardPool));
+        vm.stopPrank();
+
+        vm.prank(ipOwner1);
+        licensingModule.attachLicenseTerms(ipId1, address(pilTemplate), termsId);
+
+        vm.startPrank(alice);
+        address[] memory parentIpIds = new address[](1);
+        uint256[] memory licenseTermsIds = new uint256[](1);
+        parentIpIds[0] = ipId1;
+        licenseTermsIds[0] = termsId;
+
+        vm.expectRevert(abi.encodeWithSelector(Errors.LicenseRegistry__GroupCannotHasParentIp.selector, groupId));
+        licensingModule.registerDerivative(groupId, parentIpIds, licenseTermsIds, address(pilTemplate), "", 0, 100e6);
+        vm.stopPrank();
     }
 
     function test_GroupingModule_removeIp_revert_after_registerDerivative() public {

--- a/test/foundry/utils/BaseTest.t.sol
+++ b/test/foundry/utils/BaseTest.t.sol
@@ -101,7 +101,12 @@ contract BaseTest is Test, DeployHelper, LicensingHelper {
 
         ipAccountRegistry = IPAccountRegistry(ipAssetRegistry);
         lrHarnessImpl = address(
-            new LicenseRegistryHarness(address(licensingModule), address(disputeModule), address(ipGraphACL))
+            new LicenseRegistryHarness(
+                address(ipAssetRegistry),
+                address(licensingModule),
+                address(disputeModule),
+                address(ipGraphACL)
+            )
         );
 
         mockArbitrationPolicy = new MockArbitrationPolicy(address(disputeModule), address(USDC), ARBITRATION_PRICE);


### PR DESCRIPTION
## Description

This PR introduces restrictions to ensure that an empty group cannot have derivative IPs or mint license tokens. Additionally, it prevents a group IP from having any parent IPs. These changes are necessary to maintain the integrity and consistency of the IP management process.

## Key Changes

- **Empty Group Restrictions**: Added checks to prevent empty groups from having derivative IPs or minting license tokens.
- **Group IP Parent Restriction**: Added a check to prevent group IPs from having any parent IPs.

Closes https://github.com/storyprotocol/trust-protocol-contracts-v1/issues/26