### PR TITLE
Reset Reward Token Allowance to 0  to RoyaltyModule

### DIFF
--- a/contracts/modules/grouping/EvenSplitGroupPool.sol
+++ b/contracts/modules/grouping/EvenSplitGroupPool.sol
@@ -157,6 +157,7 @@ contract EvenSplitGroupPool is IGroupRewardPool, ProtocolPausableUpgradeable, UU
             // call royalty module to transfer reward to IP's vault as royalty
             ROYALTY_MODULE.payRoyaltyOnBehalf(ipIds[i], groupId, token, rewards[i]);
         }
+        IERC20(token).forceApprove(address(ROYALTY_MODULE), 0);
     }
 
     function getTotalIps(address groupId) external view returns (uint256) {


### PR DESCRIPTION
## Description

This PR updates the `EvenSplitGroupPool` contract's `distributeRewards` function to reset the allowance to 0 at the end of the function. This change ensures that the contract does not retain any unnecessary allowances, enhancing security and preventing potential misuse.

## Key Changes

- **Allowance Reset**: Added code to reset the allowance to 0 at the end of the `distributeRewards` function in the `EvenSplitGroupPool` contract.

Closes https://github.com/storyprotocol/trust-protocol-contracts-v1/issues/10

