### PR TITLE
NatSpec fix in IpRoyaltyVault.sol

### DIFF
--- a/contracts/modules/royalty/policies/IpRoyaltyVault.sol
+++ b/contracts/modules/royalty/policies/IpRoyaltyVault.sol
@@ -32,7 +32,7 @@ contract IpRoyaltyVault is IIpRoyaltyVault, ERC20Upgradeable, ReentrancyGuardUpg
     /// @param claimableAtSnapshot [DEPRECATED] Amount of revenue token claimable at a given snapshot
     /// @param isClaimedAtSnapshot [DEPRECATED] Indicates whether the claimer has claimed the token at a given snapshot
     /// @param tokens The list of revenue tokens in the vault
-    /// @param revenueAccBalances The accumulated balance of revenue tokens in the vault
+    /// @param vaultAccBalances The accumulated balance of revenue tokens in the vault
     /// @param claimerRevenueDebt The revenue debt of the claimer, used to calculate the claimable revenue,
     /// positive value means claimed need to deducted, negative value means claimable from vault
     /// @custom:storage-location erc7201:story-protocol.IpRoyaltyVault


### PR DESCRIPTION
## Description
Rename outdated NatSpec `revenueAccBalances` parameter to `vaultAccBalances`.