### PR TITLE
Add More Validations to Group IPA

### DIFF
--- a/contracts/lib/Errors.sol
+++ b/contracts/lib/Errors.sol
@@ -271,6 +271,36 @@ library Errors {
     /// @notice The empty group cannot mint license token.
     error LicenseRegistry__EmptyGroupCannotMintLicenseToken(address groupId);
 
+    /// @notice The group can only attach one license terms which is common for all members.
+    error LicenseRegistry__GroupIpAlreadyHasLicenseTerms(address groupId);
+
+    /// @notice The license template cannot be Zero address.
+    error LicenseRegistry__LicenseTemplateCannotBeZeroAddress();
+
+    /// @notice license minting fee configured in IP must be identical to the group minting fee.
+    error LicenseRegistry__IpMintingFeeNotMatchWithGroup(address ipId, uint256 mintingFee, uint256 groupMintingFee);
+
+    /// @notice licensing hook configured in IP must be identical to the group licensing hook.
+    error LicenseRegistry__IpLicensingHookNotMatchWithGroup(
+        address ipId,
+        address licensingHook,
+        address groupLicensingHook
+    );
+
+    /// @notice licensing hook data configured in IP must be identical to the group licensing hook data.
+    error LicenseRegistry__IpLicensingHookDataNotMatchWithGroup(
+        address ipId,
+        bytes hookData,
+        bytes groupHookData
+    );
+
+    /// @notice commercial revenue share configured in group must be NOT less than the IP commercial revenue share.
+    error LicenseRegistry__GroupIpCommercialRevShareConfigMustNotLessThanIp(
+        address groupId,
+        uint32 ipCommercialRevShare,
+        uint32 groupCommercialRevShare
+    );
+
     ////////////////////////////////////////////////////////////////////////////
     //                             License Token                              //
     ////////////////////////////////////////////////////////////////////////////
@@ -401,6 +431,28 @@ library Errors {
 
     /// @notice register derivative require all parent IP to have the same royalty policy.
     error LicensingModule__RoyaltyPolicyMismatch(address royaltyPolicy, address anotherRoyaltyPolicy);
+
+    /// @notice The group IP cannot enable/disable the licensing configuration once it has members.
+    error LicensingModule__GroupIpCannotChangeIsSet(address groupId);
+
+    /// @notice The group IP cannot change minting fee once it has members.
+    error LicensingModule__GroupIpCannotChangeMintingFee(address groupId);
+
+    /// @notice The group IP cannot change licensing hook once it has members.
+    error LicensingModule__GroupIpCannotChangeLicensingHook(address groupId);
+
+    /// @notice The group IP cannot change hook data once it has members.
+    error LicensingModule__GroupIpCannotChangeHookData(address groupId);
+
+    /// @notice The group Ip cannot specify expect group reward pool, as a group cannot be added to another group.
+    error LicensingModule__GroupIpCannotSetExpectGroupRewardPool(address groupId);
+
+    /// @notice GroupIP cannot decrease the royalty percentage.
+    error LicensingModule__GroupIpCannotDecreaseRoyalty(
+        address groupId,
+        uint32 newRoyaltyPercent,
+        uint32 oldRoyaltyPercent
+    );
 
     ////////////////////////////////////////////////////////////////////////////
     //                             Dispute Module                             //

--- a/contracts/lib/Errors.sol
+++ b/contracts/lib/Errors.sol
@@ -288,11 +288,7 @@ library Errors {
     );
 
     /// @notice licensing hook data configured in IP must be identical to the group licensing hook data.
-    error LicenseRegistry__IpLicensingHookDataNotMatchWithGroup(
-        address ipId,
-        bytes hookData,
-        bytes groupHookData
-    );
+    error LicenseRegistry__IpLicensingHookDataNotMatchWithGroup(address ipId, bytes hookData, bytes groupHookData);
 
     /// @notice commercial revenue share configured in group must be NOT less than the IP commercial revenue share.
     error LicenseRegistry__GroupIpCommercialRevShareConfigMustNotLessThanIp(

--- a/contracts/registries/LicenseRegistry.sol
+++ b/contracts/registries/LicenseRegistry.sol
@@ -333,6 +333,7 @@ contract LicenseRegistry is ILicenseRegistry, AccessManagedUpgradeable, UUPSUpgr
     /// @param groupLicenseTermsId The ID of the license terms attached to the group.
     /// the IP must have this license terms.
     /// @return ipLicensingConfig The configuration for license attached to the IP.
+    // solhint-disable code-complexity
     function verifyGroupAddIp(
         address groupId,
         address groupRewardPool,

--- a/contracts/registries/LicenseRegistry.sol
+++ b/contracts/registries/LicenseRegistry.sol
@@ -197,6 +197,13 @@ contract LicenseRegistry is ILicenseRegistry, AccessManagedUpgradeable, UUPSUpgr
         if (!_exists(licenseTemplate, licenseTermsId)) {
             revert Errors.LicensingModule__LicenseTermsNotFound(licenseTemplate, licenseTermsId);
         }
+        // The group can only attach one license terms which is common for all members.
+        if (
+            GROUP_IP_ASSET_REGISTRY.isRegisteredGroup(ipId) &&
+            _getLicenseRegistryStorage().attachedLicenseTerms[ipId].length() > 0
+        ) {
+            revert Errors.LicenseRegistry__GroupIpAlreadyHasLicenseTerms(ipId);
+        }
 
         if (_isExpiredNow(ipId)) {
             revert Errors.LicenseRegistry__IpExpired(ipId);
@@ -356,6 +363,39 @@ contract LicenseRegistry is ILicenseRegistry, AccessManagedUpgradeable, UUPSUpgr
         if (_getExpireTime(ipId) != 0) {
             revert Errors.LicenseRegistry__CannotAddIpWithExpirationToGroup(ipId);
         }
+        // ipId must have the same license config items with group IP
+        Licensing.LicensingConfig memory groupLct = _getLicensingConfig(
+            groupId,
+            groupLicenseTemplate,
+            groupLicenseTermsId
+        );
+        // minting fee must be the same
+        if (lct.mintingFee != groupLct.mintingFee) {
+            revert Errors.LicenseRegistry__IpMintingFeeNotMatchWithGroup(ipId, lct.mintingFee, groupLct.mintingFee);
+        }
+        // hook must be the same
+        if (lct.licensingHook != groupLct.licensingHook) {
+            revert Errors.LicenseRegistry__IpLicensingHookNotMatchWithGroup(
+                ipId,
+                lct.licensingHook,
+                groupLct.licensingHook
+            );
+        }
+        // hook data must be the same
+        if (
+            lct.hookData.length != groupLct.hookData.length || keccak256(lct.hookData) != keccak256(groupLct.hookData)
+        ) {
+            revert Errors.LicenseRegistry__IpLicensingHookDataNotMatchWithGroup(ipId, lct.hookData, groupLct.hookData);
+        }
+        // group commercial revenue share must be greater than or equal to IP commercial revenue share
+        if (groupLct.commercialRevShare < lct.commercialRevShare) {
+            revert Errors.LicenseRegistry__GroupIpCommercialRevShareConfigMustNotLessThanIp(
+                ipId,
+                lct.commercialRevShare,
+                groupLct.commercialRevShare
+            );
+        }
+
         ipLicensingConfig = lct;
     }
 

--- a/test/foundry/integration/flows/grouping/Grouping.t.sol
+++ b/test/foundry/integration/flows/grouping/Grouping.t.sol
@@ -69,13 +69,18 @@ contract Flows_Integration_Grouping is BaseIntegration, ERC721Holder {
             expectGroupRewardPool: address(evenSplitGroupPool)
         });
 
+        licensingConfig.expectGroupRewardPool = address(0);
+
         {
             vm.startPrank(groupOwner);
             groupId = groupingModule.registerGroup(address(evenSplitGroupPool));
             vm.label(groupId, "Group1");
             licensingModule.attachLicenseTerms(groupId, address(pilTemplate), commRemixTermsId);
+            licensingModule.setLicensingConfig(groupId, address(pilTemplate), commRemixTermsId, licensingConfig);
             vm.stopPrank();
         }
+
+        licensingConfig.expectGroupRewardPool = address(evenSplitGroupPool);
         {
             vm.startPrank(u.alice);
             ipAcct[1] = registerIpAccount(mockNFT, 1, u.alice);

--- a/test/foundry/modules/grouping/GroupingModule.t.sol
+++ b/test/foundry/modules/grouping/GroupingModule.t.sol
@@ -160,6 +160,8 @@ contract GroupingModuleTest is BaseTest, ERC721Holder {
 
         vm.startPrank(alice);
         licensingModule.attachLicenseTerms(groupId, address(pilTemplate), termsId);
+        licensingConfig.expectGroupRewardPool = address(0);
+        licensingModule.setLicensingConfig(groupId, address(pilTemplate), termsId, licensingConfig);
         address[] memory ipIds = new address[](2);
         ipIds[0] = ipId1;
         ipIds[1] = ipId2;
@@ -204,8 +206,10 @@ contract GroupingModuleTest is BaseTest, ERC721Holder {
         licensingModule.setLicensingConfig(ipId2, address(pilTemplate), termsId, licensingConfig);
         vm.stopPrank();
 
+        licensingConfig.expectGroupRewardPool = address(0);
         vm.startPrank(alice);
         licensingModule.attachLicenseTerms(groupId, address(pilTemplate), termsId);
+        licensingModule.setLicensingConfig(groupId, address(pilTemplate), termsId, licensingConfig);
         address[] memory ipIds = new address[](2);
         ipIds[0] = ipId1;
         ipIds[1] = ipId2;
@@ -254,8 +258,10 @@ contract GroupingModuleTest is BaseTest, ERC721Holder {
         licensingModule.mintLicenseTokens(ipId2, address(pilTemplate), termsId, 1, address(this), "", 0);
         vm.stopPrank();
 
+        licensingConfig.expectGroupRewardPool = address(0);
         vm.startPrank(alice);
         licensingModule.attachLicenseTerms(groupId, address(pilTemplate), termsId);
+        licensingModule.setLicensingConfig(groupId, address(pilTemplate), termsId, licensingConfig);
         address[] memory ipIds = new address[](2);
         ipIds[0] = ipId1;
         ipIds[1] = ipId2;
@@ -332,8 +338,10 @@ contract GroupingModuleTest is BaseTest, ERC721Holder {
         licensingModule.mintLicenseTokens(ipId2, address(pilTemplate), termsId, 1, address(this), "", 0);
         vm.stopPrank();
 
+        licensingConfig.expectGroupRewardPool = address(0);
         vm.startPrank(alice);
         licensingModule.attachLicenseTerms(groupId, address(pilTemplate), termsId);
+        licensingModule.setLicensingConfig(groupId, address(pilTemplate), termsId, licensingConfig);
         address[] memory ipIds = new address[](2);
         ipIds[0] = ipId1;
         ipIds[1] = ipId2;
@@ -650,10 +658,6 @@ contract GroupingModuleTest is BaseTest, ERC721Holder {
                 royaltyPolicy: address(royaltyPolicyLAP)
             })
         );
-        vm.startPrank(alice);
-        address groupId1 = groupingModule.registerGroup(address(rewardPool));
-        licensingModule.attachLicenseTerms(groupId1, address(pilTemplate), termsId);
-        vm.stopPrank();
 
         Licensing.LicensingConfig memory licensingConfig = Licensing.LicensingConfig({
             isSet: true,
@@ -674,6 +678,13 @@ contract GroupingModuleTest is BaseTest, ERC721Holder {
         vm.startPrank(ipOwner2);
         licensingModule.attachLicenseTerms(ipId2, address(pilTemplate), termsId);
         licensingModule.setLicensingConfig(ipId2, address(pilTemplate), termsId, licensingConfig);
+        vm.stopPrank();
+
+        licensingConfig.expectGroupRewardPool = address(0);
+        vm.startPrank(alice);
+        address groupId1 = groupingModule.registerGroup(address(rewardPool));
+        licensingModule.attachLicenseTerms(groupId1, address(pilTemplate), termsId);
+        licensingModule.setLicensingConfig(groupId1, address(pilTemplate), termsId, licensingConfig);
         vm.stopPrank();
 
         address[] memory ipIds = new address[](1);
@@ -760,11 +771,6 @@ contract GroupingModuleTest is BaseTest, ERC721Holder {
             })
         );
 
-        vm.startPrank(alice);
-        address groupId = groupingModule.registerGroup(address(rewardPool));
-        licensingModule.attachLicenseTerms(groupId, address(pilTemplate), termsId);
-        vm.stopPrank();
-
         vm.prank(ipOwner1);
         licensingModule.attachLicenseTerms(ipId1, address(pilTemplate), termsId);
         vm.prank(ipOwner2);
@@ -782,6 +788,13 @@ contract GroupingModuleTest is BaseTest, ERC721Holder {
         });
         vm.prank(ipOwner1);
         licensingModule.setLicensingConfig(ipId1, address(pilTemplate), termsId, licensingConfig);
+
+        licensingConfig.expectGroupRewardPool = address(0);
+        vm.startPrank(alice);
+        address groupId = groupingModule.registerGroup(address(rewardPool));
+        licensingModule.attachLicenseTerms(groupId, address(pilTemplate), termsId);
+        licensingModule.setLicensingConfig(groupId, address(pilTemplate), termsId, licensingConfig);
+        vm.stopPrank();
 
         address[] memory ipIds = new address[](1);
         ipIds[0] = ipId1;
@@ -922,9 +935,11 @@ contract GroupingModuleTest is BaseTest, ERC721Holder {
         licensingModule.setLicensingConfig(ipId2, address(pilTemplate), termsId, licensingConfig);
         vm.stopPrank();
 
+        licensingConfig.expectGroupRewardPool = address(0);
         vm.startPrank(alice);
         address groupId = groupingModule.registerGroup(address(rewardPool));
         licensingModule.attachLicenseTerms(groupId, address(pilTemplate), termsId);
+        licensingModule.setLicensingConfig(groupId, address(pilTemplate), termsId, licensingConfig);
         address[] memory ipIds = new address[](2);
         ipIds[0] = ipId1;
         ipIds[1] = ipId2;


### PR DESCRIPTION
## Description

This PR introduces additional validations to the Group IPA to ensure consistency and integrity in the licensing process. The changes include restrictions on attaching license terms, requirements for adding IPs to a group, and freezing certain license configuration items once the group has its first member.

## Key Changes

- **Single License Term Validation**: Ensures that a Group IPA can only attach one license term, which must be common to all members.
- **Consistent License Config Validation**: When adding an IP to a Group, the Group and IP must have the same `mintingFee` and `licenseHook` in the `LicenseConfig`. Additionally, the Group's commercial revenue share must be greater than or equal to the IP's commercial revenue share.
- **Freezing License Config Items**: Once a Group has its first member, the `mintingFee`, `licensingHook`, and `licensingHookData` are frozen. The Group's commercial revenue share can only increase.

## Objectives

- **Ensure Consistency**: Prevent Group IPAs from attaching more than one license term and ensure consistent license configurations when adding IPs to a Group.
- **Maintain Integrity**: Freeze certain license configuration items once the Group has its first member to maintain the integrity of the Group's licensing process.

Closes https://github.com/storyprotocol/trust-protocol-contracts-v1/issues/7