### PR TITLE
Prevent Re-Charge of IP Registration Fee for Idempotent Registration

### DIFF
--- a/contracts/registries/IPAssetRegistry.sol
+++ b/contracts/registries/IPAssetRegistry.sol
@@ -119,7 +119,6 @@ contract IPAssetRegistry is
             emit IPRegistrationFeePaid(registerFeePayer, treasury, feeToken, feeAmount);
         }
 
-
         (string memory name, string memory uri) = _getNameAndUri(chainid, tokenContract, tokenId);
         uint256 registrationDate = block.timestamp;
         ipAccount.setString("NAME", name);

--- a/contracts/registries/IPAssetRegistry.sol
+++ b/contracts/registries/IPAssetRegistry.sol
@@ -101,8 +101,15 @@ contract IPAssetRegistry is
         uint256 tokenId,
         address registerFeePayer
     ) internal override returns (address id) {
-        IPAssetRegistryStorage storage $ = _getIPAssetRegistryStorage();
+        id = _registerIpAccount(chainid, tokenContract, tokenId);
+        IIPAccount ipAccount = IIPAccount(payable(id));
 
+        // return if the IP was already registered
+        if (bytes(ipAccount.getString("NAME")).length != 0) {
+            return id;
+        }
+
+        IPAssetRegistryStorage storage $ = _getIPAssetRegistryStorage();
         // Pay registration fee
         uint96 feeAmount = $.feeAmount;
         if (feeAmount > 0) {
@@ -112,13 +119,6 @@ contract IPAssetRegistry is
             emit IPRegistrationFeePaid(registerFeePayer, treasury, feeToken, feeAmount);
         }
 
-        id = _registerIpAccount(chainid, tokenContract, tokenId);
-        IIPAccount ipAccount = IIPAccount(payable(id));
-
-        // return if the IP was already registered
-        if (bytes(ipAccount.getString("NAME")).length != 0) {
-            return id;
-        }
 
         (string memory name, string memory uri) = _getNameAndUri(chainid, tokenContract, tokenId);
         uint256 registrationDate = block.timestamp;


### PR DESCRIPTION
## Description

This PR updates the IP registration process to prevent re-charging the registration fee when the same IP is registered idempotently. This change ensures that users are not charged multiple times for registering the same IP, enhancing the user experience and preventing unnecessary costs.

This PR was originally initiated by @maxisch in [PR #1](https://github.com/kingster-will/protocol-core-v1-dev/pull/1).

## Key Changes

- **Idempotent Registration**: Added logic to check if an IP is already registered and prevent re-charging the registration fee if it is.

