### PR TITLE
Implement EIP-1271 with Access Control for IP Account

### DIFF
--- a/contracts/IPAccountImpl.sol
+++ b/contracts/IPAccountImpl.sol
@@ -250,10 +250,7 @@ contract IPAccountImpl is ERC6551, IPAccountStorage, IIPAccount {
     }
 
     /// @dev Returns whether the `signature` is valid for the `hash.
-    function _erc1271IsValidSignature(
-        bytes32 hash,
-        bytes calldata signature
-    ) internal view override returns (bool) {
+    function _erc1271IsValidSignature(bytes32 hash, bytes calldata signature) internal view override returns (bool) {
         uint8 v = uint8(signature[64]);
         address signer;
 

--- a/contracts/IPAccountImpl.sol
+++ b/contracts/IPAccountImpl.sol
@@ -5,6 +5,7 @@ import { IERC165 } from "@openzeppelin/contracts/utils/introspection/ERC165.sol"
 import { IERC721Receiver } from "@openzeppelin/contracts/token/ERC721/IERC721Receiver.sol";
 import { IERC1155Receiver } from "@openzeppelin/contracts/token/ERC1155/IERC1155Receiver.sol";
 import { SignatureChecker } from "@openzeppelin/contracts/utils/cryptography/SignatureChecker.sol";
+import { ECDSA } from "@openzeppelin/contracts/utils/cryptography/ECDSA.sol";
 import { MessageHashUtils } from "@openzeppelin/contracts/utils/cryptography/MessageHashUtils.sol";
 import { IERC6551Account } from "erc6551/interfaces/IERC6551Account.sol";
 import { IERC6551Executable } from "erc6551/interfaces/IERC6551Executable.sol";
@@ -246,6 +247,38 @@ contract IPAccountImpl is ERC6551, IPAccountStorage, IIPAccount {
         bytes calldata context
     ) internal view override returns (bool) {
         return isValidSigner(signer, address(uint160(uint256(extraData))), context);
+    }
+
+    /// @dev Returns whether the `signature` is valid for the `hash.
+    function _erc1271IsValidSignature(
+        bytes32 hash,
+        bytes calldata signature
+    ) internal view override returns (bool) {
+        uint8 v = uint8(signature[64]);
+        address signer;
+
+        // Smart contract signature
+        if (v == 0) {
+            // Signer address encoded in r
+            signer = address(uint160(uint256(bytes32(signature[:32]))));
+
+            // Allow recursive signature verification
+            if (!this.isValidSigner(signer, address(0), "") && signer != address(this)) {
+                return false;
+            }
+
+            // Signature offset encoded in s
+            bytes calldata _signature = signature[uint256(bytes32(signature[32:64])):];
+
+            return SignatureChecker.isValidERC1271SignatureNow(signer, hash, _signature);
+        }
+
+        ECDSA.RecoverError _error;
+        (signer, _error, ) = ECDSA.tryRecover(hash, signature);
+
+        if (_error != ECDSA.RecoverError.NoError) return false;
+
+        return this.isValidSigner(signer, address(0), "");
     }
 
     /// @dev Override Solady EIP712 function and return EIP712 domain name for IPAccount.

--- a/test/foundry/IPAccountMetaTx.t.sol
+++ b/test/foundry/IPAccountMetaTx.t.sol
@@ -190,7 +190,6 @@ contract IPAccountMetaTxTest is BaseTest {
         assertEq(ipAccount.state(), expectedState);
     }
 
-
     function test_IPAccount_isValidSignature() public {
         uint256 tokenId = 100;
 
@@ -255,7 +254,10 @@ contract IPAccountMetaTxTest is BaseTest {
         (uint8 v, bytes32 r, bytes32 s) = vm.sign(ownerPrivateKey, digest);
 
         bytes memory signature = abi.encodePacked(r, s, v);
-        assertEq(ERC6551(payable(address(ipAccount))).isValidSignature(digest, signature), ERC1271.isValidSignature.selector);
+        assertEq(
+            ERC6551(payable(address(ipAccount))).isValidSignature(digest, signature),
+            ERC1271.isValidSignature.selector
+        );
     }
 
     function test_IPAccount_setPermissionWithSignatureThenCallAccessControlledModule() public {

--- a/test/foundry/IPAccountMetaTx.t.sol
+++ b/test/foundry/IPAccountMetaTx.t.sol
@@ -2,6 +2,8 @@
 pragma solidity 0.8.26;
 
 import { MessageHashUtils } from "@openzeppelin/contracts/utils/cryptography/MessageHashUtils.sol";
+import { ERC6551 } from "@solady/src/accounts/ERC6551.sol";
+import { ERC1271 } from "@solady/src/accounts/ERC1271.sol";
 
 import { IIPAccount } from "../../contracts/interfaces/IIPAccount.sol";
 import { MetaTx } from "../../contracts/lib/MetaTx.sol";
@@ -186,6 +188,74 @@ contract IPAccountMetaTxTest is BaseTest {
         assertEq("test", abi.decode(result, (string)));
 
         assertEq(ipAccount.state(), expectedState);
+    }
+
+
+    function test_IPAccount_isValidSignature() public {
+        uint256 tokenId = 100;
+
+        mockNFT.mintId(owner, tokenId);
+
+        address account = ipAssetRegistry.register(block.chainid, address(mockNFT), tokenId);
+
+        IIPAccount ipAccount = IIPAccount(payable(account));
+
+        uint deadline = block.timestamp + 1000;
+
+        bytes32 setPermissionState = keccak256(
+            abi.encode(
+                ipAccount.state(),
+                abi.encodeWithSignature(
+                    "execute(address,uint256,bytes)",
+                    address(accessController),
+                    0,
+                    abi.encodeWithSignature(
+                        "setPermission(address,address,address,bytes4,uint8)",
+                        address(ipAccount),
+                        address(metaTxModule),
+                        address(module),
+                        bytes4(0),
+                        AccessPermission.ALLOW
+                    )
+                )
+            )
+        );
+        bytes32 expectedState = keccak256(
+            abi.encode(
+                setPermissionState,
+                abi.encodeWithSignature(
+                    "execute(address,uint256,bytes)",
+                    address(module),
+                    0,
+                    abi.encodeWithSignature("executeSuccessfully(string)", "test")
+                )
+            )
+        );
+
+        bytes32 digest = MessageHashUtils.toTypedDataHash(
+            MetaTx.calculateDomainSeparator(address(ipAccount)),
+            MetaTx.getExecuteStructHash(
+                MetaTx.Execute({
+                    to: address(accessController),
+                    value: 0,
+                    data: abi.encodeWithSignature(
+                        "setPermission(address,address,address,bytes4,uint8)",
+                        address(ipAccount),
+                        address(metaTxModule),
+                        address(module),
+                        bytes4(0),
+                        AccessPermission.ALLOW
+                    ),
+                    nonce: setPermissionState,
+                    deadline: deadline
+                })
+            )
+        );
+
+        (uint8 v, bytes32 r, bytes32 s) = vm.sign(ownerPrivateKey, digest);
+
+        bytes memory signature = abi.encodePacked(r, s, v);
+        assertEq(ERC6551(payable(address(ipAccount))).isValidSignature(digest, signature), ERC1271.isValidSignature.selector);
     }
 
     function test_IPAccount_setPermissionWithSignatureThenCallAccessControlledModule() public {


### PR DESCRIPTION
## Description

This PR implements EIP-1271 for the IP Account, adding support for contract-based signature validation. It also integrates access control mechanisms to ensure that only authorized signers can be considered is valid signature.

## Key Changes

- **EIP-1271 Implementation**: Added support for EIP-1271 to validate signatures from smart contract.

This update enhances the security of the IP Account by ensuring that only authorized signers can execute transactions and supports contract-based signature validation as per EIP-1271.


Closes https://github.com/FuzzingLabs/story-audit-monorepo/issues/10