### PR TITLE
Introduce `maxRevenueShare` for Minting License Tokens and Registering Derivatives

### DIFF
--- a/contracts/LicenseToken.sol
+++ b/contracts/LicenseToken.sol
@@ -88,6 +88,7 @@ contract LicenseToken is ILicenseToken, ERC721EnumerableUpgradeable, AccessManag
     /// @param amount The amount of License Tokens to mint.
     /// @param minter The address of the minter.
     /// @param receiver The address of the receiver of the minted License Tokens.
+    /// @param maxRevenueShare The maximum revenue share percentage allowed for minting the License Tokens.
     /// @return startLicenseTokenId The start ID of the minted License Tokens.
     function mintLicenseTokens(
         address licensorIpId,
@@ -95,7 +96,8 @@ contract LicenseToken is ILicenseToken, ERC721EnumerableUpgradeable, AccessManag
         uint256 licenseTermsId,
         uint256 amount, // mint amount
         address minter,
-        address receiver
+        address receiver,
+        uint32 maxRevenueShare
     ) external onlyLicensingModule returns (uint256 startLicenseTokenId) {
         LicenseTokenMetadata memory ltm = LicenseTokenMetadata({
             licensorIpId: licensorIpId,
@@ -104,7 +106,15 @@ contract LicenseToken is ILicenseToken, ERC721EnumerableUpgradeable, AccessManag
             transferable: ILicenseTemplate(licenseTemplate).isLicenseTransferable(licenseTermsId),
             commercialRevShare: LICENSE_REGISTRY.getRoyaltyPercent(licensorIpId, licenseTemplate, licenseTermsId)
         });
-
+        if (maxRevenueShare != 0 && ltm.commercialRevShare > maxRevenueShare) {
+            revert Errors.LicenseToken__CommercialRevenueShareExceedMaxRevenueShare(
+                ltm.commercialRevShare,
+                maxRevenueShare,
+                licensorIpId,
+                licenseTemplate,
+                licenseTermsId
+            );
+        }
         if (ltm.commercialRevShare > MAX_COMMERCIAL_REVENUE_SHARE) {
             revert Errors.LicenseToken__InvalidRoyaltyPercent(
                 ltm.commercialRevShare,

--- a/contracts/interfaces/ILicenseToken.sol
+++ b/contracts/interfaces/ILicenseToken.sol
@@ -41,6 +41,7 @@ interface ILicenseToken is IERC721Metadata, IERC721Enumerable {
     /// @param amount The amount of License Tokens to mint.
     /// @param minter The address of the minter.
     /// @param receiver The address of the receiver of the minted License Tokens.
+    /// @param maxRevenueShare The maximum revenue share percentage allowed for minting the License Tokens.
     /// @return startLicenseTokenId The start ID of the minted License Tokens.
     function mintLicenseTokens(
         address licensorIpId,
@@ -48,7 +49,8 @@ interface ILicenseToken is IERC721Metadata, IERC721Enumerable {
         uint256 licenseTermsId,
         uint256 amount, // mint amount
         address minter,
-        address receiver
+        address receiver,
+        uint32 maxRevenueShare
     ) external returns (uint256 startLicenseTokenId);
 
     /// @notice Burns specified License Tokens.

--- a/contracts/interfaces/modules/licensing/ILicensingModule.sol
+++ b/contracts/interfaces/modules/licensing/ILicensingModule.sol
@@ -83,6 +83,7 @@ interface ILicensingModule is IModule {
     /// @param receiver The address of the receiver.
     /// @param royaltyContext The context of the royalty.
     /// @param maxMintingFee The maximum minting fee that the caller is willing to pay. if set to 0 then no limit.
+    /// @param maxRevenueShare The maximum revenue share percentage allowed for minting the License Tokens.
     /// @return startLicenseTokenId The start ID of the minted license tokens.
     function mintLicenseTokens(
         address licensorIpId,
@@ -91,7 +92,8 @@ interface ILicensingModule is IModule {
         uint256 amount,
         address receiver,
         bytes calldata royaltyContext,
-        uint256 maxMintingFee
+        uint256 maxMintingFee,
+        uint32 maxRevenueShare
     ) external returns (uint256 startLicenseTokenId);
 
     /// @notice Registers a derivative directly with parent IP's license terms, without needing license tokens,
@@ -106,6 +108,7 @@ interface ILicensingModule is IModule {
     /// @param royaltyContext The context of the royalty.
     /// @param maxMintingFee The maximum minting fee that the caller is willing to pay. if set to 0 then no limit.
     /// @param maxRts The maximum number of royalty tokens that can be distributed to the external royalty policies.
+    /// @param maxRevenueShare The maximum revenue share percentage allowed for minting the License Tokens.
     function registerDerivative(
         address childIpId,
         address[] calldata parentIpIds,
@@ -113,7 +116,8 @@ interface ILicensingModule is IModule {
         address licenseTemplate,
         bytes calldata royaltyContext,
         uint256 maxMintingFee,
-        uint32 maxRts
+        uint32 maxRts,
+        uint32 maxRevenueShare
     ) external;
 
     /// @notice Registers a derivative with license tokens.

--- a/contracts/lib/Errors.sol
+++ b/contracts/lib/Errors.sol
@@ -337,7 +337,14 @@ library Errors {
         address licenseTemplate,
         uint256 licenseTermsId
     );
-
+    /// @notice Commercial revenue share exceeds the maximum revenue share set by the minter of license token.
+    error LicenseToken__CommercialRevenueShareExceedMaxRevenueShare(
+        uint32 commercialRevenueShare,
+        uint32 maxRevenueShare,
+        address ipId,
+        address licenseTemplate,
+        uint256 licenseTermsId
+    );
     ////////////////////////////////////////////////////////////////////////////
     //                           Licensing Module                             //
     ////////////////////////////////////////////////////////////////////////////
@@ -448,6 +455,15 @@ library Errors {
         address groupId,
         uint32 newRoyaltyPercent,
         uint32 oldRoyaltyPercent
+    );
+
+    /// @notice Parent IP Royalty percentage is above the maximum royalty percentage.
+    error LicensingModule__ExceedMaxRevenueShare(
+        address ipId,
+        address licenseTemplate,
+        uint256 licenseTermsId,
+        uint32 revenueShare,
+        uint32 maxRevenueShare
     );
 
     ////////////////////////////////////////////////////////////////////////////

--- a/test/foundry/LicenseToken.t.sol
+++ b/test/foundry/LicenseToken.t.sol
@@ -66,7 +66,8 @@ contract LicenseTokenTest is BaseTest {
             licenseTermsId: commTermsId,
             amount: mintAmount,
             minter: ipOwner[1],
-            receiver: ipOwner[1]
+            receiver: ipOwner[1],
+            maxRevenueShare: 0
         });
 
         for (uint256 i = 0; i < mintAmount; i++) {
@@ -89,7 +90,8 @@ contract LicenseTokenTest is BaseTest {
             licenseTermsId: commTermsId,
             amount: 1,
             minter: ipOwner[1],
-            receiver: ipOwner[1]
+            receiver: ipOwner[1],
+            maxRevenueShare: 0
         });
 
         vm.prank(ipOwner[1]);
@@ -137,7 +139,8 @@ contract LicenseTokenTest is BaseTest {
             licenseTermsId: licenseTermsId,
             amount: 1,
             minter: ipOwner[1],
-            receiver: ipOwner[1]
+            receiver: ipOwner[1],
+            maxRevenueShare: 0
         });
 
         vm.expectRevert(Errors.LicenseToken__NotTransferable.selector);
@@ -157,7 +160,8 @@ contract LicenseTokenTest is BaseTest {
             licenseTermsId: licenseTermsId,
             amount: 1,
             minter: ipOwner[1],
-            receiver: ipOwner[1]
+            receiver: ipOwner[1],
+            maxRevenueShare: 0
         });
 
         string memory tokenURI = licenseToken.tokenURI(licenseTokenId);
@@ -196,7 +200,8 @@ contract LicenseTokenTest is BaseTest {
             licenseTermsId: licenseTermsId,
             amount: 1,
             minter: ipOwner[1],
-            receiver: ipOwner[1]
+            receiver: ipOwner[1],
+            maxRevenueShare: 0
         });
 
         ILicenseToken.LicenseTokenMetadata memory lmt = licenseToken.getLicenseTokenMetadata(licenseTokenId);
@@ -233,7 +238,8 @@ contract LicenseTokenTest is BaseTest {
             licenseTermsId: licenseTermsId,
             amount: 1,
             minter: ipOwner[1],
-            receiver: ipOwner[1]
+            receiver: ipOwner[1],
+            maxRevenueShare: 0
         });
 
         ILicenseToken.LicenseTokenMetadata memory lmt = licenseToken.getLicenseTokenMetadata(licenseTokenId);
@@ -280,7 +286,8 @@ contract LicenseTokenTest is BaseTest {
             licenseTermsId: licenseTermsId,
             amount: 1,
             minter: ipOwner[1],
-            receiver: ipOwner[1]
+            receiver: ipOwner[1],
+            maxRevenueShare: 0
         });
     }
 }

--- a/test/foundry/integration/big-bang/SingleNftCollection.t.sol
+++ b/test/foundry/integration/big-bang/SingleNftCollection.t.sol
@@ -154,7 +154,8 @@ contract BigBang_Integration_SingleNftCollection is BaseIntegration {
                 amount: 1,
                 receiver: u.carl,
                 royaltyContext: "",
-                maxMintingFee: 0
+                maxMintingFee: 0,
+                maxRevenueShare: 0
             });
 
             ipAcct[6] = registerIpAccount(mockNFT, 6, u.carl);
@@ -180,7 +181,8 @@ contract BigBang_Integration_SingleNftCollection is BaseIntegration {
                 amount: 1,
                 receiver: u.carl,
                 royaltyContext: "",
-                maxMintingFee: 0
+                maxMintingFee: 0,
+                maxRevenueShare: 0
             });
 
             ipAcct[tokenId] = registerIpAccount(address(mockNFT), tokenId, u.carl);
@@ -210,7 +212,8 @@ contract BigBang_Integration_SingleNftCollection is BaseIntegration {
                 amount: 2,
                 receiver: u.alice,
                 royaltyContext: "",
-                maxMintingFee: 0
+                maxMintingFee: 0,
+                maxRevenueShare: 0
             }); // ID 0 (first license)
 
             ipAcct[2] = registerIpAccount(mockNFT, 2, u.alice);
@@ -247,7 +250,8 @@ contract BigBang_Integration_SingleNftCollection is BaseIntegration {
                 amount: license0_mintAmount,
                 receiver: u.carl,
                 royaltyContext: "",
-                maxMintingFee: 0
+                maxMintingFee: 0,
+                maxRevenueShare: 0
             });
 
             // NC Social Remix license
@@ -258,7 +262,8 @@ contract BigBang_Integration_SingleNftCollection is BaseIntegration {
                 amount: 1,
                 receiver: u.carl,
                 royaltyContext: "",
-                maxMintingFee: 0
+                maxMintingFee: 0,
+                maxRevenueShare: 0
             });
 
             ipAcct[tokenId] = registerIpAccount(address(mockNFT), tokenId, u.carl);
@@ -284,7 +289,8 @@ contract BigBang_Integration_SingleNftCollection is BaseIntegration {
                 amount: license1_mintAmount,
                 receiver: u.carl,
                 royaltyContext: "",
-                maxMintingFee: 0
+                maxMintingFee: 0,
+                maxRevenueShare: 0
             });
             carl_licenses[1] = carl_licenses[1] + license1_mintAmount - 1; // use last license ID minted from above
 

--- a/test/foundry/integration/flows/disputes/Disputes.t.sol
+++ b/test/foundry/integration/flows/disputes/Disputes.t.sol
@@ -56,7 +56,8 @@ contract Flows_Integration_Disputes is BaseIntegration {
             amount: 1,
             receiver: u.carl,
             royaltyContext: "",
-            maxMintingFee: 0
+            maxMintingFee: 0,
+            maxRevenueShare: 0
         });
         assertEq(licenseToken.balanceOf(u.carl), 1);
 
@@ -71,7 +72,8 @@ contract Flows_Integration_Disputes is BaseIntegration {
             amount: 1,
             receiver: u.carl,
             royaltyContext: "",
-            maxMintingFee: 0
+            maxMintingFee: 0,
+            maxRevenueShare: 0
         });
     }
 
@@ -86,7 +88,8 @@ contract Flows_Integration_Disputes is BaseIntegration {
             amount: 1,
             receiver: u.carl,
             royaltyContext: "",
-            maxMintingFee: 0
+            maxMintingFee: 0,
+            maxRevenueShare: 0
         });
         assertEq(licenseToken.balanceOf(u.carl), 1);
 
@@ -118,7 +121,8 @@ contract Flows_Integration_Disputes is BaseIntegration {
             licenseTemplate: address(pilTemplate),
             royaltyContext: "",
             maxMintingFee: 0,
-            maxRts: 100e6
+            maxRts: 100e6,
+            maxRevenueShare: 0
         });
     }
 
@@ -133,7 +137,8 @@ contract Flows_Integration_Disputes is BaseIntegration {
             amount: 1,
             receiver: u.carl,
             royaltyContext: "",
-            maxMintingFee: 0
+            maxMintingFee: 0,
+            maxRevenueShare: 0
         });
         assertEq(licenseToken.balanceOf(u.carl), 1);
 
@@ -161,7 +166,8 @@ contract Flows_Integration_Disputes is BaseIntegration {
             amount: 1,
             receiver: u.carl,
             royaltyContext: "",
-            maxMintingFee: 0
+            maxMintingFee: 0,
+            maxRevenueShare: 0
         });
         assertEq(licenseToken.balanceOf(u.carl), 1);
     }

--- a/test/foundry/integration/flows/grouping/Grouping.t.sol
+++ b/test/foundry/integration/flows/grouping/Grouping.t.sol
@@ -99,8 +99,26 @@ contract Flows_Integration_Grouping is BaseIntegration, ERC721Holder {
             vm.stopPrank();
         }
 
-        licensingModule.mintLicenseTokens(ipAcct[1], address(pilTemplate), commRemixTermsId, 1, address(this), "", 0);
-        licensingModule.mintLicenseTokens(ipAcct[2], address(pilTemplate), commRemixTermsId, 1, address(this), "", 0);
+        licensingModule.mintLicenseTokens(
+            ipAcct[1],
+            address(pilTemplate),
+            commRemixTermsId,
+            1,
+            address(this),
+            "",
+            0,
+            0
+        );
+        licensingModule.mintLicenseTokens(
+            ipAcct[2],
+            address(pilTemplate),
+            commRemixTermsId,
+            1,
+            address(this),
+            "",
+            0,
+            0
+        );
         {
             address[] memory ipIds = new address[](2);
             ipIds[0] = ipAcct[1];
@@ -117,7 +135,16 @@ contract Flows_Integration_Grouping is BaseIntegration, ERC721Holder {
             parentIpIds[0] = groupId;
             uint256[] memory licenseIds = new uint256[](1);
             licenseIds[0] = commRemixTermsId;
-            licensingModule.registerDerivative(ipAcct[3], parentIpIds, licenseIds, address(pilTemplate), "", 0, 100e6);
+            licensingModule.registerDerivative(
+                ipAcct[3],
+                parentIpIds,
+                licenseIds,
+                address(pilTemplate),
+                "",
+                0,
+                100e6,
+                0
+            );
             vm.stopPrank();
         }
 

--- a/test/foundry/integration/flows/licensing/LicensingIntegration.t.sol
+++ b/test/foundry/integration/flows/licensing/LicensingIntegration.t.sol
@@ -122,7 +122,16 @@ contract LicensingIntegrationTest is BaseIntegration {
         parentIpIds[0] = ipAcct[1];
         licenseTermsIds[0] = 1;
 
-        licensingModule.registerDerivative(ipAcct[2], parentIpIds, licenseTermsIds, address(pilTemplate), "", 0, 100e6);
+        licensingModule.registerDerivative(
+            ipAcct[2],
+            parentIpIds,
+            licenseTermsIds,
+            address(pilTemplate),
+            "",
+            0,
+            100e6,
+            0
+        );
 
         assertEq(licenseRegistry.hasIpAttachedLicenseTerms(ipAcct[2], address(pilTemplate), 1), true);
         assertEq(licenseRegistry.getAttachedLicenseTermsCount(ipAcct[2]), 2);
@@ -146,6 +155,7 @@ contract LicensingIntegrationTest is BaseIntegration {
             1,
             address(u.carl),
             "",
+            0,
             0
         );
         assertEq(licenseToken.ownerOf(lcTokenId), u.carl);
@@ -183,7 +193,7 @@ contract LicensingIntegrationTest is BaseIntegration {
         erc20.mint(u.dan, 1000);
         erc20.approve(address(royaltyModule), 100);
 
-        lcTokenId = licensingModule.mintLicenseTokens(ipAcct[1], address(pilTemplate), 2, 1, address(u.dan), "", 0);
+        lcTokenId = licensingModule.mintLicenseTokens(ipAcct[1], address(pilTemplate), 2, 1, address(u.dan), "", 0, 0);
 
         assertEq(licenseToken.ownerOf(lcTokenId), u.dan);
         assertEq(licenseToken.getLicenseTermsId(lcTokenId), 2);
@@ -226,7 +236,16 @@ contract LicensingIntegrationTest is BaseIntegration {
         parentIpIds[0] = ipAcct[1];
         licenseTermsIds[0] = 2;
 
-        licensingModule.registerDerivative(ipAcct[7], parentIpIds, licenseTermsIds, address(pilTemplate), "", 0, 100e6);
+        licensingModule.registerDerivative(
+            ipAcct[7],
+            parentIpIds,
+            licenseTermsIds,
+            address(pilTemplate),
+            "",
+            0,
+            100e6,
+            0
+        );
 
         assertEq(licenseRegistry.hasIpAttachedLicenseTerms(ipAcct[7], address(pilTemplate), 2), true);
         assertEq(licenseRegistry.getAttachedLicenseTermsCount(ipAcct[7]), 2);
@@ -275,7 +294,8 @@ contract LicensingIntegrationTest is BaseIntegration {
             licenseTemplate: address(anotherPILTemplate),
             royaltyContext: "",
             maxMintingFee: 0,
-            maxRts: 100e6
+            maxRts: 100e6,
+            maxRevenueShare: 0
         });
     }
 
@@ -323,7 +343,8 @@ contract LicensingIntegrationTest is BaseIntegration {
             licenseTemplate: address(pilTemplate),
             royaltyContext: "",
             maxMintingFee: 0,
-            maxRts: 100e6
+            maxRts: 100e6,
+            maxRevenueShare: 0
         });
     }
 }

--- a/test/foundry/integration/flows/licensing/LicensingScenarios.t.sol
+++ b/test/foundry/integration/flows/licensing/LicensingScenarios.t.sol
@@ -139,7 +139,8 @@ contract Licensing_Scenarios is BaseIntegration {
             amount: 1,
             receiver: u.bob,
             royaltyContext: "",
-            maxMintingFee: 0
+            maxMintingFee: 0,
+            maxRevenueShare: 0
         });
         licensingModule.registerDerivativeWithLicenseTokens(ipAcct[2], licenseIds, "", 100e6);
 
@@ -152,7 +153,8 @@ contract Licensing_Scenarios is BaseIntegration {
             amount: 1,
             receiver: u.bob,
             royaltyContext: "",
-            maxMintingFee: 0
+            maxMintingFee: 0,
+            maxRevenueShare: 0
         });
         vm.expectRevert(
             abi.encodeWithSelector(
@@ -172,7 +174,8 @@ contract Licensing_Scenarios is BaseIntegration {
             amount: 1,
             receiver: u.bob,
             royaltyContext: "",
-            maxMintingFee: 0
+            maxMintingFee: 0,
+            maxRevenueShare: 0
         });
         licensingModule.registerDerivativeWithLicenseTokens(ipAcct[4], licenseIds, "", 100e6);
 

--- a/test/foundry/integration/flows/royalty/Royalty.t.sol
+++ b/test/foundry/integration/flows/royalty/Royalty.t.sol
@@ -81,7 +81,8 @@ contract Flows_Integration_Disputes is BaseIntegration {
                 amount: mintAmount,
                 receiver: u.bob,
                 royaltyContext: "",
-                maxMintingFee: 0
+                maxMintingFee: 0,
+                maxRevenueShare: 0
             }); // first license minted
             licenseIds[1] = licenseIds[0] + 1; // second license minted
             licenseIds[2] = licenseIds[0] + 2; // third license minted
@@ -128,7 +129,8 @@ contract Flows_Integration_Disputes is BaseIntegration {
                 amount: mintAmount,
                 receiver: u.carl,
                 royaltyContext: "",
-                maxMintingFee: 0
+                maxMintingFee: 0,
+                maxRevenueShare: 0
             });
 
             vm.expectEmit(address(royaltyModule));
@@ -146,7 +148,8 @@ contract Flows_Integration_Disputes is BaseIntegration {
                 amount: mintAmount,
                 receiver: u.carl,
                 royaltyContext: "",
-                maxMintingFee: 0
+                maxMintingFee: 0,
+                maxRevenueShare: 0
             });
 
             ipAcct[3] = registerIpAccount(address(mockNFT), 3, u.carl);
@@ -236,7 +239,8 @@ contract Flows_Integration_Disputes is BaseIntegration {
                 amount: 1,
                 receiver: u.alice,
                 royaltyContext: "",
-                maxMintingFee: 0
+                maxMintingFee: 0,
+                maxRevenueShare: 0
             });
 
             mockNFT.mintId(u.alice, 5);

--- a/test/foundry/invariants/DisputeModule.t.sol
+++ b/test/foundry/invariants/DisputeModule.t.sol
@@ -182,7 +182,8 @@ contract DisputeInvariants is BaseTest {
             licenseTemplate: address(pilTemplate),
             royaltyContext: "",
             maxMintingFee: 0,
-            maxRts: 100e6
+            maxRts: 100e6,
+            maxRevenueShare: 0
         });
 
         /*         targetContract(address(harness));

--- a/test/foundry/invariants/LicenseToken.t.sol
+++ b/test/foundry/invariants/LicenseToken.t.sol
@@ -20,7 +20,7 @@ contract LicenseTokenHarness {
         address minter,
         address receiver
     ) external {
-        licenseToken.mintLicenseTokens(licensorIpId, licenseTemplate, licenseTermsId, amount, minter, receiver);
+        licenseToken.mintLicenseTokens(licensorIpId, licenseTemplate, licenseTermsId, amount, minter, receiver, 0);
     }
 
     function burnLicenseTokens(address holder, uint256[] calldata tokenIds) external {
@@ -77,7 +77,8 @@ contract LicenseTokenBaseInvariants is BaseTest {
             licenseTermsId: _commTermsId,
             amount: 1,
             minter: address(harness),
-            receiver: address(harness)
+            receiver: address(harness),
+            maxRevenueShare: 0
         });
     }
 

--- a/test/foundry/invariants/LicensingModule.t.sol
+++ b/test/foundry/invariants/LicensingModule.t.sol
@@ -76,6 +76,7 @@ contract LicensingModuleHarness is Test {
             amount,
             receiver,
             royaltyContext,
+            0,
             0
         );
 
@@ -110,7 +111,8 @@ contract LicensingModuleHarness is Test {
             licenseTemplate,
             royaltyContext,
             0,
-            100e6
+            100e6,
+            0
         );
 
         mintedOrRegisterDerivative = true;

--- a/test/foundry/modules/dispute/DisputeModule.t.sol
+++ b/test/foundry/modules/dispute/DisputeModule.t.sol
@@ -98,7 +98,8 @@ contract DisputeModuleTest is BaseTest {
             amount: mintAmount,
             receiver: u.bob,
             royaltyContext: "",
-            maxMintingFee: 0
+            maxMintingFee: 0,
+            maxRevenueShare: 0
         }); // first license minted
 
         ipAddr2 = ipAssetRegistry.register(block.chainid, address(mockNFT), 1);

--- a/test/foundry/modules/grouping/EvenSplitGroupPool.t.sol
+++ b/test/foundry/modules/grouping/EvenSplitGroupPool.t.sol
@@ -205,7 +205,7 @@ contract EvenSplitGroupPoolTest is BaseTest, ERC721Holder {
 
         vm.prank(ipOwner1);
         licensingModule.attachLicenseTerms(ipId1, address(pilTemplate), commRemixTermsId);
-        licensingModule.mintLicenseTokens(ipId1, address(pilTemplate), commRemixTermsId, 1, address(this), "", 0);
+        licensingModule.mintLicenseTokens(ipId1, address(pilTemplate), commRemixTermsId, 1, address(this), "", 0, 0);
 
         vm.prank(address(groupingModule));
         rewardPool.addIp(group1, ipId1, 0);
@@ -270,11 +270,11 @@ contract EvenSplitGroupPoolTest is BaseTest, ERC721Holder {
 
         vm.prank(ipOwner1);
         licensingModule.attachLicenseTerms(ipId1, address(pilTemplate), commRemixTermsId);
-        licensingModule.mintLicenseTokens(ipId1, address(pilTemplate), commRemixTermsId, 1, address(this), "", 0);
+        licensingModule.mintLicenseTokens(ipId1, address(pilTemplate), commRemixTermsId, 1, address(this), "", 0, 0);
 
         vm.prank(ipOwner2);
         licensingModule.attachLicenseTerms(ipId2, address(pilTemplate), commRemixTermsId);
-        licensingModule.mintLicenseTokens(ipId2, address(pilTemplate), commRemixTermsId, 1, address(this), "", 0);
+        licensingModule.mintLicenseTokens(ipId2, address(pilTemplate), commRemixTermsId, 1, address(this), "", 0, 0);
 
         vm.startPrank(address(groupingModule));
         rewardPool.addIp(group1, ipId1, 0);

--- a/test/foundry/modules/grouping/GroupingModule.t.sol
+++ b/test/foundry/modules/grouping/GroupingModule.t.sol
@@ -251,11 +251,11 @@ contract GroupingModuleTest is BaseTest, ERC721Holder {
         licensingModule.attachLicenseTerms(ipId1, address(pilTemplate), termsId);
         licensingModule.setLicensingConfig(ipId1, address(pilTemplate), termsId, licensingConfig);
         vm.stopPrank();
-        licensingModule.mintLicenseTokens(ipId1, address(pilTemplate), termsId, 1, address(this), "", 0);
+        licensingModule.mintLicenseTokens(ipId1, address(pilTemplate), termsId, 1, address(this), "", 0, 0);
         vm.startPrank(ipOwner2);
         licensingModule.attachLicenseTerms(ipId2, address(pilTemplate), termsId);
         licensingModule.setLicensingConfig(ipId2, address(pilTemplate), termsId, licensingConfig);
-        licensingModule.mintLicenseTokens(ipId2, address(pilTemplate), termsId, 1, address(this), "", 0);
+        licensingModule.mintLicenseTokens(ipId2, address(pilTemplate), termsId, 1, address(this), "", 0, 0);
         vm.stopPrank();
 
         licensingConfig.expectGroupRewardPool = address(0);
@@ -275,7 +275,7 @@ contract GroupingModuleTest is BaseTest, ERC721Holder {
         uint256[] memory licenseTermsIds = new uint256[](1);
         licenseTermsIds[0] = termsId;
         vm.prank(ipOwner3);
-        licensingModule.registerDerivative(ipId3, parentIpIds, licenseTermsIds, address(pilTemplate), "", 0, 100e6);
+        licensingModule.registerDerivative(ipId3, parentIpIds, licenseTermsIds, address(pilTemplate), "", 0, 100e6, 0);
 
         erc20.mint(ipOwner3, 1000);
         vm.startPrank(ipOwner3);
@@ -331,11 +331,11 @@ contract GroupingModuleTest is BaseTest, ERC721Holder {
         licensingModule.attachLicenseTerms(ipId1, address(pilTemplate), termsId);
         licensingModule.setLicensingConfig(ipId1, address(pilTemplate), termsId, licensingConfig);
         vm.stopPrank();
-        licensingModule.mintLicenseTokens(ipId1, address(pilTemplate), termsId, 1, address(this), "", 0);
+        licensingModule.mintLicenseTokens(ipId1, address(pilTemplate), termsId, 1, address(this), "", 0, 0);
         vm.startPrank(ipOwner2);
         licensingModule.attachLicenseTerms(ipId2, address(pilTemplate), termsId);
         licensingModule.setLicensingConfig(ipId2, address(pilTemplate), termsId, licensingConfig);
-        licensingModule.mintLicenseTokens(ipId2, address(pilTemplate), termsId, 1, address(this), "", 0);
+        licensingModule.mintLicenseTokens(ipId2, address(pilTemplate), termsId, 1, address(this), "", 0, 0);
         vm.stopPrank();
 
         licensingConfig.expectGroupRewardPool = address(0);
@@ -355,7 +355,7 @@ contract GroupingModuleTest is BaseTest, ERC721Holder {
         uint256[] memory licenseTermsIds = new uint256[](1);
         licenseTermsIds[0] = termsId;
         vm.prank(ipOwner3);
-        licensingModule.registerDerivative(ipId3, parentIpIds, licenseTermsIds, address(pilTemplate), "", 0, 100e6);
+        licensingModule.registerDerivative(ipId3, parentIpIds, licenseTermsIds, address(pilTemplate), "", 0, 100e6, 0);
 
         erc20.mint(ipOwner3, 1000);
         vm.startPrank(ipOwner3);
@@ -744,7 +744,7 @@ contract GroupingModuleTest is BaseTest, ERC721Holder {
         uint256[] memory licenseTermsIds = new uint256[](1);
         licenseTermsIds[0] = termsId;
         vm.startPrank(ipOwner2);
-        licensingModule.registerDerivative(ipId2, parentIpIds, licenseTermsIds, address(pilTemplate), "", 0, 100e6);
+        licensingModule.registerDerivative(ipId2, parentIpIds, licenseTermsIds, address(pilTemplate), "", 0, 100e6, 0);
         licensingModule.setLicensingConfig(ipId2, address(pilTemplate), termsId, licensingConfig);
         vm.stopPrank();
 
@@ -807,7 +807,7 @@ contract GroupingModuleTest is BaseTest, ERC721Holder {
         parentIpIds[0] = groupId;
         licenseTermsIds[0] = termsId;
 
-        licensingModule.registerDerivative(ipId3, parentIpIds, licenseTermsIds, address(pilTemplate), "", 0, 100e6);
+        licensingModule.registerDerivative(ipId3, parentIpIds, licenseTermsIds, address(pilTemplate), "", 0, 100e6, 0);
         vm.stopPrank();
 
         ipIds = new address[](1);
@@ -850,7 +850,7 @@ contract GroupingModuleTest is BaseTest, ERC721Holder {
         licenseTermsIds[0] = termsId;
 
         vm.expectRevert(abi.encodeWithSelector(Errors.LicenseRegistry__ParentIpIsEmptyGroup.selector, groupId));
-        licensingModule.registerDerivative(ipId3, parentIpIds, licenseTermsIds, address(pilTemplate), "", 0, 100e6);
+        licensingModule.registerDerivative(ipId3, parentIpIds, licenseTermsIds, address(pilTemplate), "", 0, 100e6, 0);
         vm.stopPrank();
     }
 
@@ -873,7 +873,7 @@ contract GroupingModuleTest is BaseTest, ERC721Holder {
         vm.expectRevert(
             abi.encodeWithSelector(Errors.LicenseRegistry__EmptyGroupCannotMintLicenseToken.selector, groupId)
         );
-        licensingModule.mintLicenseTokens(groupId, address(pilTemplate), termsId, 1, ipOwner3, "", 0);
+        licensingModule.mintLicenseTokens(groupId, address(pilTemplate), termsId, 1, ipOwner3, "", 0, 0);
         vm.stopPrank();
     }
 
@@ -901,7 +901,16 @@ contract GroupingModuleTest is BaseTest, ERC721Holder {
         licenseTermsIds[0] = termsId;
 
         vm.expectRevert(abi.encodeWithSelector(Errors.LicenseRegistry__GroupCannotHasParentIp.selector, groupId));
-        licensingModule.registerDerivative(groupId, parentIpIds, licenseTermsIds, address(pilTemplate), "", 0, 100e6);
+        licensingModule.registerDerivative(
+            groupId,
+            parentIpIds,
+            licenseTermsIds,
+            address(pilTemplate),
+            "",
+            0,
+            100e6,
+            0
+        );
         vm.stopPrank();
     }
 
@@ -958,7 +967,7 @@ contract GroupingModuleTest is BaseTest, ERC721Holder {
         parentIpIds[0] = groupId;
         licenseTermsIds[0] = termsId;
 
-        licensingModule.registerDerivative(ipId3, parentIpIds, licenseTermsIds, address(pilTemplate), "", 0, 100e6);
+        licensingModule.registerDerivative(ipId3, parentIpIds, licenseTermsIds, address(pilTemplate), "", 0, 100e6, 0);
         vm.stopPrank();
 
         address[] memory removeIpIds = new address[](1);

--- a/test/foundry/modules/licensing/LicensingModule.t.sol
+++ b/test/foundry/modules/licensing/LicensingModule.t.sol
@@ -210,7 +210,8 @@ contract LicensingModuleTest is BaseTest {
             amount: 1,
             receiver: ipOwner2,
             royaltyContext: "",
-            maxMintingFee: 0
+            maxMintingFee: 0,
+            maxRevenueShare: 0
         });
         assertEq(licenseToken.ownerOf(lcTokenId), ipOwner2);
         assertEq(licenseToken.getLicenseTermsId(lcTokenId), termsId);
@@ -252,7 +253,8 @@ contract LicensingModuleTest is BaseTest {
             amount: 1,
             receiver: address(ipOwner2),
             royaltyContext: "",
-            maxMintingFee: 0
+            maxMintingFee: 0,
+            maxRevenueShare: 0
         });
 
         vm.warp(11 days);
@@ -341,7 +343,8 @@ contract LicensingModuleTest is BaseTest {
             amount: 1,
             receiver: receiver,
             royaltyContext: "",
-            maxMintingFee: 0
+            maxMintingFee: 0,
+            maxRevenueShare: 0
         });
         assertEq(licenseToken.ownerOf(lcTokenId), receiver);
         assertEq(licenseToken.getLicenseTermsId(lcTokenId), termsId);
@@ -379,7 +382,8 @@ contract LicensingModuleTest is BaseTest {
             amount: 1,
             receiver: receiver,
             royaltyContext: "",
-            maxMintingFee: 100
+            maxMintingFee: 100,
+            maxRevenueShare: 0
         });
         vm.stopPrank();
         assertEq(licenseToken.ownerOf(lcTokenId), receiver);
@@ -418,7 +422,8 @@ contract LicensingModuleTest is BaseTest {
             amount: 1,
             receiver: receiver,
             royaltyContext: "",
-            maxMintingFee: 1000
+            maxMintingFee: 1000,
+            maxRevenueShare: 0
         });
         vm.stopPrank();
         assertEq(erc20.balanceOf(ipOwner2), 900);
@@ -459,7 +464,8 @@ contract LicensingModuleTest is BaseTest {
             amount: 1,
             receiver: receiver,
             royaltyContext: "",
-            maxMintingFee: 100
+            maxMintingFee: 100,
+            maxRevenueShare: 0
         });
         vm.stopPrank();
     }
@@ -479,7 +485,8 @@ contract LicensingModuleTest is BaseTest {
             amount: 2,
             receiver: receiver,
             royaltyContext: "",
-            maxMintingFee: 0
+            maxMintingFee: 0,
+            maxRevenueShare: 0
         });
         assertEq(licenseToken.ownerOf(firstTokenId), receiver);
         assertEq(licenseToken.getLicenseTermsId(firstTokenId), termsId);
@@ -526,7 +533,8 @@ contract LicensingModuleTest is BaseTest {
             amount: 2,
             receiver: receiver,
             royaltyContext: "",
-            maxMintingFee: 1500
+            maxMintingFee: 1500,
+            maxRevenueShare: 0
         });
     }
 
@@ -554,7 +562,8 @@ contract LicensingModuleTest is BaseTest {
                 amount: 1,
                 receiver: receiver,
                 royaltyContext: "",
-                maxMintingFee: 0
+                maxMintingFee: 0,
+                maxRevenueShare: 0
             });
             assertEq(licenseToken.ownerOf(tokenId), receiver);
             assertEq(licenseToken.getLicenseTermsId(tokenId), termsId);
@@ -601,7 +610,8 @@ contract LicensingModuleTest is BaseTest {
             amount: 1,
             receiver: ipOwner2,
             royaltyContext: "",
-            maxMintingFee: 0
+            maxMintingFee: 0,
+            maxRevenueShare: 0
         });
         assertEq(licenseToken.ownerOf(lcTokenId), ipOwner2);
         assertEq(licenseToken.getLicenseTermsId(lcTokenId), termsId);
@@ -625,7 +635,8 @@ contract LicensingModuleTest is BaseTest {
             amount: 1,
             receiver: address(0x777),
             royaltyContext: "",
-            maxMintingFee: 0
+            maxMintingFee: 0,
+            maxRevenueShare: 0
         });
     }
 
@@ -643,7 +654,8 @@ contract LicensingModuleTest is BaseTest {
             amount: 0,
             receiver: receiver,
             royaltyContext: "",
-            maxMintingFee: 0
+            maxMintingFee: 0,
+            maxRevenueShare: 0
         });
 
         vm.expectRevert(Errors.LicensingModule__ReceiverZeroAddress.selector);
@@ -654,7 +666,8 @@ contract LicensingModuleTest is BaseTest {
             amount: 1,
             receiver: address(0),
             royaltyContext: "",
-            maxMintingFee: 0
+            maxMintingFee: 0,
+            maxRevenueShare: 0
         });
     }
 
@@ -676,7 +689,8 @@ contract LicensingModuleTest is BaseTest {
             amount: 1,
             receiver: receiver,
             royaltyContext: "",
-            maxMintingFee: 0
+            maxMintingFee: 0,
+            maxRevenueShare: 0
         });
     }
 
@@ -693,7 +707,8 @@ contract LicensingModuleTest is BaseTest {
             amount: 1,
             receiver: receiver,
             royaltyContext: "",
-            maxMintingFee: 0
+            maxMintingFee: 0,
+            maxRevenueShare: 0
         });
     }
 
@@ -715,7 +730,8 @@ contract LicensingModuleTest is BaseTest {
             amount: 2,
             receiver: receiver,
             royaltyContext: "",
-            maxMintingFee: 0
+            maxMintingFee: 0,
+            maxRevenueShare: 0
         });
     }
 
@@ -730,7 +746,8 @@ contract LicensingModuleTest is BaseTest {
             amount: 1,
             receiver: receiver,
             royaltyContext: "",
-            maxMintingFee: 0
+            maxMintingFee: 0,
+            maxRevenueShare: 0
         });
         assertEq(licenseToken.ownerOf(lcTokenId), receiver);
         assertEq(licenseToken.getLicenseTermsId(lcTokenId), termsId);
@@ -762,7 +779,8 @@ contract LicensingModuleTest is BaseTest {
             amount: 1,
             receiver: ipOwner2,
             royaltyContext: "",
-            maxMintingFee: 0
+            maxMintingFee: 0,
+            maxRevenueShare: 0
         });
         assertEq(licenseToken.ownerOf(lcTokenId), ipOwner2);
         assertEq(licenseToken.getLicenseTermsId(lcTokenId), termsId);
@@ -816,7 +834,8 @@ contract LicensingModuleTest is BaseTest {
             amount: 1,
             receiver: ipOwner2,
             royaltyContext: "",
-            maxMintingFee: 0
+            maxMintingFee: 0,
+            maxRevenueShare: 0
         });
 
         assertEq(licenseRegistry.hasIpAttachedLicenseTerms(ipId1, address(pilTemplate), termsId), false);
@@ -877,7 +896,8 @@ contract LicensingModuleTest is BaseTest {
             amount: 1,
             receiver: ipOwner2,
             royaltyContext: "",
-            maxMintingFee: 0
+            maxMintingFee: 0,
+            maxRevenueShare: 0
         });
 
         vm.prank(u.admin);
@@ -920,7 +940,8 @@ contract LicensingModuleTest is BaseTest {
             amount: 1,
             receiver: ipOwner3,
             royaltyContext: "",
-            maxMintingFee: 0
+            maxMintingFee: 0,
+            maxRevenueShare: 0
         });
 
         uint256 lcTokenId2 = licensingModule.mintLicenseTokens({
@@ -930,7 +951,8 @@ contract LicensingModuleTest is BaseTest {
             amount: 1,
             receiver: ipOwner3,
             royaltyContext: "",
-            maxMintingFee: 0
+            maxMintingFee: 0,
+            maxRevenueShare: 0
         });
 
         assertEq(licenseToken.ownerOf(lcTokenId1), ipOwner3);
@@ -996,7 +1018,8 @@ contract LicensingModuleTest is BaseTest {
             amount: 1,
             receiver: ipOwner1,
             royaltyContext: "",
-            maxMintingFee: 0
+            maxMintingFee: 0,
+            maxRevenueShare: 0
         });
 
         uint256[] memory licenseTokens = new uint256[](1);
@@ -1024,7 +1047,8 @@ contract LicensingModuleTest is BaseTest {
             amount: 1,
             receiver: ipOwner3,
             royaltyContext: "",
-            maxMintingFee: 0
+            maxMintingFee: 0,
+            maxRevenueShare: 0
         });
 
         uint256 lcTokenId2 = licensingModule.mintLicenseTokens({
@@ -1034,7 +1058,8 @@ contract LicensingModuleTest is BaseTest {
             amount: 1,
             receiver: ipOwner3,
             royaltyContext: "",
-            maxMintingFee: 0
+            maxMintingFee: 0,
+            maxRevenueShare: 0
         });
 
         assertEq(licenseToken.ownerOf(lcTokenId1), ipOwner3);
@@ -1091,7 +1116,8 @@ contract LicensingModuleTest is BaseTest {
             amount: 1,
             receiver: ipOwner5,
             royaltyContext: "",
-            maxMintingFee: 0
+            maxMintingFee: 0,
+            maxRevenueShare: 0
         });
 
         vm.warp(11 days);
@@ -1124,7 +1150,8 @@ contract LicensingModuleTest is BaseTest {
             amount: 1,
             receiver: ipOwner1,
             royaltyContext: "",
-            maxMintingFee: 0
+            maxMintingFee: 0,
+            maxRevenueShare: 0
         });
 
         uint256[] memory licenseTokens = new uint256[](1);
@@ -1165,7 +1192,8 @@ contract LicensingModuleTest is BaseTest {
             amount: 1,
             receiver: ipOwner2,
             royaltyContext: "",
-            maxMintingFee: 0
+            maxMintingFee: 0,
+            maxRevenueShare: 0
         });
 
         uint256 lcTokenId2 = licensingModule.mintLicenseTokens({
@@ -1175,7 +1203,8 @@ contract LicensingModuleTest is BaseTest {
             amount: 1,
             receiver: ipOwner3,
             royaltyContext: "",
-            maxMintingFee: 0
+            maxMintingFee: 0,
+            maxRevenueShare: 0
         });
 
         uint256[] memory licenseTokens = new uint256[](1);
@@ -1220,7 +1249,8 @@ contract LicensingModuleTest is BaseTest {
             amount: 1,
             receiver: ipOwner3,
             royaltyContext: "",
-            maxMintingFee: 0
+            maxMintingFee: 0,
+            maxRevenueShare: 0
         });
 
         uint256 lcTokenId2 = licensingModule.mintLicenseTokens({
@@ -1230,7 +1260,8 @@ contract LicensingModuleTest is BaseTest {
             amount: 1,
             receiver: ipOwner3,
             royaltyContext: "",
-            maxMintingFee: 0
+            maxMintingFee: 0,
+            maxRevenueShare: 0
         });
 
         uint256[] memory licenseTokens = new uint256[](1);
@@ -1270,7 +1301,8 @@ contract LicensingModuleTest is BaseTest {
             amount: 1,
             receiver: ipOwner3,
             royaltyContext: "",
-            maxMintingFee: 0
+            maxMintingFee: 0,
+            maxRevenueShare: 0
         });
 
         uint256 lcTokenId2 = licensingModule.mintLicenseTokens({
@@ -1280,7 +1312,8 @@ contract LicensingModuleTest is BaseTest {
             amount: 1,
             receiver: ipOwner3,
             royaltyContext: "",
-            maxMintingFee: 0
+            maxMintingFee: 0,
+            maxRevenueShare: 0
         });
 
         uint256[] memory licenseTokens = new uint256[](2);
@@ -1331,7 +1364,7 @@ contract LicensingModuleTest is BaseTest {
             )
         );
         vm.prank(ipOwner3);
-        licensingModule.registerDerivative(ipId3, parentIpIds, licenseTermsIds, address(pilTemplate), "", 0, 100e6);
+        licensingModule.registerDerivative(ipId3, parentIpIds, licenseTermsIds, address(pilTemplate), "", 0, 100e6, 0);
     }
 
     function test_LicensingModule_registerDerivativeWithLicenseTokens_ownedByDelegator() public {
@@ -1356,7 +1389,8 @@ contract LicensingModuleTest is BaseTest {
             amount: 1,
             receiver: ipOwner2,
             royaltyContext: "",
-            maxMintingFee: 0
+            maxMintingFee: 0,
+            maxRevenueShare: 0
         });
 
         uint256[] memory licenseTokens = new uint256[](1);
@@ -1386,7 +1420,8 @@ contract LicensingModuleTest is BaseTest {
             amount: 1,
             receiver: ipId3,
             royaltyContext: "",
-            maxMintingFee: 0
+            maxMintingFee: 0,
+            maxRevenueShare: 0
         });
 
         uint256[] memory licenseTokens = new uint256[](1);
@@ -1416,7 +1451,8 @@ contract LicensingModuleTest is BaseTest {
             amount: 1,
             receiver: ipOwner2,
             royaltyContext: "",
-            maxMintingFee: 0
+            maxMintingFee: 0,
+            maxRevenueShare: 0
         });
 
         uint256[] memory licenseTokens = new uint256[](1);
@@ -1455,7 +1491,8 @@ contract LicensingModuleTest is BaseTest {
             amount: 1,
             receiver: ipOwner2,
             royaltyContext: "",
-            maxMintingFee: 0
+            maxMintingFee: 0,
+            maxRevenueShare: 0
         });
 
         vm.prank(ipOwner2);
@@ -1525,7 +1562,8 @@ contract LicensingModuleTest is BaseTest {
             amount: 1,
             receiver: ipOwner2,
             royaltyContext: "",
-            maxMintingFee: 0
+            maxMintingFee: 0,
+            maxRevenueShare: 0
         });
 
         assertEq(licenseToken.ownerOf(lcTokenId), ipOwner2);
@@ -1581,7 +1619,8 @@ contract LicensingModuleTest is BaseTest {
             amount: 1,
             receiver: ipOwner2,
             royaltyContext: "",
-            maxMintingFee: 0
+            maxMintingFee: 0,
+            maxRevenueShare: 0
         });
     }
 
@@ -1623,7 +1662,8 @@ contract LicensingModuleTest is BaseTest {
             amount: 1,
             receiver: ipOwner2,
             royaltyContext: "",
-            maxMintingFee: 0
+            maxMintingFee: 0,
+            maxRevenueShare: 0
         });
         assertEq(licenseToken.ownerOf(lcTokenId), ipOwner2);
         assertEq(licenseToken.getLicenseTermsId(lcTokenId), termsId);
@@ -1660,7 +1700,7 @@ contract LicensingModuleTest is BaseTest {
     function test_LicensingModule_registerDerivative_revert_emptyParentIpIds() public {
         vm.expectRevert(Errors.LicensingModule__NoParentIp.selector);
         vm.prank(ipOwner2);
-        licensingModule.registerDerivative(ipId2, new address[](0), new uint256[](0), address(0), "", 0, 100e6);
+        licensingModule.registerDerivative(ipId2, new address[](0), new uint256[](0), address(0), "", 0, 100e6, 0);
     }
 
     function test_LicensingModule_registerDerivative_revert_parentIdsLengthMismatchWithLicenseIds() public {
@@ -1668,7 +1708,7 @@ contract LicensingModuleTest is BaseTest {
         parentIpIds[0] = ipId1;
         vm.expectRevert(abi.encodeWithSelector(Errors.LicensingModule__LicenseTermsLengthMismatch.selector, 1, 0));
         vm.prank(ipOwner2);
-        licensingModule.registerDerivative(ipId2, parentIpIds, new uint256[](0), address(0), "", 0, 100e6);
+        licensingModule.registerDerivative(ipId2, parentIpIds, new uint256[](0), address(0), "", 0, 100e6, 0);
     }
 
     function test_LicensingModule_registerDerivative_revert_IncompatibleLicenses() public {
@@ -1706,7 +1746,7 @@ contract LicensingModuleTest is BaseTest {
             abi.encodeWithSelector(Errors.LicensingModule__LicenseNotCompatibleForDerivative.selector, ipId3)
         );
         vm.prank(ipOwner3);
-        licensingModule.registerDerivative(ipId3, parentIpIds, licenseTermsIds, address(pilTemplate), "", 0, 100e6);
+        licensingModule.registerDerivative(ipId3, parentIpIds, licenseTermsIds, address(pilTemplate), "", 0, 100e6, 0);
     }
 
     function test_LicensingModule_registerDerivative_revert_CommercialUseOnlyLicense() public {
@@ -1734,7 +1774,7 @@ contract LicensingModuleTest is BaseTest {
             abi.encodeWithSelector(Errors.LicensingModule__LicenseNotCompatibleForDerivative.selector, ipId3)
         );
         vm.prank(ipOwner3);
-        licensingModule.registerDerivative(ipId3, parentIpIds, licenseTermsIds, address(pilTemplate), "", 0, 100e6);
+        licensingModule.registerDerivative(ipId3, parentIpIds, licenseTermsIds, address(pilTemplate), "", 0, 100e6, 0);
     }
 
     function test_LicensingModule_registerDerivative_revert_NotAllowDerivativesReciprocal() public {
@@ -1755,7 +1795,7 @@ contract LicensingModuleTest is BaseTest {
         licenseTermsIds[0] = socialRemixTermsId;
 
         vm.prank(ipOwner2);
-        licensingModule.registerDerivative(ipId2, parentIpIds, licenseTermsIds, address(pilTemplate), "", 0, 100e6);
+        licensingModule.registerDerivative(ipId2, parentIpIds, licenseTermsIds, address(pilTemplate), "", 0, 100e6, 0);
 
         // register derivative of derivative, should revert
         parentIpIds = new address[](1);
@@ -1765,7 +1805,7 @@ contract LicensingModuleTest is BaseTest {
             abi.encodeWithSelector(Errors.LicensingModule__LicenseNotCompatibleForDerivative.selector, ipId3)
         );
         vm.prank(ipOwner3);
-        licensingModule.registerDerivative(ipId3, parentIpIds, licenseTermsIds, address(pilTemplate), "", 0, 100e6);
+        licensingModule.registerDerivative(ipId3, parentIpIds, licenseTermsIds, address(pilTemplate), "", 0, 100e6, 0);
     }
 
     function test_LicensingModule_setLicensingConfig() public {
@@ -1876,7 +1916,7 @@ contract LicensingModuleTest is BaseTest {
         licenseTermsIds[0] = termsId;
         // register derivative
         vm.prank(ipOwner2);
-        licensingModule.registerDerivative(ipId2, parentIpIds, licenseTermsIds, address(pilTemplate), "", 0, 100e6);
+        licensingModule.registerDerivative(ipId2, parentIpIds, licenseTermsIds, address(pilTemplate), "", 0, 100e6, 0);
 
         Licensing.LicensingConfig memory licensingConfig = Licensing.LicensingConfig({
             isSet: true,
@@ -1902,7 +1942,7 @@ contract LicensingModuleTest is BaseTest {
         parentIpIds = new address[](1);
         parentIpIds[0] = ipId2;
         vm.prank(ipOwner3);
-        licensingModule.registerDerivative(ipId3, parentIpIds, licenseTermsIds, address(pilTemplate), "", 0, 100e6);
+        licensingModule.registerDerivative(ipId3, parentIpIds, licenseTermsIds, address(pilTemplate), "", 0, 100e6, 0);
 
         erc20.mint(ipOwner3, 1000);
         vm.startPrank(ipOwner3);
@@ -2166,7 +2206,8 @@ contract LicensingModuleTest is BaseTest {
             amount: 1,
             receiver: receiver,
             royaltyContext: "",
-            maxMintingFee: 0
+            maxMintingFee: 0,
+            maxRevenueShare: 0
         });
     }
 
@@ -2203,7 +2244,8 @@ contract LicensingModuleTest is BaseTest {
             amount: 1,
             receiver: receiver,
             royaltyContext: "",
-            maxMintingFee: 0
+            maxMintingFee: 0,
+            maxRevenueShare: 0
         });
     }
 
@@ -2264,7 +2306,8 @@ contract LicensingModuleTest is BaseTest {
             amount: 5,
             receiver: receiver,
             royaltyContext: "",
-            maxMintingFee: 0
+            maxMintingFee: 0,
+            maxRevenueShare: 0
         });
         vm.stopPrank();
 
@@ -2326,7 +2369,8 @@ contract LicensingModuleTest is BaseTest {
             amount: 5,
             receiver: receiver,
             royaltyContext: "",
-            maxMintingFee: 0
+            maxMintingFee: 0,
+            maxRevenueShare: 0
         });
         vm.stopPrank();
 
@@ -2375,7 +2419,8 @@ contract LicensingModuleTest is BaseTest {
             amount: 5,
             receiver: receiver,
             royaltyContext: "",
-            maxMintingFee: 0
+            maxMintingFee: 0,
+            maxRevenueShare: 0
         });
         vm.stopPrank();
 
@@ -2430,7 +2475,8 @@ contract LicensingModuleTest is BaseTest {
             amount: 1,
             receiver: receiver,
             royaltyContext: "",
-            maxMintingFee: 0
+            maxMintingFee: 0,
+            maxRevenueShare: 0
         });
         vm.stopPrank();
 
@@ -2485,7 +2531,7 @@ contract LicensingModuleTest is BaseTest {
             licenseTermsIds,
             address(pilTemplate)
         );
-        licensingModule.registerDerivative(ipId2, parentIpIds, licenseTermsIds, address(pilTemplate), "", 0, 100e6);
+        licensingModule.registerDerivative(ipId2, parentIpIds, licenseTermsIds, address(pilTemplate), "", 0, 100e6, 0);
         vm.stopPrank();
 
         assertEq(erc20.balanceOf(ipOwner2), 900);
@@ -2541,7 +2587,7 @@ contract LicensingModuleTest is BaseTest {
             licenseTermsIds,
             address(pilTemplate)
         );
-        licensingModule.registerDerivative(ipId2, parentIpIds, licenseTermsIds, address(pilTemplate), "", 0, 100e6);
+        licensingModule.registerDerivative(ipId2, parentIpIds, licenseTermsIds, address(pilTemplate), "", 0, 100e6, 0);
         vm.stopPrank();
 
         assertEq(erc20.balanceOf(ipOwner2), 900);
@@ -2572,7 +2618,8 @@ contract LicensingModuleTest is BaseTest {
             amount: 1,
             receiver: ipOwner2,
             royaltyContext: "",
-            maxMintingFee: 0
+            maxMintingFee: 0,
+            maxRevenueShare: 0
         });
         vm.stopPrank();
         assertEq(erc20.balanceOf(ipOwner2), 900 - 300);
@@ -2613,7 +2660,7 @@ contract LicensingModuleTest is BaseTest {
         licenseTermsIds[0] = termsId;
         vm.prank(ipOwner2);
         vm.expectRevert("MockLicensingHook: caller is invalid");
-        licensingModule.registerDerivative(ipId2, parentIpIds, licenseTermsIds, address(pilTemplate), "", 0, 100e6);
+        licensingModule.registerDerivative(ipId2, parentIpIds, licenseTermsIds, address(pilTemplate), "", 0, 100e6, 0);
     }
 
     function test_LicensingModule_registerDerivative_revert_licenseDisabled() public {
@@ -2644,7 +2691,7 @@ contract LicensingModuleTest is BaseTest {
                 termsId
             )
         );
-        licensingModule.registerDerivative(ipId2, parentIpIds, licenseTermsIds, address(pilTemplate), "", 0, 100e6);
+        licensingModule.registerDerivative(ipId2, parentIpIds, licenseTermsIds, address(pilTemplate), "", 0, 100e6, 0);
     }
 
     function onERC721Received(address, address, uint256, bytes memory) public pure returns (bytes4) {

--- a/test/foundry/modules/licensing/PILicenseTemplate.t.sol
+++ b/test/foundry/modules/licensing/PILicenseTemplate.t.sol
@@ -335,7 +335,16 @@ contract PILicenseTemplateTest is BaseTest {
         uint256[] memory licenseTermsIds = new uint256[](1);
         licenseTermsIds[0] = commRemixTermsId;
         vm.prank(ipOwner[2]);
-        licensingModule.registerDerivative(ipAcct[2], parentIpIds, licenseTermsIds, address(pilTemplate), "", 0, 100e6);
+        licensingModule.registerDerivative(
+            ipAcct[2],
+            parentIpIds,
+            licenseTermsIds,
+            address(pilTemplate),
+            "",
+            0,
+            100e6,
+            0
+        );
 
         uint256 anotherTermsId = pilTemplate.registerLicenseTerms(
             PILFlavors.commercialUse({
@@ -367,7 +376,16 @@ contract PILicenseTemplateTest is BaseTest {
         uint256[] memory licenseTermsIds = new uint256[](1);
         licenseTermsIds[0] = commNoReciprocalTermsId;
         vm.prank(ipOwner[2]);
-        licensingModule.registerDerivative(ipAcct[2], parentIpIds, licenseTermsIds, address(pilTemplate), "", 0, 100e6);
+        licensingModule.registerDerivative(
+            ipAcct[2],
+            parentIpIds,
+            licenseTermsIds,
+            address(pilTemplate),
+            "",
+            0,
+            100e6,
+            0
+        );
 
         bool result = pilTemplate.verifyMintLicenseToken(commNoReciprocalTermsId, ipOwner[3], ipAcct[2], 1);
         assertFalse(result);
@@ -428,7 +446,16 @@ contract PILicenseTemplateTest is BaseTest {
         uint256[] memory licenseTermsIds = new uint256[](1);
         licenseTermsIds[0] = socialRemixTermsId;
         vm.prank(ipOwner[2]);
-        licensingModule.registerDerivative(ipAcct[2], parentIpIds, licenseTermsIds, address(pilTemplate), "", 0, 100e6);
+        licensingModule.registerDerivative(
+            ipAcct[2],
+            parentIpIds,
+            licenseTermsIds,
+            address(pilTemplate),
+            "",
+            0,
+            100e6,
+            0
+        );
 
         // checking register derivative of derivative, expect false
         bool result = pilTemplate.verifyRegisterDerivative(ipAcct[3], ipAcct[2], socialRemixTermsId, ipOwner[3]);

--- a/test/foundry/modules/royalty/RoyaltyModule.t.sol
+++ b/test/foundry/modules/royalty/RoyaltyModule.t.sol
@@ -900,7 +900,8 @@ contract TestRoyaltyModule is BaseTest, ERC721Holder {
             amount: 1,
             receiver: ipAcct2,
             royaltyContext: "",
-            maxMintingFee: 1e30
+            maxMintingFee: 1e30,
+            maxRevenueShare: 0
         });
         // register derivative
         vm.startPrank(address(2));

--- a/test/foundry/registries/LicenseRegistry.t.sol
+++ b/test/foundry/registries/LicenseRegistry.t.sol
@@ -184,7 +184,16 @@ contract LicenseRegistryTest is BaseTest {
         uint256[] memory licenseTermsIds = new uint256[](1);
         licenseTermsIds[0] = socialRemixTermsId;
         vm.prank(ipOwner[2]);
-        licensingModule.registerDerivative(ipAcct[2], parentIpIds, licenseTermsIds, address(pilTemplate), "", 0, 100e6);
+        licensingModule.registerDerivative(
+            ipAcct[2],
+            parentIpIds,
+            licenseTermsIds,
+            address(pilTemplate),
+            "",
+            0,
+            100e6,
+            0
+        );
 
         uint256 defaultTermsId = pilTemplate.registerLicenseTerms(PILFlavors.defaultValuesLicenseTerms());
         vm.expectRevert(Errors.LicensingModule__DerivativesCannotAddLicenseTerms.selector);
@@ -221,7 +230,16 @@ contract LicenseRegistryTest is BaseTest {
         uint256[] memory licenseTermsIds = new uint256[](1);
         licenseTermsIds[0] = socialRemixTermsId;
         vm.prank(ipOwner[2]);
-        licensingModule.registerDerivative(ipAcct[2], parentIpIds, licenseTermsIds, address(pilTemplate), "", 0, 100e6);
+        licensingModule.registerDerivative(
+            ipAcct[2],
+            parentIpIds,
+            licenseTermsIds,
+            address(pilTemplate),
+            "",
+            0,
+            100e6,
+            0
+        );
 
         vm.expectRevert(abi.encodeWithSelector(Errors.LicenseRegistry__IndexOutOfBounds.selector, ipAcct[1], 1, 1));
         licenseRegistry.getDerivativeIp(ipAcct[1], 1);
@@ -237,7 +255,16 @@ contract LicenseRegistryTest is BaseTest {
         uint256[] memory licenseTermsIds = new uint256[](1);
         licenseTermsIds[0] = socialRemixTermsId;
         vm.prank(ipOwner[2]);
-        licensingModule.registerDerivative(ipAcct[2], parentIpIds, licenseTermsIds, address(pilTemplate), "", 0, 100e6);
+        licensingModule.registerDerivative(
+            ipAcct[2],
+            parentIpIds,
+            licenseTermsIds,
+            address(pilTemplate),
+            "",
+            0,
+            100e6,
+            0
+        );
 
         vm.expectRevert(abi.encodeWithSelector(Errors.LicenseRegistry__IndexOutOfBounds.selector, ipAcct[2], 1, 1));
         licenseRegistry.getParentIp(ipAcct[2], 1);


### PR DESCRIPTION
## Description

This PR introduces a new feature that allows users to specify the maximum royalty percentage (`maxRevenueShare`) they are willing to accept when minting license tokens from an IP or registering a derivative to parent IPs. This change enhances the flexibility and control users have over their licensing agreements.

## Key Changes

- **`maxRevenueShare` Parameter**: Added a `maxRevenueShare` parameter to the functions for minting license tokens and registering derivatives.
- **Validation Logic**: Implemented validation logic to ensure that the specified `maxRevenueShare` is not exceeded during the minting or registration process.

Closes https://github.com/storyprotocol/trust-protocol-contracts-v1/issues/17