### PR TITLE
Deploy Protocol Using Pre-Deployed CREATE3 Deployer

### DIFF
--- a/package.json
+++ b/package.json
@@ -65,6 +65,6 @@
         "@openzeppelin/contracts": "5.0.2",
         "@openzeppelin/contracts-upgradeable": "5.0.2",
         "erc6551": "^0.3.1",
-        "solady": "^0.0.192"
+        "solady": "^0.0.281"
     }
 }

--- a/script/foundry/deployment/Main.s.sol
+++ b/script/foundry/deployment/Main.s.sol
@@ -11,7 +11,7 @@ contract Main is DeployHelper {
     address internal ERC6551_REGISTRY = 0x000000006551c19487814612e58FE06813775758;
     address internal CREATE3_DEPLOYER = 0x9fBB3DF7C40Da2e5A0dE984fFE2CCB7C47cd0ABf;
     uint256 internal CREATE3_DEFAULT_SEED = 6;
-    address internal IP_GRAPH_ACL = 0x680E66e4c7Df9133a7AFC1ed091089B32b89C4ae;
+    address internal IP_GRAPH_ACL = address(0);
     // For arbitration policy
     uint256 internal constant ARBITRATION_PRICE = 1000 * 10 ** 6; // 1000 USDC
     address internal constant TREASURY_ADDRESS = address(200);

--- a/script/foundry/deployment/Main.s.sol
+++ b/script/foundry/deployment/Main.s.sol
@@ -11,7 +11,7 @@ contract Main is DeployHelper {
     address internal ERC6551_REGISTRY = 0x000000006551c19487814612e58FE06813775758;
     address internal CREATE3_DEPLOYER = 0x9fBB3DF7C40Da2e5A0dE984fFE2CCB7C47cd0ABf;
     uint256 internal CREATE3_DEFAULT_SEED = 6;
-    address internal IP_GRAPH_ACL = address(0);
+    address internal IP_GRAPH_ACL = address(0x1640A22a8A086747cD377b73954545e2Dfcc9Cad);
     // For arbitration policy
     uint256 internal constant ARBITRATION_PRICE = 1000 * 10 ** 6; // 1000 USDC
     address internal constant TREASURY_ADDRESS = address(200);

--- a/script/foundry/utils/BroadcastManager.s.sol
+++ b/script/foundry/utils/BroadcastManager.s.sol
@@ -74,6 +74,13 @@ contract BroadcastManager is Script {
             relayer = u.relayer;
             upgraderExecDelay = 10 minutes;
             vm.startPrank(deployer);
+        } else if (block.chainid == 1399) {
+            deployerPrivateKey = vm.envUint("STORY_PRIVATEKEY");
+            deployer = vm.addr(deployerPrivateKey);
+            multisig = vm.envAddress("STORY_MULTISIG_ADDRESS");
+            relayer = vm.envAddress("STORY_RELAYER_ADDRESS");
+            upgraderExecDelay = 10 minutes;
+            vm.startBroadcast(deployerPrivateKey);
         } else {
             console2.log("Unsupported chain", block.chainid);
             revert("Unsupported chain");

--- a/script/foundry/utils/Create3Deployer.sol
+++ b/script/foundry/utils/Create3Deployer.sol
@@ -6,12 +6,12 @@ import { ICreate3Deployer } from "./ICreate3Deployer.sol";
 
 contract Create3Deployer is ICreate3Deployer {
     /// @inheritdoc	ICreate3Deployer
-    function deploy(bytes32 salt, bytes calldata creationCode) external payable returns (address) {
-        return CREATE3.deploy(salt, creationCode, msg.value);
+    function deployDeterministic(bytes memory creationCode, bytes32 salt) external payable returns (address deployed) {
+        return CREATE3.deployDeterministic(creationCode, salt);
     }
 
     /// @inheritdoc	ICreate3Deployer
-    function getDeployed(address deployer, bytes32 salt) external view returns (address) {
-        return CREATE3.getDeployed(salt);
+    function predictDeterministicAddress(bytes32 salt) external view returns (address deployed) {
+        return CREATE3.predictDeterministicAddress(salt);
     }
 }

--- a/script/foundry/utils/Create3Deployer.sol
+++ b/script/foundry/utils/Create3Deployer.sol
@@ -1,0 +1,17 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.26;
+
+import { CREATE3 } from "@solady/src/utils/CREATE3.sol";
+import { ICreate3Deployer } from "./ICreate3Deployer.sol";
+
+contract Create3Deployer is ICreate3Deployer {
+    /// @inheritdoc	ICreate3Deployer
+    function deploy(bytes32 salt, bytes calldata creationCode) external payable returns (address) {
+        return CREATE3.deploy(salt, creationCode, msg.value);
+    }
+
+    /// @inheritdoc	ICreate3Deployer
+    function getDeployed(address deployer, bytes32 salt) external view returns (address) {
+        return CREATE3.getDeployed(salt);
+    }
+}

--- a/script/foundry/utils/DeployHelper.sol
+++ b/script/foundry/utils/DeployHelper.sol
@@ -215,9 +215,9 @@ contract DeployHelper is Script, BroadcastManager, JsonDeploymentHandler, Storag
             contractKey = "MockERC20";
             _predeploy(contractKey);
             erc20 = MockERC20(
-                create3Deployer.deploy(
-                    _getSalt(type(MockERC20).name),
-                    abi.encodePacked(type(MockERC20).creationCode, abi.encode(deployer))
+                create3Deployer.deployDeterministic(
+                    abi.encodePacked(type(MockERC20).creationCode, abi.encode(deployer)),
+                    _getSalt(type(MockERC20).name)
                 )
             );
             require(
@@ -231,9 +231,9 @@ contract DeployHelper is Script, BroadcastManager, JsonDeploymentHandler, Storag
         contractKey = "ProtocolAccessManager";
         _predeploy(contractKey);
         protocolAccessManager = AccessManager(
-            create3Deployer.deploy(
-                _getSalt(type(AccessManager).name),
-                abi.encodePacked(type(AccessManager).creationCode, abi.encode(deployer))
+            create3Deployer.deployDeterministic(
+                abi.encodePacked(type(AccessManager).creationCode, abi.encode(deployer)),
+                _getSalt(type(AccessManager).name)
             )
         );
         require(
@@ -245,9 +245,9 @@ contract DeployHelper is Script, BroadcastManager, JsonDeploymentHandler, Storag
         contractKey = "ProtocolPauseAdmin";
         _predeploy(contractKey);
         protocolPauser = ProtocolPauseAdmin(
-            create3Deployer.deploy(
-                _getSalt(type(ProtocolPauseAdmin).name),
-                abi.encodePacked(type(ProtocolPauseAdmin).creationCode, abi.encode(address(protocolAccessManager)))
+            create3Deployer.deployDeterministic(
+                abi.encodePacked(type(ProtocolPauseAdmin).creationCode, abi.encode(address(protocolAccessManager))),
+                _getSalt(type(ProtocolPauseAdmin).name)
             )
         );
         require(
@@ -359,7 +359,7 @@ contract DeployHelper is Script, BroadcastManager, JsonDeploymentHandler, Storag
         );
         _predeploy(contractKey);
         ipAccountImpl = IPAccountImpl(
-            payable(create3Deployer.deploy(_getSalt(type(IPAccountImpl).name), ipAccountImplCode))
+            payable(create3Deployer.deployDeterministic(ipAccountImplCode, _getSalt(type(IPAccountImpl).name)))
         );
         _postdeploy(contractKey, address(ipAccountImpl));
         require(
@@ -621,24 +621,29 @@ contract DeployHelper is Script, BroadcastManager, JsonDeploymentHandler, Storag
 
         _predeploy("IpRoyaltyVaultImpl");
         ipRoyaltyVaultImpl = IpRoyaltyVault(
-            create3Deployer.deploy(
-                _getSalt(type(IpRoyaltyVault).name),
+            create3Deployer.deployDeterministic(
                 abi.encodePacked(
                     type(IpRoyaltyVault).creationCode,
-                    abi.encode(address(disputeModule), address(royaltyModule), address(ipAssetRegistry), address(groupingModule))
-                )
+                    abi.encode(
+                        address(disputeModule),
+                        address(royaltyModule),
+                        address(ipAssetRegistry),
+                        address(groupingModule)
+                    )
+                ),
+                _getSalt(type(IpRoyaltyVault).name)
             )
         );
         _postdeploy("IpRoyaltyVaultImpl", address(ipRoyaltyVaultImpl));
 
         _predeploy("IpRoyaltyVaultBeacon");
         ipRoyaltyVaultBeacon = UpgradeableBeacon(
-            create3Deployer.deploy(
-                _getSalt(type(UpgradeableBeacon).name),
+            create3Deployer.deployDeterministic(
                 abi.encodePacked(
                     type(UpgradeableBeacon).creationCode,
                     abi.encode(address(ipRoyaltyVaultImpl), deployer)
-                )
+                ),
+                _getSalt(type(UpgradeableBeacon).name)
             )
         );
         _postdeploy("IpRoyaltyVaultBeacon", address(ipRoyaltyVaultBeacon));
@@ -665,12 +670,12 @@ contract DeployHelper is Script, BroadcastManager, JsonDeploymentHandler, Storag
 
         _predeploy("CoreMetadataViewModule");
         coreMetadataViewModule = CoreMetadataViewModule(
-            create3Deployer.deploy(
-                _getSalt(type(CoreMetadataViewModule).name),
+            create3Deployer.deployDeterministic(
                 abi.encodePacked(
                     type(CoreMetadataViewModule).creationCode,
                     abi.encode(address(ipAssetRegistry), address(moduleRegistry))
-                )
+                ),
+                _getSalt(type(CoreMetadataViewModule).name)
             )
         );
         _postdeploy("CoreMetadataViewModule", address(coreMetadataViewModule));
@@ -679,9 +684,9 @@ contract DeployHelper is Script, BroadcastManager, JsonDeploymentHandler, Storag
         if (newDeployedIpGraphACL) {
             _predeploy("IPGraphACL");
             ipGraphACL = IPGraphACL(
-                create3Deployer.deploy(
-                    _getSalt(type(IPGraphACL).name),
-                    abi.encodePacked(type(IPGraphACL).creationCode, abi.encode(address(protocolAccessManager)))
+                create3Deployer.deployDeterministic(
+                    abi.encodePacked(type(IPGraphACL).creationCode, abi.encode(address(protocolAccessManager))),
+                    _getSalt(type(IPGraphACL).name)
                 )
             );
         } else {
@@ -902,7 +907,7 @@ contract DeployHelper is Script, BroadcastManager, JsonDeploymentHandler, Storag
 
     /// @dev Get the deterministic deployed address of a contract with CREATE3
     function _getDeployedAddress(string memory name) private view returns (address) {
-        return create3Deployer.getDeployed(msg.sender, _getSalt(name));
+        return create3Deployer.predictDeterministicAddress(_getSalt(name));
     }
 
     /// @dev Load the implementation address from the proxy contract

--- a/script/foundry/utils/DeployHelper.sol
+++ b/script/foundry/utils/DeployHelper.sol
@@ -59,7 +59,7 @@ import { JsonDeploymentHandler } from "./JsonDeploymentHandler.s.sol";
 
 // test
 import { TestProxyHelper } from "test/foundry/utils/TestProxyHelper.sol";
-import { ICreate3Deployer } from "@create3-deployer/contracts/ICreate3Deployer.sol";
+import { ICreate3Deployer } from "./ICreate3Deployer.sol";
 
 contract DeployHelper is Script, BroadcastManager, JsonDeploymentHandler, StorageLayoutChecker {
     using StringUtil for uint256;
@@ -902,7 +902,7 @@ contract DeployHelper is Script, BroadcastManager, JsonDeploymentHandler, Storag
 
     /// @dev Get the deterministic deployed address of a contract with CREATE3
     function _getDeployedAddress(string memory name) private view returns (address) {
-        return create3Deployer.getDeployed(_getSalt(name));
+        return create3Deployer.getDeployed(msg.sender, _getSalt(name));
     }
 
     /// @dev Load the implementation address from the proxy contract

--- a/script/foundry/utils/ICreate3Deployer.sol
+++ b/script/foundry/utils/ICreate3Deployer.sol
@@ -3,14 +3,13 @@ pragma solidity ^0.8.26;
 
 interface ICreate3Deployer {
     /// @notice Deploys a contract using CREATE3
-    /// @param salt The salt to use for deployment
-    /// @param creationCode The contract creation code
-    /// @return deployed The address of the deployed contract
-    function deploy(bytes32 salt, bytes calldata creationCode) external payable returns (address);
+    /// @param salt          The deployer-specific salt for determining the deployed contract's address
+    /// @param creationCode  The creation code of the contract to deploy
+    /// @return deployed     The address of the deployed contract
+    function deployDeterministic(bytes memory creationCode, bytes32 salt) external payable returns (address deployed);
 
-    /// @notice Predicts the address of a deployed contract
-    /// @param deployer The address of the deployer
-    /// @param salt The salt to use for deployment
-    /// @return deployed The address of the contract that will be deployed
-    function getDeployed(address deployer, bytes32 salt) external view returns (address);
+    ///  @notice Predicts the address of a deployed contract
+    ///  @param salt      The deployer-specific salt for determining the deployed contract's address
+    ///  @return deployed The address of the contract that will be deployed
+    function predictDeterministicAddress(bytes32 salt) external view returns (address deployed);
 }

--- a/script/foundry/utils/ICreate3Deployer.sol
+++ b/script/foundry/utils/ICreate3Deployer.sol
@@ -1,0 +1,16 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.26;
+
+interface ICreate3Deployer {
+    /// @notice Deploys a contract using CREATE3
+    /// @param salt The salt to use for deployment
+    /// @param creationCode The contract creation code
+    /// @return deployed The address of the deployed contract
+    function deploy(bytes32 salt, bytes calldata creationCode) external payable returns (address);
+
+    /// @notice Predicts the address of a deployed contract
+    /// @param deployer The address of the deployer
+    /// @param salt The salt to use for deployment
+    /// @return deployed The address of the contract that will be deployed
+    function getDeployed(address deployer, bytes32 salt) external view returns (address);
+}

--- a/script/foundry/utils/upgrades/DeployerUtils.sol
+++ b/script/foundry/utils/upgrades/DeployerUtils.sol
@@ -3,7 +3,7 @@ pragma solidity ^0.8.23;
 
 import { console2 } from "forge-std/console2.sol";
 import { ERC6551Registry } from "erc6551/ERC6551Registry.sol";
-import { ICreate3Deployer } from "@create3-deployer/contracts/ICreate3Deployer.sol";
+import { ICreate3Deployer } from "../ICreate3Deployer.sol";
 
 contract DeployerUtils {
 

--- a/script/foundry/utils/upgrades/UpgradeExecutor.s.sol
+++ b/script/foundry/utils/upgrades/UpgradeExecutor.s.sol
@@ -17,7 +17,7 @@ import { BroadcastManager } from "../BroadcastManager.s.sol";
 import { JsonDeploymentHandler } from "../JsonDeploymentHandler.s.sol";
 import { JsonBatchTxHelper } from "../JsonBatchTxHelper.s.sol";
 import { StringUtil } from "../StringUtil.sol";
-import { ICreate3Deployer } from "@create3-deployer/contracts/ICreate3Deployer.sol";
+import { ICreate3Deployer } from "../ICreate3Deployer.sol";
 import { UpgradedImplHelper } from "./UpgradedImplHelper.sol";
 import { StorageLayoutChecker } from "./StorageLayoutCheck.s.sol";
 

--- a/test/foundry/utils/BaseTest.t.sol
+++ b/test/foundry/utils/BaseTest.t.sol
@@ -5,7 +5,7 @@ pragma solidity 0.8.26;
 // external
 import { Test } from "forge-std/Test.sol";
 import { ERC6551Registry } from "erc6551/ERC6551Registry.sol";
-import { Create3Deployer } from "@create3-deployer/contracts/Create3Deployer.sol";
+import { Create3Deployer } from "../../../script/foundry/utils/Create3Deployer.sol";
 
 // contract
 import { IPAccountRegistry } from "../../../contracts/registries/IPAccountRegistry.sol";

--- a/test/foundry/utils/TestProxyHelper.sol
+++ b/test/foundry/utils/TestProxyHelper.sol
@@ -19,6 +19,10 @@ library TestProxyHelper {
         address impl,
         bytes memory data
     ) internal returns (address) {
-        return create3Deployer.deploy(salt, abi.encodePacked(type(ERC1967Proxy).creationCode, abi.encode(impl, data)));
+        return
+            create3Deployer.deployDeterministic(
+                abi.encodePacked(type(ERC1967Proxy).creationCode, abi.encode(impl, data)),
+                salt
+            );
     }
 }

--- a/test/foundry/utils/TestProxyHelper.sol
+++ b/test/foundry/utils/TestProxyHelper.sol
@@ -1,7 +1,7 @@
 // SPDX-License-Identifier: MIT
 pragma solidity ^0.8.23;
 import { ERC1967Proxy } from "@openzeppelin/contracts/proxy/ERC1967/ERC1967Proxy.sol";
-import { ICreate3Deployer } from "@create3-deployer/contracts/ICreate3Deployer.sol";
+import { ICreate3Deployer } from "../../../script/foundry/utils/ICreate3Deployer.sol";
 
 library TestProxyHelper {
     /// Deploys a new UUPS proxy with the provided implementation and data

--- a/yarn.lock
+++ b/yarn.lock
@@ -5109,10 +5109,10 @@ slice-ansi@^4.0.0:
     astral-regex "^2.0.0"
     is-fullwidth-code-point "^3.0.0"
 
-solady@^0.0.192:
-  version "0.0.192"
-  resolved "https://registry.yarnpkg.com/solady/-/solady-0.0.192.tgz#f80ea061903ba1914d2c96c3c69f53d66865f88f"
-  integrity sha512-96A4dhYkSB/xUyZIuc6l8RMbQ+nqk7GFr0hEci7/64D3G63Ial06puqXA14ZVy/xFe8nzBJbz3Mxssn7SH/1Ag==
+solady@^0.0.281:
+  version "0.0.281"
+  resolved "https://registry.yarnpkg.com/solady/-/solady-0.0.281.tgz#2538b475ef4db587c4c946cd032412e08acba4ca"
+  integrity sha512-pO/r0cVb6EXwAISE/cgcn1outhvkEKHEnVCSUTlRdIWDnl013CrUtMx8PbkDYfef2TrJB178TOA0jIBDVyjGBg==
 
 solc@0.7.3:
   version "0.7.3"


### PR DESCRIPTION
## Description

This PR includes the deployment of the protocol using the pre-deployed CREATE3 deployer. The changes ensure that the protocol contracts are deployed efficiently and consistently using the CREATE3 deployment method.

## Key Changes

- **Deployment Script Update**: Modified the deployment script to utilize the pre-deployed CREATE3 deployer for deploying protocol contracts.
- **Contract Deployment**: Deployed all necessary protocol contracts using the CREATE3 deployer.
