### PR TITLE
Ensure IP Cannot Be Registered as Derivative After Minting Private License Token

### DIFF
--- a/contracts/LicenseToken.sol
+++ b/contracts/LicenseToken.sol
@@ -126,7 +126,9 @@ contract LicenseToken is ILicenseToken, ERC721EnumerableUpgradeable, AccessManag
         LicenseTokenStorage storage $ = _getLicenseTokenStorage();
         startLicenseTokenId = $.totalMintedTokens;
         $.totalMintedTokens += amount;
-        $.licensorIpTotalTokens[licensorIpId] += amount;
+        if (!LICENSE_REGISTRY.isDefaultLicense(licenseTemplate, licenseTermsId)) {
+            $.licensorIpTotalTokens[licensorIpId] += amount;
+        }
         for (uint256 i = 0; i < amount; i++) {
             uint256 tokenId = startLicenseTokenId + i;
             $.licenseTokenMetadatas[tokenId] = ltm;
@@ -170,6 +172,11 @@ contract LicenseToken is ILicenseToken, ERC721EnumerableUpgradeable, AccessManag
         )
     {
         LicenseTokenStorage storage $ = _getLicenseTokenStorage();
+
+        if ($.licensorIpTotalTokens[childIpId] != 0) {
+            revert Errors.LicenseToken__ChildIPAlreadyHasBeenMintedLicenseTokens(childIpId);
+        }
+
         licenseTemplate = $.licenseTokenMetadatas[tokenIds[0]].licenseTemplate;
         licensorIpIds = new address[](tokenIds.length);
         licenseTermsIds = new uint256[](tokenIds.length);

--- a/contracts/interfaces/registries/ILicenseRegistry.sol
+++ b/contracts/interfaces/registries/ILicenseRegistry.sol
@@ -37,6 +37,9 @@ interface ILicenseRegistry {
     /// @notice Returns the default license terms.
     function getDefaultLicenseTerms() external view returns (address licenseTemplate, uint256 licenseTermsId);
 
+    /// @notice Checks if the license terms are the default license terms.
+    function isDefaultLicense(address licenseTemplate, uint256 licenseTermsId) external view returns (bool);
+
     /// @notice Registers a new license template in the Story Protocol.
     /// @param licenseTemplate The address of the license template to register.
     function registerLicenseTemplate(address licenseTemplate) external;

--- a/contracts/lib/Errors.sol
+++ b/contracts/lib/Errors.sol
@@ -345,6 +345,9 @@ library Errors {
         address licenseTemplate,
         uint256 licenseTermsId
     );
+
+    /// @notice There are non-default license tokens have already been minted from the child Ip.
+    error LicenseToken__ChildIPAlreadyHasBeenMintedLicenseTokens(address childIpId);
     ////////////////////////////////////////////////////////////////////////////
     //                           Licensing Module                             //
     ////////////////////////////////////////////////////////////////////////////
@@ -384,6 +387,9 @@ library Errors {
 
     /// @notice Derivative IP cannot add license terms.
     error LicensingModule__DerivativesCannotAddLicenseTerms();
+
+    /// @notice there are non-default license tokens have already been minted from the child Ip.
+    error LicensingModule__DerivativeAlreadyHasBeenMintedLicenseTokens(address childIpId);
 
     /// @notice IP list and license terms list length mismatch.
     error LicensingModule__LicenseTermsLengthMismatch(uint256 ipLength, uint256 licenseTermsLength);

--- a/contracts/modules/licensing/LicensingModule.sol
+++ b/contracts/modules/licensing/LicensingModule.sol
@@ -257,7 +257,9 @@ contract LicensingModule is
         ) {
             revert Errors.LicensingModule__LicenseNotCompatibleForDerivative(childIpId);
         }
-
+        if (LICENSE_NFT.getTotalTokensByLicensor(childIpId) != 0) {
+            revert Errors.LicensingModule__DerivativeAlreadyHasBeenMintedLicenseTokens(childIpId);
+        }
         // Ensure none of the parent IPs have expired.
         // Confirm that each parent IP has the license terms attached as specified by 'licenseTermsIds'
         // or default license terms.

--- a/contracts/registries/LicenseRegistry.sol
+++ b/contracts/registries/LicenseRegistry.sol
@@ -563,6 +563,11 @@ contract LicenseRegistry is ILicenseRegistry, AccessManagedUpgradeable, UUPSUpgr
         return ($.defaultLicenseTemplate, $.defaultLicenseTermsId);
     }
 
+    /// @notice Checks if the license terms are the default license terms.
+    function isDefaultLicense(address licenseTemplate, uint256 licenseTermsId) external view returns (bool) {
+        LicenseRegistryStorage storage $ = _getLicenseRegistryStorage();
+        return $.defaultLicenseTemplate == licenseTemplate && $.defaultLicenseTermsId == licenseTermsId;
+    }
     /// @notice Returns the license terms through which a child IP links to a parent IP.
     /// @param childIpId The address of the child IP.
     /// @param parentIpId The address of the parent IP.


### PR DESCRIPTION
## Description

This PR ensures that an IP cannot be registered as a derivative of any IP once the IP owner has minted a private license token of a non-default license. This change enhances the integrity of the licensing system by preventing unauthorized derivative registrations.

## Key Changes

- **Derivative Registration Restriction**: Added logic to prevent an IP from being registered as a derivative if a private license token of a non-default license has been minted by the IP owner.

