### PR TITLE
Update README with Contact Us section: Discord button and contact form

### DIFF
--- a/README.md
+++ b/README.md
@@ -182,3 +182,8 @@ docgen: {
 ```
 
 You can refer to the [config.ts](https://github.com/OpenZeppelin/solidity-docgen/blob/master/src/config.ts) of solidity-docgen for the full list of configurable parameters.
+
+## Contact Us
+
+- [Join our Discord](https://discord.gg/storyprotocol)
+- [Contact Form](https://us12.list-manage.com/contact-form?u=31e9becc054689c22a9946af4&form_id=2745f1aa221b6ccc31aa51f1c5b44366)

--- a/README.md
+++ b/README.md
@@ -185,4 +185,4 @@ You can refer to the [config.ts](https://github.com/OpenZeppelin/solidity-docgen
 
 ## Contact Us
 
-- [Join our Discord](https://discord.gg/storyprotocol)
+- [Join our Discord](https://discord.gg/storyprotocol) 

--- a/README.md
+++ b/README.md
@@ -186,4 +186,3 @@ You can refer to the [config.ts](https://github.com/OpenZeppelin/solidity-docgen
 ## Contact Us
 
 - [Join our Discord](https://discord.gg/storyprotocol)
-- [Contact Form](https://us12.list-manage.com/contact-form?u=31e9becc054689c22a9946af4&form_id=2745f1aa221b6ccc31aa51f1c5b44366)

--- a/README.md
+++ b/README.md
@@ -1,10 +1,9 @@
 # Story Protocol Beta
 
-Story Protocol is building the Programmable IP layer to bring programmability to IP. Story Protocol transforms IPs into networks that transcend mediums and platforms, unleashing global creativity and liquidity. Instead of static JPEGs that lack interactivity and composability with other assets, programmable IPs are dynamic and extensible: built to be built upon. Creators and applications can register their IP with Story Protocol, converting their static IP into programmable IP by declaring a set of onchain rights that any program can read and write on.
-
+Story Protocol is building the Programmable IP layer to bring programmability to IP. Story Protocol transforms IPs into networks that transcend mediums and platforms, unleashing global creativity and liquidity. Instead of static JPEGs that lack interactivity and composability with other assets, programmable IPs are dynamic and extensible: built to be built upon. Creators and applications can register their IP with Story Protocol, converting their static IP into programmable IP by declaring a set of on-chain rights that any program can read and write on.
 # Documentation
 
-🚧 WARNING, Beta version: This code is in active development and unaudited. Do not use in Production 🚧
+🚧 WARNING, Beta version: This code is in active development and has not been audited. Do not use in Production 🚧
 
 [Learn more about Story Protocol](https://docs.storyprotocol.xyz/)
 


### PR DESCRIPTION
Description :

This PR updates the README file to include a "Contact Us" section with clickable links for Discord and a contact form.

Added a clickable button for the Discord invite link.

Added a link to a contact form for inquiries.

Test Plan : 

Verified that the Markdown renders correctly in the GitHub preview.

Checked that both the Discord button and the contact form link redirect to the correct pages.

Related Issue : 

None.

Notes : 

This update enhances the README to provide easy access to the project's community via Discord and also enables users to submit inquiries through the contact form.