### PR TITLE
Fix JSON formatting issue and typos 

### DIFF
--- a/contracts/GroupNFT.sol
+++ b/contracts/GroupNFT.sol
@@ -100,7 +100,7 @@ contract GroupNFT is IGroupNFT, ERC721Upgradeable, AccessManagedUpgradeable, UUP
                 '"name": "Story Protocol IP Assets Group #',
                 id.toString(),
                 '",',
-                '"description": IPAsset Group",',
+                '"description": "IPAsset Group",',
                 '"external_url": "https://protocol.storyprotocol.xyz/ipa/',
                 id.toString(),
                 '",',

--- a/contracts/IPAccountImpl.sol
+++ b/contracts/IPAccountImpl.sol
@@ -223,7 +223,7 @@ contract IPAccountImpl is ERC6551, IPAccountStorage, IIPAccount {
         }
     }
 
-    /// @dev Updates the IP Account's state all execute transactions.
+    /// @dev Updates the IP Account's state for all executed transactions.
     /// @param to The "target" of the execute transactions.
     /// @param value The amount of Ether to send.
     /// @param data The data to send along with the transaction.
@@ -238,7 +238,7 @@ contract IPAccountImpl is ERC6551, IPAccountStorage, IIPAccount {
 
     /// @dev Override Solady 6551 _isValidSigner function.
     /// @param signer The signer to check
-    /// @param extraData The extra data to check against, it should bethe address of the recipient for IPAccount
+    /// @param extraData The extra data to check against, it should be the address of the recipient for IPAccount
     /// @param context The context for validating the signer
     /// @return bool is true if the signer is valid, false otherwise
     function _isValidSigner(

--- a/script/foundry/utils/upgrades/StorageLayoutCheck.s.sol
+++ b/script/foundry/utils/upgrades/StorageLayoutCheck.s.sol
@@ -50,7 +50,7 @@ contract StorageLayoutChecker is Script {
         uint8 i = 0;
         // npx @openzeppelin/upgrades-core validate <build-info-dir> --requireReference
         inputBuilder[i++] = "npx";
-        inputBuilder[i++] = string.concat("@openzeppelin/upgrades-core");
+        inputBuilder[i++] = "@openzeppelin/upgrades-core";
         inputBuilder[i++] = "validate";
         inputBuilder[i++] = string.concat(outDir, "/build-info");
 


### PR DESCRIPTION
**## Description**
This PR resolves a JSON formatting issue and addresses multiple typos across the codebase. Below is a detailed breakdown of the changes made:

**1. GroupNFT.sol**
Issue:
The 'description' field in the 'tokenURI' function contained incorrect JSON formatting, which could lead to invalid JSON.
'"description": IPAsset Group",' to '"description": "IPAsset Group",'

**2. IPAccountImpl.sol**
Issues:
1-The word 'bethe' was a typo in a comment.
2-A missing word ('for') in a comment made it unclear.
'bethe' to 'be the'
'/// @dev Updates the IP Account's state all execute transactions.' to '/// @dev Updates the IP Account's state for all executed transactions.'

**3. StorageLayoutCheck.s.sol**
Issue:
'string.concat' was unnecessarily used for a single string in the 'inputBuilder.'

'inputBuilder[i++] = string.concat("@openzeppelin/upgrades-core");' to 'inputBuilder[i++] = "@openzeppelin/upgrades-core";' 

**Why These Changes Were Made**
-To ensure valid JSON formatting for GroupNFT.
-To fix typos and improve clarity in comments for better readability.
-To remove unnecessary code and improve efficiency in StorageLayoutCheck.
