### PR TITLE
Correct Strings.toHexString Usage for Address Variables

### DIFF
--- a/test/foundry/mocks/module/MockAllMetadataViewModule.sol
+++ b/test/foundry/mocks/module/MockAllMetadataViewModule.sol
@@ -52,7 +52,7 @@ contract MockAllMetadataViewModule is BaseModule, IViewModule {
             /* solhint-disable */
             abi.encodePacked(
                 '{"name": "IP Asset #',
-                Strings.toHexString(ipId),
+                Strings.toHexString(uint160(ipId)),
                 '", "description": "',
                 description(ipId),
                 '", "attributes": ['
@@ -70,7 +70,7 @@ contract MockAllMetadataViewModule is BaseModule, IViewModule {
                 ipType(ipId),
                 '"},'
                 '{"trait_type": "Owner", "value": "',
-                Strings.toHexString(owner(ipId)),
+                Strings.toHexString(uint160(owner(ipId))),
                 '"},'
                 '{"trait_type": "Registration Date", "value": "',
                 Strings.toString(registrationDate(ipId)),

--- a/test/foundry/mocks/module/MockCoreMetadataViewModule.sol
+++ b/test/foundry/mocks/module/MockCoreMetadataViewModule.sol
@@ -30,9 +30,9 @@ contract MockCoreMetadataViewModule is BaseModule, IViewModule {
             string.concat(
                 getName(ipId),
                 ", IP #",
-                Strings.toHexString(ipId),
+                Strings.toHexString(uint160(ipId)),
                 ", is currently owned by",
-                Strings.toHexString(owner(ipId)),
+                Strings.toHexString(uint160(owner(ipId))),
                 ". To learn more about this IP, visit ",
                 uri(ipId)
             );
@@ -55,7 +55,7 @@ contract MockCoreMetadataViewModule is BaseModule, IViewModule {
             /* solhint-disable */
             abi.encodePacked(
                 '{"name": "IP Asset #',
-                Strings.toHexString(ipId),
+                Strings.toHexString(uint160(ipId)),
                 '", "description": "',
                 description(ipId),
                 '", "attributes": ['
@@ -70,7 +70,7 @@ contract MockCoreMetadataViewModule is BaseModule, IViewModule {
                 getName(ipId),
                 '"},'
                 '{"trait_type": "Owner", "value": "',
-                Strings.toHexString(owner(ipId)),
+                Strings.toHexString(uint160(owner(ipId))),
                 '"},'
                 '{"trait_type": "Registration Date", "value": "',
                 Strings.toString(registrationDate(ipId)),
@@ -93,7 +93,8 @@ contract MockCoreMetadataViewModule is BaseModule, IViewModule {
     }
 
     function isSupported(address ipAccount) external returns (bool) {
-        return !_isEmptyString(IIPAccount(payable(ipAccount)).getString(ipAssetRegistry, "NAME"));
+        return
+            !_isEmptyString(IIPAccount(payable(ipAccount)).getString(ipAssetRegistry, "NAME"));
     }
 
     function _isEmptyString(string memory str) internal pure returns (bool) {


### PR DESCRIPTION
**Description**
This PR fixes incorrect usage of Strings.toHexString for address type variables in the following files:

-MockAllMetadataViewModule.sol
-MockCoreMetadataViewModule.sol

**Changes:**
1-Converted Strings.toHexString(ipId) to Strings.toHexString(uint160(ipId)) to handle the address type correctly.
2-Updated Strings.toHexString(owner(ipId)) to Strings.toHexString(uint160(owner(ipId))).
3-Minor formatting corrections in the code for better readability.
These fixes ensure proper hexadecimal string conversion and resolve potential compilation issues.

**Test Plan**
The changes have been validated with test cases to ensure the correctness of the fixes:

1-Created a dedicated test file, TestToHexString.t.sol, to verify:
Incorrect usage: Using Strings.toHexString(ipId) directly with an address type.
Correct usage: Using Strings.toHexString(uint160(ipId)) for proper conversion.

2-Observed the following:
Compilation failed for incorrect usage.
Compilation passed successfully with the fixed code.

Example Test:
address ipId = 0x1234567890123456789012345678901234567890;
string memory result = Strings.toHexString(uint160(ipId)); 
emit log(result); // Successfully outputs hexadecimal string.

3-Test Results: Below is the screenshot of the successful test result:
![image](https://github.com/user-attachments/assets/9fb5459d-1c46-488d-a93a-9e8cc85f6433)

**Related Issue**
Fixes: Issue #386

Notes
Ensure this fix is applied consistently across other files that use Strings.toHexString with address types, if applicable.
The changes are backward compatible and do not affect the functionality beyond fixing the conversion issue.




