### PR TITLE
Remove IP-Level Licensing Configuration

### DIFF
--- a/contracts/interfaces/registries/ILicenseRegistry.sol
+++ b/contracts/interfaces/registries/ILicenseRegistry.sol
@@ -23,9 +23,6 @@ interface ILicenseRegistry {
     /// @notice Emitted when set new default license terms.
     event DefaultLicenseTermsSet(address licenseTemplate, uint256 licenseTermsId);
 
-    /// @notice Emitted when a minting license configuration is set for all licenses of an IP.
-    event LicensingConfigSetForIP(address indexed ipId, Licensing.LicensingConfig licensingConfig);
-
     /// @notice Emitted when an expiration time is set for an IP.
     event ExpirationTimeSet(address indexed ipId, uint256 expireTime);
 
@@ -198,13 +195,6 @@ interface ILicenseRegistry {
         uint256 licenseTermsId,
         Licensing.LicensingConfig calldata licensingConfig
     ) external;
-
-    /// @notice Sets the MintingLicenseConfig for an IP and applies it to all licenses attached to the IP.
-    /// @dev This function will set a global configuration for all licenses under a specific IP.
-    /// However, this global configuration can be overridden by a configuration set at a specific license level.
-    /// @param ipId The IP ID for which the configuration is being set.
-    /// @param licensingConfig The MintingLicenseConfig to be set for all licenses under the given IP.
-    function setLicensingConfigForIp(address ipId, Licensing.LicensingConfig calldata licensingConfig) external;
 
     /// @notice Gets the expiration time for an IP.
     /// @param ipId The address of the IP.

--- a/contracts/lib/Errors.sol
+++ b/contracts/lib/Errors.sol
@@ -481,9 +481,6 @@ library Errors {
     /// @notice license terms disabled.
     error LicensingModule__LicenseDisabled(address ipId, address licenseTemplate, uint256 licenseTermsId);
 
-    /// @notice When Set LicenseConfig the license template cannot be Zero address if royalty percentage is not Zero.
-    error LicensingModule__LicenseTemplateCannotBeZeroAddressToOverrideRoyaltyPercent();
-
     /// @notice Current License does not allow to override royalty percentage.
     error LicensingModule__CurrentLicenseNotAllowOverrideRoyaltyPercent(
         address licenseTemplate,
@@ -544,6 +541,9 @@ library Errors {
         uint256 licensingConfigMintingFee,
         uint256 licenseTermsMintingFee
     );
+
+    /// @notice When setting licensing config, the license template cannot be zero address.
+    error LicensingModule__ZeroLicenseTemplate();
 
     ////////////////////////////////////////////////////////////////////////////
     //                             Dispute Module                             //

--- a/contracts/modules/licensing/LicensingModule.sol
+++ b/contracts/modules/licensing/LicensingModule.sol
@@ -405,6 +405,9 @@ contract LicensingModule is
         if (licenseTemplate == address(0)) {
             revert Errors.LicensingModule__ZeroLicenseTemplate();
         }
+        if (licenseTermsId == 0) {
+            revert Errors.LicensingModule__InvalidLicenseTermsId(licenseTemplate, licenseTermsId);
+        }
         if (IGroupIPAssetRegistry(address(IP_ASSET_REGISTRY)).isRegisteredGroup(ipId)) {
             _verifyGroupIpConfig(ipId, licenseTemplate, licenseTermsId, licensingConfig);
         }
@@ -442,11 +445,7 @@ contract LicensingModule is
         ) {
             revert Errors.LicensingModule__InvalidLicensingHook(licensingConfig.licensingHook);
         }
-        if (licenseTemplate != address(0) && licenseTermsId != 0) {
-            LICENSE_REGISTRY.setLicensingConfigForLicense(ipId, licenseTemplate, licenseTermsId, licensingConfig);
-        } else {
-            revert Errors.LicensingModule__InvalidLicenseTermsId(licenseTemplate, licenseTermsId);
-        }
+        LICENSE_REGISTRY.setLicensingConfigForLicense(ipId, licenseTemplate, licenseTermsId, licensingConfig);
     }
 
     /// @notice pre-compute the minting license fee for the given IP and license terms.

--- a/contracts/registries/LicenseRegistry.sol
+++ b/contracts/registries/LicenseRegistry.sol
@@ -765,7 +765,19 @@ contract LicenseRegistry is ILicenseRegistry, AccessManagedUpgradeable, UUPSUpgr
         if (!$.registeredLicenseTemplates[licenseTemplate]) {
             revert Errors.LicenseRegistry__UnregisteredLicenseTemplate(licenseTemplate);
         }
-        return $.licensingConfigs[_getIpLicenseHash(ipId, licenseTemplate, licenseTermsId)];
+        if ($.licensingConfigs[_getIpLicenseHash(ipId, licenseTemplate, licenseTermsId)].isSet) {
+            return $.licensingConfigs[_getIpLicenseHash(ipId, licenseTemplate, licenseTermsId)];
+        }
+        return Licensing.LicensingConfig({
+            isSet: false,
+            mintingFee: 0,
+            licensingHook: address(0),
+            hookData: "",
+            commercialRevShare: 0,
+            disabled: false,
+            expectMinimumGroupRewardShare: 0,
+            expectGroupRewardPool: address(0)
+        });
     }
 
     /// @dev Get the hash of the IP ID, license template, and license terms ID

--- a/contracts/registries/LicenseRegistry.sol
+++ b/contracts/registries/LicenseRegistry.sol
@@ -59,8 +59,6 @@ contract LicenseRegistry is ILicenseRegistry, AccessManagedUpgradeable, UUPSUpgr
     /// @param licenseTemplates Mapping of license templates to IP IDs
     /// @param expireTimes Mapping of IP IDs to expire times
     /// @param licensingConfigs Mapping of minting license configs to a licenseTerms of an IP
-    /// @param licensingConfigsForIp Mapping of minting license configs to an IP,
-    /// the config will apply to all licenses under the IP
     /// @dev Storage structure for the LicenseRegistry
     /// @custom:storage-location erc7201:story-protocol.LicenseRegistry
     struct LicenseRegistryStorage {
@@ -73,7 +71,6 @@ contract LicenseRegistry is ILicenseRegistry, AccessManagedUpgradeable, UUPSUpgr
         mapping(address ipId => EnumerableSet.UintSet licenseTermsIds) attachedLicenseTerms;
         mapping(address ipId => address licenseTemplate) licenseTemplates;
         mapping(bytes32 ipLicenseHash => Licensing.LicensingConfig licensingConfig) licensingConfigs;
-        mapping(address ipId => Licensing.LicensingConfig licensingConfig) licensingConfigsForIp;
     }
 
     // keccak256(abi.encode(uint256(keccak256("story-protocol.LicenseRegistry")) - 1)) & ~bytes32(uint256(0xff));
@@ -166,29 +163,6 @@ contract LicenseRegistry is ILicenseRegistry, AccessManagedUpgradeable, UUPSUpgr
         });
 
         emit LicensingConfigSetForLicense(ipId, licenseTemplate, licenseTermsId, licensingConfig);
-    }
-
-    /// @notice Sets the LicensingConfig for an IP and applies it to all licenses attached to the IP.
-    /// @dev This function will set a global configuration for all licenses under a specific IP.
-    /// However, this global configuration can be overridden by a configuration set at a specific license level.
-    /// @param ipId The IP ID for which the configuration is being set.
-    /// @param licensingConfig The LicensingConfig to be set for all licenses under the given IP.
-    function setLicensingConfigForIp(
-        address ipId,
-        Licensing.LicensingConfig calldata licensingConfig
-    ) external onlyLicensingModule {
-        LicenseRegistryStorage storage $ = _getLicenseRegistryStorage();
-        $.licensingConfigsForIp[ipId] = Licensing.LicensingConfig({
-            isSet: licensingConfig.isSet,
-            mintingFee: licensingConfig.mintingFee,
-            licensingHook: licensingConfig.licensingHook,
-            hookData: licensingConfig.hookData,
-            commercialRevShare: licensingConfig.commercialRevShare,
-            disabled: licensingConfig.disabled,
-            expectMinimumGroupRewardShare: licensingConfig.expectMinimumGroupRewardShare,
-            expectGroupRewardPool: licensingConfig.expectGroupRewardPool
-        });
-        emit LicensingConfigSetForIP(ipId, licensingConfig);
     }
 
     /// @notice Attaches license terms to an IP.
@@ -779,7 +753,6 @@ contract LicenseRegistry is ILicenseRegistry, AccessManagedUpgradeable, UUPSUpgr
     }
 
     /// @dev Retrieves the minting license configuration for a given license terms of the IP.
-    /// Will return the configuration for the license terms of the IP if configuration is not set for the license terms.
     /// @param ipId The address of the IP.
     /// @param licenseTemplate The address of the license template where the license terms are defined.
     /// @param licenseTermsId The ID of the license terms.
@@ -792,10 +765,7 @@ contract LicenseRegistry is ILicenseRegistry, AccessManagedUpgradeable, UUPSUpgr
         if (!$.registeredLicenseTemplates[licenseTemplate]) {
             revert Errors.LicenseRegistry__UnregisteredLicenseTemplate(licenseTemplate);
         }
-        if ($.licensingConfigs[_getIpLicenseHash(ipId, licenseTemplate, licenseTermsId)].isSet) {
-            return $.licensingConfigs[_getIpLicenseHash(ipId, licenseTemplate, licenseTermsId)];
-        }
-        return $.licensingConfigsForIp[ipId];
+        return $.licensingConfigs[_getIpLicenseHash(ipId, licenseTemplate, licenseTermsId)];
     }
 
     /// @dev Get the hash of the IP ID, license template, and license terms ID

--- a/contracts/registries/LicenseRegistry.sol
+++ b/contracts/registries/LicenseRegistry.sol
@@ -768,16 +768,17 @@ contract LicenseRegistry is ILicenseRegistry, AccessManagedUpgradeable, UUPSUpgr
         if ($.licensingConfigs[_getIpLicenseHash(ipId, licenseTemplate, licenseTermsId)].isSet) {
             return $.licensingConfigs[_getIpLicenseHash(ipId, licenseTemplate, licenseTermsId)];
         }
-        return Licensing.LicensingConfig({
-            isSet: false,
-            mintingFee: 0,
-            licensingHook: address(0),
-            hookData: "",
-            commercialRevShare: 0,
-            disabled: false,
-            expectMinimumGroupRewardShare: 0,
-            expectGroupRewardPool: address(0)
-        });
+        return
+            Licensing.LicensingConfig({
+                isSet: false,
+                mintingFee: 0,
+                licensingHook: address(0),
+                hookData: "",
+                commercialRevShare: 0,
+                disabled: false,
+                expectMinimumGroupRewardShare: 0,
+                expectGroupRewardPool: address(0)
+            });
     }
 
     /// @dev Get the hash of the IP ID, license template, and license terms ID

--- a/test/foundry/modules/licensing/LicensingModule.t.sol
+++ b/test/foundry/modules/licensing/LicensingModule.t.sol
@@ -2794,7 +2794,7 @@ contract LicensingModuleTest is BaseTest {
             abi.encodeWithSelector(Errors.LicensingModule__InvalidLicensingHook.selector, address(licensingHook))
         );
         vm.prank(ipOwner1);
-        licensingModule.setLicensingConfig(ipId1, address(pilTemplate), 0, licensingConfig);
+        licensingModule.setLicensingConfig(ipId1, address(pilTemplate), socialRemixTermsId, licensingConfig);
 
         // unsupport licensing hook interface
         MockTokenGatedHook tokenGatedHook = new MockTokenGatedHook();
@@ -2815,7 +2815,7 @@ contract LicensingModuleTest is BaseTest {
             abi.encodeWithSelector(Errors.LicensingModule__InvalidLicensingHook.selector, address(tokenGatedHook))
         );
         vm.prank(ipOwner1);
-        licensingModule.setLicensingConfig(ipId1, address(pilTemplate), 0, licensingConfig);
+        licensingModule.setLicensingConfig(ipId1, address(pilTemplate), socialRemixTermsId, licensingConfig);
     }
 
     function test_LicensingModule_setLicensingConfig_revert_paused() public {

--- a/test/foundry/modules/licensing/LicensingModule.t.sol
+++ b/test/foundry/modules/licensing/LicensingModule.t.sol
@@ -2475,7 +2475,7 @@ contract LicensingModuleTest is BaseTest {
         );
 
         vm.prank(ipOwner2);
-        licensingModule.setLicensingConfig(ipId2, address(0), 0, licensingConfig);
+        licensingModule.setLicensingConfig(ipId2, address(pilTemplate), socialRemixTermsId, licensingConfig);
         assertEq(licenseRegistry.getLicensingConfig(ipId1, address(pilTemplate), socialRemixTermsId).isSet, true);
         assertEq(licenseRegistry.getLicensingConfig(ipId1, address(pilTemplate), socialRemixTermsId).mintingFee, 0);
         assertEq(
@@ -2624,7 +2624,7 @@ contract LicensingModuleTest is BaseTest {
 
         licensingConfig.isSet = true;
         vm.prank(ipOwner2);
-        licensingModule.setLicensingConfig(ipId2, address(0), 0, licensingConfig);
+        licensingModule.setLicensingConfig(ipId2, address(pilTemplate), socialRemixTermsId, licensingConfig);
         assertEq(licenseRegistry.getLicensingConfig(ipId2, address(pilTemplate), socialRemixTermsId).isSet, true);
         assertEq(licenseRegistry.getLicensingConfig(ipId2, address(pilTemplate), socialRemixTermsId).mintingFee, 0);
         assertEq(
@@ -2638,7 +2638,7 @@ contract LicensingModuleTest is BaseTest {
 
         licensingConfig.isSet = false;
         vm.prank(ipOwner2);
-        licensingModule.setLicensingConfig(ipId2, address(0), 0, licensingConfig);
+        licensingModule.setLicensingConfig(ipId2, address(pilTemplate), socialRemixTermsId, licensingConfig);
         assertEq(licenseRegistry.getLicensingConfig(ipId2, address(pilTemplate), socialRemixTermsId).isSet, false);
     }
 
@@ -2702,14 +2702,10 @@ contract LicensingModuleTest is BaseTest {
         licensingModule.setLicensingConfig(ipId1, address(pilTemplate), 0, licensingConfig);
 
         vm.expectRevert(
-            abi.encodeWithSelector(
-                Errors.LicensingModule__InvalidLicenseTermsId.selector,
-                address(0),
-                socialRemixTermsId
-            )
+            abi.encodeWithSelector(Errors.LicensingModule__InvalidLicenseTermsId.selector, address(pilTemplate), 0)
         );
         vm.prank(ipOwner1);
-        licensingModule.setLicensingConfig(ipId1, address(0), socialRemixTermsId, licensingConfig);
+        licensingModule.setLicensingConfig(ipId1, address(pilTemplate), 0, licensingConfig);
     }
 
     function test_LicensingModule_setLicensingConfig_revert_InvalidRoyaltyPercentConfig() public {
@@ -2732,10 +2728,6 @@ contract LicensingModuleTest is BaseTest {
         );
         vm.prank(ipOwner1);
         licensingModule.setLicensingConfig(ipId1, address(0x123), 1, licensingConfig);
-
-        vm.expectRevert(Errors.LicensingModule__LicenseTemplateCannotBeZeroAddressToOverrideRoyaltyPercent.selector);
-        vm.prank(ipOwner1);
-        licensingModule.setLicensingConfig(ipId1, address(0), socialRemixTermsId, licensingConfig);
 
         vm.expectRevert(
             abi.encodeWithSelector(
@@ -3528,6 +3520,27 @@ contract LicensingModuleTest is BaseTest {
         );
         vm.prank(ipOwner1);
         licensingModule.setLicensingConfig(ipId1, address(pilTemplate), termsId, licensingConfig);
+    }
+
+    function test_LicensingModule_setLicensingConfig_revert_ZeroLicenseTemplate() public {
+        Licensing.LicensingConfig memory licensingConfig = Licensing.LicensingConfig({
+            isSet: true,
+            mintingFee: 0,
+            licensingHook: address(0),
+            hookData: "",
+            commercialRevShare: 0,
+            disabled: false,
+            expectMinimumGroupRewardShare: 0,
+            expectGroupRewardPool: address(0)
+        });
+
+        vm.expectRevert(Errors.LicensingModule__ZeroLicenseTemplate.selector);
+        vm.prank(ipOwner1);
+        licensingModule.setLicensingConfig(ipId1, address(0), 0, licensingConfig);
+
+        vm.expectRevert(Errors.LicensingModule__ZeroLicenseTemplate.selector);
+        vm.prank(ipOwner1);
+        licensingModule.setLicensingConfig(ipId1, address(0), 1, licensingConfig);
     }
 
     function onERC721Received(address, address, uint256, bytes memory) public pure returns (bytes4) {

--- a/test/foundry/registries/LicenseRegistry.t.sol
+++ b/test/foundry/registries/LicenseRegistry.t.sol
@@ -160,32 +160,6 @@ contract LicenseRegistryTest is BaseTest {
         licenseRegistry.setLicensingConfigForLicense(ipAcct[1], address(pilTemplate2), termsId, mintingLicenseConfig);
     }
 
-    function test_LicenseRegistry_setLicensingConfigForIp() public {
-        uint256 defaultTermsId = pilTemplate.registerLicenseTerms(PILFlavors.defaultValuesLicenseTerms());
-        Licensing.LicensingConfig memory mintingLicenseConfig = Licensing.LicensingConfig({
-            isSet: true,
-            mintingFee: 100,
-            licensingHook: address(0),
-            hookData: "",
-            commercialRevShare: 0,
-            disabled: false,
-            expectMinimumGroupRewardShare: 0,
-            expectGroupRewardPool: address(0)
-        });
-
-        vm.prank(address(licensingModule));
-        licenseRegistry.setLicensingConfigForIp(ipAcct[1], mintingLicenseConfig);
-
-        Licensing.LicensingConfig memory returnedLicensingConfig = licenseRegistry.getLicensingConfig(
-            ipAcct[1],
-            address(pilTemplate),
-            defaultTermsId
-        );
-        assertEq(returnedLicensingConfig.mintingFee, 100);
-        assertEq(returnedLicensingConfig.licensingHook, address(0));
-        assertEq(returnedLicensingConfig.hookData, "");
-    }
-
     // test attachLicenseTermsToIp
     function test_LicenseRegistry_attachLicenseTermsToIp_revert_CannotAttachToDerivativeIP() public {
         uint256 socialRemixTermsId = pilTemplate.registerLicenseTerms(PILFlavors.nonCommercialSocialRemixing());


### PR DESCRIPTION
## Overview
This PR removes the ability to set licensing configurations at the IP level, requiring all configurations to be set at the specific license template and terms ID level. 

## Key Changes

### LicensingModule.sol
- Modified `setLicensingConfig()` to require both licenseTemplate and licenseTermsId parameters
- Removed IP-level configuration fallback logic
- Updated error handling to enforce non-zero license template addresses
- Added validation to ensure licenseTermsId is non-zero when setting config

### LicenseRegistry.sol
- Removed storage and logic for IP-level configurations
- Updated `getLicensingConfig()` to only return license-specific configurations
- Modified event emissions to reflect removal of IP-level configs

### Tests
- Updated test cases to remove IP-level configuration scenarios
- Added new test cases to verify proper validation of license template and terms ID
- Modified group-related tests to work with license-specific configurations only

## Motivation
The previous implementation allowed licensing configurations to be set at both the IP level and license-specific level, which created:
1. Ambiguity in configuration precedence
2. Complex inheritance rules
3. Potential for conflicting configurations and security concerns

This change enforces a simpler, more explicit model where all configurations must be set at the license level.