### PR TITLE
Adjust claim

### DIFF
--- a/contracts/modules/dispute/policies/UMA/ArbitrationPolicyUMA.sol
+++ b/contracts/modules/dispute/policies/UMA/ArbitrationPolicyUMA.sol
@@ -333,6 +333,8 @@ contract ArbitrationPolicyUMA is
                 BytesConversion.toUtf8Bytes(targetTag),
                 " given the evidence hash ",
                 BytesConversion.toUtf8Bytes(disputeEvidenceHash),
+                // solhint-disable-next-line max-line-length
+                ". This dispute is original and not a duplicate of a previous dispute that has been raised against the same IP.",
                 '"}'
             );
     }


### PR DESCRIPTION
## Description
Adjusts the UMA claim to penalize duplicate disputes. Raising a duplicate dispute can now be countered with just the fact that a similar dispute has already been raised against the IP in the past.