### PR TITLE
Enforce Group Max Size Limit of 1000

### DIFF
--- a/contracts/lib/Errors.sol
+++ b/contracts/lib/Errors.sol
@@ -114,6 +114,9 @@ library Errors {
     /// @notice Group Pool is not registered.
     error GroupIPAssetRegistry__GroupRewardPoolNotRegistered(address groupPool);
 
+    /// @notice The group size exceeds the limit.
+    error GroupIPAssetRegistry__GroupSizeExceedsLimit(uint256 groupSize, uint256 limit);
+
     /// @notice The group ip has derivative IPs.
     error GroupingModule__GroupFrozenDueToHasDerivativeIps(address groupId);
 
@@ -1049,4 +1052,7 @@ library Errors {
 
     /// @notice Deposit token into pool but the token address is zero.
     error EvenSplitGroupPool__DepositWithZeroTokenAddress(address groupId);
+
+    /// @notice The maximum group size has been reached.
+    error EvenSplitGroupPool__MaxGroupSizeReached(address groupId, uint256 maxGroupSize);
 }

--- a/contracts/lib/Errors.sol
+++ b/contracts/lib/Errors.sol
@@ -1054,5 +1054,5 @@ library Errors {
     error EvenSplitGroupPool__DepositWithZeroTokenAddress(address groupId);
 
     /// @notice The maximum group size has been reached.
-    error EvenSplitGroupPool__MaxGroupSizeReached(address groupId, uint256 maxGroupSize);
+    error EvenSplitGroupPool__MaxGroupSizeReached(address groupId, uint32 groupSize, uint256 maxGroupSize);
 }

--- a/contracts/modules/grouping/EvenSplitGroupPool.sol
+++ b/contracts/modules/grouping/EvenSplitGroupPool.sol
@@ -102,7 +102,7 @@ contract EvenSplitGroupPool is IGroupRewardPool, ProtocolPausableUpgradeable, UU
         $.ipAddedTime[groupId][ipId] = block.timestamp;
         groupInfo.totalMembers += 1;
         if (groupInfo.totalMembers > MAX_GROUP_SIZE) {
-            revert Errors.EvenSplitGroupPool__MaxGroupSizeReached(groupInfo.totalMembers, MAX_GROUP_SIZE);
+            revert Errors.EvenSplitGroupPool__MaxGroupSizeReached(groupId, groupInfo.totalMembers, MAX_GROUP_SIZE);
         }
         if (minimumGroupRewardShare > 0) {
             $.minimumRewardShare[groupId][ipId] = minimumGroupRewardShare;

--- a/contracts/modules/grouping/EvenSplitGroupPool.sol
+++ b/contracts/modules/grouping/EvenSplitGroupPool.sol
@@ -26,7 +26,7 @@ contract EvenSplitGroupPool is IGroupRewardPool, ProtocolPausableUpgradeable, UU
     /// @custom:oz-upgrades-unsafe-allow state-variable-immutable
     IGroupIPAssetRegistry public immutable GROUP_IP_ASSET_REGISTRY;
 
-    uint32 public constant MAX_GROUP_SIZE = 1_000_000_000;
+    uint32 public constant MAX_GROUP_SIZE = 1_000;
 
     /// @dev Storage structure for the GroupInfo
     /// As a group can only attach one non-default license to it, the reward token is defined by the license terms
@@ -101,6 +101,9 @@ contract EvenSplitGroupPool is IGroupRewardPool, ProtocolPausableUpgradeable, UU
         if (_isIpAdded(groupId, ipId)) return groupInfo.averageRewardShare * $.groupInfo[groupId].totalMembers;
         $.ipAddedTime[groupId][ipId] = block.timestamp;
         groupInfo.totalMembers += 1;
+        if (groupInfo.totalMembers > MAX_GROUP_SIZE) {
+            revert Errors.EvenSplitGroupPool__MaxGroupSizeReached(groupInfo.totalMembers, MAX_GROUP_SIZE);
+        }
         if (minimumGroupRewardShare > 0) {
             $.minimumRewardShare[groupId][ipId] = minimumGroupRewardShare;
             groupInfo.averageRewardShare = Math.max(groupInfo.averageRewardShare, minimumGroupRewardShare);

--- a/contracts/registries/GroupIPAssetRegistry.sol
+++ b/contracts/registries/GroupIPAssetRegistry.sol
@@ -16,6 +16,8 @@ abstract contract GroupIPAssetRegistry is IGroupIPAssetRegistry, ProtocolPausabl
     using IPAccountStorageOps for IIPAccount;
     using EnumerableSet for EnumerableSet.AddressSet;
 
+    uint256 public constant MAX_GROUP_SIZE = 1000;
+
     /// @custom:oz-upgrades-unsafe-allow state-variable-immutable
     IGroupingModule public immutable GROUPING_MODULE;
 
@@ -94,6 +96,9 @@ abstract contract GroupIPAssetRegistry is IGroupIPAssetRegistry, ProtocolPausabl
         for (uint256 i = 0; i < ipIds.length; i++) {
             if (!_isRegistered(ipIds[i])) revert Errors.GroupIPAssetRegistry__NotRegisteredIP(ipIds[i]);
             allMemberIpIds.add(ipIds[i]);
+        }
+        if (allMemberIpIds.length() > MAX_GROUP_SIZE) {
+            revert Errors.GroupIPAssetRegistry__GroupSizeExceedsLimit(allMemberIpIds.length(), MAX_GROUP_SIZE);
         }
     }
 


### PR DESCRIPTION
Description

This PR enforces a maximum size limit of 1000 members for each group in the `GroupIPAssetRegistry`. This change ensures that no group can exceed the specified limit.

