### PR TITLE
Add validation for licensing hook minting fees

### DIFF
--- a/contracts/lib/Errors.sol
+++ b/contracts/lib/Errors.sol
@@ -548,6 +548,12 @@ library Errors {
     /// @notice When setting licensing config, the license template cannot be zero address.
     error LicensingModule__ZeroLicenseTemplate();
 
+    /// @notice The minting fee set by the licensing hook is less than the minting fee set by the license terms.
+    error LicensingModule__LicensingHookMintingFeeBelowLicenseTerms(
+        uint256 licensingHookMintingFee,
+        uint256 licenseTermsMintingFee
+    );
+
     ////////////////////////////////////////////////////////////////////////////
     //                             Dispute Module                             //
     ////////////////////////////////////////////////////////////////////////////

--- a/contracts/modules/licensing/LicensingModule.sol
+++ b/contracts/modules/licensing/LicensingModule.sol
@@ -759,6 +759,18 @@ contract LicensingModule is
         uint256 mintingFeeByHook
     ) private returns (address royaltyPolicy, uint32 royaltyPercent, uint256 tmf) {
         RoyaltyPolicyInfo memory royaltyInfo = _getRoyaltyPolicyInfo(licenseTemplate, licenseTermsId);
+        if (
+            licensingConfig.isSet &&
+            licensingConfig.licensingHook != address(0) &&
+            mintingFeeByHook < royaltyInfo.mintingFeeByLicense * amount
+        ) {
+            uint256 mintingFeePerTokenByHook = mintingFeeByHook < amount ? 0 : mintingFeeByHook / amount;
+            revert Errors.LicensingModule__LicensingHookMintingFeeBelowLicenseTerms(
+                mintingFeePerTokenByHook,
+                royaltyInfo.mintingFeeByLicense
+            );
+        }
+
         royaltyPolicy = royaltyInfo.royaltyPolicy;
         royaltyPercent = royaltyInfo.royaltyPercent;
         // override royalty percent if it is set in licensing config

--- a/contracts/modules/licensing/LicensingModule.sol
+++ b/contracts/modules/licensing/LicensingModule.sol
@@ -764,7 +764,7 @@ contract LicensingModule is
             licensingConfig.licensingHook != address(0) &&
             mintingFeeByHook < royaltyInfo.mintingFeeByLicense * amount
         ) {
-            uint256 mintingFeePerTokenByHook = mintingFeeByHook < amount ? 0 : mintingFeeByHook / amount;
+            uint256 mintingFeePerTokenByHook = amount == 0 ? mintingFeeByHook : mintingFeeByHook / amount;
             revert Errors.LicensingModule__LicensingHookMintingFeeBelowLicenseTerms(
                 mintingFeePerTokenByHook,
                 royaltyInfo.mintingFeeByLicense


### PR DESCRIPTION
## Description
This PR introduces validation to ensure that licensing hooks cannot set minting fees lower than what is specified in the license terms. This prevents potential fee circumvention.

### Changes
- Add new error `LicensingModule__LicensingHookMintingFeeBelowLicenseTerms` to handle cases where licensing hook sets a minting fee lower than license terms
- Add validation in LicensingModule to check if licensing hook's minting fee is less than the license terms' minting fee
- Update test cases with lower minting fees (from 999/300 to 100)
- Add new test cases to verify the minting fee validation:
  - test_LicensingModule_mintLicenseTokens_revert_LicensingHookMintingFeeBelowLicenseTerms
  - test_LicensingModule_registerDerivative_revert_LicensingHookMintingFeeBelowLicenseTerms
  - test_LicensingModule_predictMintingLicenseFee_LicensingHookMintingFeeBelowLicenseTerms