### PR TITLE
Ensure Private License Token's License Template Matches Attached License Terms

### DIFF
--- a/contracts/interfaces/registries/ILicenseRegistry.sol
+++ b/contracts/interfaces/registries/ILicenseRegistry.sol
@@ -31,6 +31,12 @@ interface ILicenseRegistry {
     /// @param newLicenseTermsId The ID of the new default license terms.
     function setDefaultLicenseTerms(address newLicenseTemplate, uint256 newLicenseTermsId) external;
 
+    /// @notice set license template for an IP, if the IP has no license template.
+    /// @param ipdI The address of the IP to which the license template is attached.
+    /// @param licenseTemplate The address of the license template.
+    /// @dev This function can only be called by the LicensingModule.
+    function initializeLicenseTemplate(address ipdI, address licenseTemplate) external;
+
     /// @notice Returns the default license terms.
     function getDefaultLicenseTerms() external view returns (address licenseTemplate, uint256 licenseTermsId);
 

--- a/contracts/interfaces/registries/ILicenseRegistry.sol
+++ b/contracts/interfaces/registries/ILicenseRegistry.sol
@@ -32,10 +32,10 @@ interface ILicenseRegistry {
     function setDefaultLicenseTerms(address newLicenseTemplate, uint256 newLicenseTermsId) external;
 
     /// @notice set license template for an IP, if the IP has no license template.
-    /// @param ipdI The address of the IP to which the license template is attached.
+    /// @param ipId The address of the IP to which the license template is attached.
     /// @param licenseTemplate The address of the license template.
     /// @dev This function can only be called by the LicensingModule.
-    function initializeLicenseTemplate(address ipdI, address licenseTemplate) external;
+    function initializeLicenseTemplate(address ipId, address licenseTemplate) external;
 
     /// @notice Returns the default license terms.
     function getDefaultLicenseTerms() external view returns (address licenseTemplate, uint256 licenseTermsId);

--- a/contracts/modules/licensing/LicensingModule.sol
+++ b/contracts/modules/licensing/LicensingModule.sol
@@ -685,12 +685,15 @@ contract LicensingModule is
         bytes calldata royaltyContext,
         uint256 maxMintingFee
     ) private returns (uint256 paidMintingFee) {
+        bool isMintedByOwner =  _hasPermission(licensorIpId);
         Licensing.LicensingConfig memory lsc = LICENSE_REGISTRY.verifyMintLicenseToken(
             licensorIpId,
             licenseTemplate,
             licenseTermsId,
-            _hasPermission(licensorIpId)
+            isMintedByOwner
         );
+
+        if (isMintedByOwner) LICENSE_REGISTRY.initializeLicenseTemplate(licensorIpId, licenseTemplate);
 
         if (ILicenseTemplate(licenseTemplate).allowDerivativeRegistration(licenseTermsId)) {
             uint256 ancestors = LICENSE_REGISTRY.getAncestorsCount(licensorIpId);

--- a/contracts/modules/licensing/LicensingModule.sol
+++ b/contracts/modules/licensing/LicensingModule.sol
@@ -685,7 +685,7 @@ contract LicensingModule is
         bytes calldata royaltyContext,
         uint256 maxMintingFee
     ) private returns (uint256 paidMintingFee) {
-        bool isMintedByOwner =  _hasPermission(licensorIpId);
+        bool isMintedByOwner = _hasPermission(licensorIpId);
         Licensing.LicensingConfig memory lsc = LICENSE_REGISTRY.verifyMintLicenseToken(
             licensorIpId,
             licenseTemplate,

--- a/contracts/registries/LicenseRegistry.sol
+++ b/contracts/registries/LicenseRegistry.sol
@@ -304,17 +304,17 @@ contract LicenseRegistry is ILicenseRegistry, AccessManagedUpgradeable, UUPSUpgr
     }
 
     /// @notice set license template for an IP, if the IP has no license template set.
-    /// @param ipdI The address of the IP to which the license template is attached.
+    /// @param ipId The address of the IP to which the license template is attached.
     /// @param licenseTemplate The address of the license template.
     /// @dev This function can only be called by the LicensingModule.
-    function initializeLicenseTemplate(address ipdI, address licenseTemplate) external onlyLicensingModule {
+    function initializeLicenseTemplate(address ipId, address licenseTemplate) external onlyLicensingModule {
         LicenseRegistryStorage storage $ = _getLicenseRegistryStorage();
         if (licenseTemplate == address(0)) revert Errors.LicenseRegistry__ZeroLicenseTemplate();
         // check if registered license template
         if (!$.registeredLicenseTemplates[licenseTemplate]) {
             revert Errors.LicenseRegistry__UnregisteredLicenseTemplate(licenseTemplate);
         }
-        if ($.licenseTemplates[ipdI] == address(0)) $.licenseTemplates[ipdI] = licenseTemplate;
+        if ($.licenseTemplates[ipId] == address(0)) $.licenseTemplates[ipId] = licenseTemplate;
     }
 
     /// @notice Verifies the minting of a license token.

--- a/contracts/registries/LicenseRegistry.sol
+++ b/contracts/registries/LicenseRegistry.sol
@@ -303,6 +303,20 @@ contract LicenseRegistry is ILicenseRegistry, AccessManagedUpgradeable, UUPSUpgr
         if (earliestExp != 0) _setExpirationTime(childIpId, earliestExp);
     }
 
+    /// @notice set license template for an IP, if the IP has no license template set.
+    /// @param ipdI The address of the IP to which the license template is attached.
+    /// @param licenseTemplate The address of the license template.
+    /// @dev This function can only be called by the LicensingModule.
+    function initializeLicenseTemplate(address ipdI, address licenseTemplate) external onlyLicensingModule {
+        LicenseRegistryStorage storage $ = _getLicenseRegistryStorage();
+        if (licenseTemplate == address(0)) revert Errors.LicenseRegistry__ZeroLicenseTemplate();
+        // check if registered license template
+        if (!$.registeredLicenseTemplates[licenseTemplate]) {
+            revert Errors.LicenseRegistry__UnregisteredLicenseTemplate(licenseTemplate);
+        }
+        if ($.licenseTemplates[ipdI] == address(0)) $.licenseTemplates[ipdI] = licenseTemplate;
+    }
+
     /// @notice Verifies the minting of a license token.
     /// @param licensorIpId The address of the licensor IP.
     /// @param licenseTemplate The address of the license template where the license terms are defined.
@@ -328,6 +342,14 @@ contract LicenseRegistry is ILicenseRegistry, AccessManagedUpgradeable, UUPSUpgr
         if (isMintedByIpOwner) {
             if (!_exists(licenseTemplate, licenseTermsId)) {
                 revert Errors.LicenseRegistry__LicenseTermsNotExists(licenseTemplate, licenseTermsId);
+            }
+
+            if ($.licenseTemplates[licensorIpId] != address(0) && licenseTemplate != $.licenseTemplates[licensorIpId]) {
+                revert Errors.LicenseRegistry__UnmatchedLicenseTemplate(
+                    licensorIpId,
+                    $.licenseTemplates[licensorIpId],
+                    licenseTemplate
+                );
             }
         } else if (!_hasIpAttachedLicenseTerms(licensorIpId, licenseTemplate, licenseTermsId)) {
             revert Errors.LicenseRegistry__LicensorIpHasNoLicenseTerms(licensorIpId, licenseTemplate, licenseTermsId);

--- a/test/foundry/modules/licensing/LicensingModule.t.sol
+++ b/test/foundry/modules/licensing/LicensingModule.t.sol
@@ -1357,9 +1357,7 @@ contract LicensingModuleTest is BaseTest {
         assertEq(licenseTemplate, address(pilTemplate));
         assertEq(licenseTermsId, termsId);
     }
-    // test mint private license token will revert if the license template is different from existing license template attached to the ip
-    // test attaching license terms to the ip will revert if the license template is different from existing license template attached to the ip, set during minting of the private license token
-    // test attaching license terms will success if the license template is the same as existing license template attached to the ip, set during minting of the private license token
+
     function test_LicensingModule_mintLicenseToken_revert_privateLicenseTemplateIsDifferentFromExisting() public {
         uint256 termsId1 = pilTemplate.registerLicenseTerms(
             PILFlavors.commercialRemix({
@@ -1503,7 +1501,6 @@ contract LicensingModuleTest is BaseTest {
             maxMintingFee: 0,
             maxRevenueShare: 0
         });
-
     }
 
     function test_LicensingModule_registerDerivativeWithLicenseTokens_revert_pause() public {

--- a/test/foundry/modules/licensing/LicensingModule.t.sol
+++ b/test/foundry/modules/licensing/LicensingModule.t.sol
@@ -1357,6 +1357,154 @@ contract LicensingModuleTest is BaseTest {
         assertEq(licenseTemplate, address(pilTemplate));
         assertEq(licenseTermsId, termsId);
     }
+    // test mint private license token will revert if the license template is different from existing license template attached to the ip
+    // test attaching license terms to the ip will revert if the license template is different from existing license template attached to the ip, set during minting of the private license token
+    // test attaching license terms will success if the license template is the same as existing license template attached to the ip, set during minting of the private license token
+    function test_LicensingModule_mintLicenseToken_revert_privateLicenseTemplateIsDifferentFromExisting() public {
+        uint256 termsId1 = pilTemplate.registerLicenseTerms(
+            PILFlavors.commercialRemix({
+                mintingFee: 0,
+                commercialRevShare: 10,
+                currencyToken: address(erc20),
+                royaltyPolicy: address(royaltyPolicyLRP)
+            })
+        );
+        vm.prank(ipOwner1);
+        licensingModule.attachLicenseTerms(ipId1, address(pilTemplate), termsId1);
+
+        MockLicenseTemplate pilTemplate2 = new MockLicenseTemplate();
+        vm.prank(admin);
+        licenseRegistry.registerLicenseTemplate(address(pilTemplate2));
+        uint256 termsId2 = pilTemplate2.registerLicenseTerms();
+
+        vm.expectRevert(
+            abi.encodeWithSelector(
+                Errors.LicenseRegistry__UnmatchedLicenseTemplate.selector,
+                ipId1,
+                address(pilTemplate),
+                address(pilTemplate2)
+            )
+        );
+        vm.prank(ipOwner1);
+        uint256 lcTokenId = licensingModule.mintLicenseTokens({
+            licensorIpId: ipId1,
+            licenseTemplate: address(pilTemplate2),
+            licenseTermsId: termsId2,
+            amount: 1,
+            receiver: ipOwner2,
+            royaltyContext: "",
+            maxMintingFee: 0,
+            maxRevenueShare: 0
+        });
+    }
+
+    function test_LicensingModule_attachLicenseTerms_revert_templateDifferentFromPrivateLicenseTemplate() public {
+        uint256 termsId1 = pilTemplate.registerLicenseTerms(
+            PILFlavors.commercialRemix({
+                mintingFee: 0,
+                commercialRevShare: 10,
+                currencyToken: address(erc20),
+                royaltyPolicy: address(royaltyPolicyLRP)
+            })
+        );
+        vm.prank(ipOwner1);
+        uint256 lcTokenId = licensingModule.mintLicenseTokens({
+            licensorIpId: ipId1,
+            licenseTemplate: address(pilTemplate),
+            licenseTermsId: termsId1,
+            amount: 1,
+            receiver: ipOwner2,
+            royaltyContext: "",
+            maxMintingFee: 0,
+            maxRevenueShare: 0
+        });
+
+        MockLicenseTemplate pilTemplate2 = new MockLicenseTemplate();
+        vm.prank(admin);
+        licenseRegistry.registerLicenseTemplate(address(pilTemplate2));
+        uint256 termsId2 = pilTemplate2.registerLicenseTerms();
+
+        vm.expectRevert(
+            abi.encodeWithSelector(
+                Errors.LicenseRegistry__UnmatchedLicenseTemplate.selector,
+                ipId1,
+                address(pilTemplate),
+                address(pilTemplate2)
+            )
+        );
+        vm.prank(ipOwner1);
+        licensingModule.attachLicenseTerms(ipId1, address(pilTemplate2), termsId2);
+    }
+
+    function test_LicensingModule_attachLicenseTerms_templateSameWithPrivateLicenseTemplate() public {
+        uint256 termsId1 = pilTemplate.registerLicenseTerms(
+            PILFlavors.commercialRemix({
+                mintingFee: 0,
+                commercialRevShare: 10,
+                currencyToken: address(erc20),
+                royaltyPolicy: address(royaltyPolicyLRP)
+            })
+        );
+        vm.prank(ipOwner1);
+        uint256 lcTokenId = licensingModule.mintLicenseTokens({
+            licensorIpId: ipId1,
+            licenseTemplate: address(pilTemplate),
+            licenseTermsId: termsId1,
+            amount: 1,
+            receiver: ipOwner2,
+            royaltyContext: "",
+            maxMintingFee: 0,
+            maxRevenueShare: 0
+        });
+
+        uint256 termsId2 = pilTemplate.registerLicenseTerms(
+            PILFlavors.commercialRemix({
+                mintingFee: 0,
+                commercialRevShare: 10,
+                currencyToken: address(erc20),
+                royaltyPolicy: address(royaltyPolicyLAP)
+            })
+        );
+
+        vm.prank(ipOwner1);
+        licensingModule.attachLicenseTerms(ipId1, address(pilTemplate), termsId2);
+    }
+
+    function test_LicensingModule_mintLicenseToken_PrivateLicenseTemplateSameWithExisting() public {
+        uint256 termsId1 = pilTemplate.registerLicenseTerms(
+            PILFlavors.commercialRemix({
+                mintingFee: 0,
+                commercialRevShare: 10,
+                currencyToken: address(erc20),
+                royaltyPolicy: address(royaltyPolicyLRP)
+            })
+        );
+
+        uint256 termsId2 = pilTemplate.registerLicenseTerms(
+            PILFlavors.commercialRemix({
+                mintingFee: 0,
+                commercialRevShare: 10,
+                currencyToken: address(erc20),
+                royaltyPolicy: address(royaltyPolicyLAP)
+            })
+        );
+
+        vm.prank(ipOwner1);
+        licensingModule.attachLicenseTerms(ipId1, address(pilTemplate), termsId1);
+
+        vm.prank(ipOwner1);
+        uint256 lcTokenId = licensingModule.mintLicenseTokens({
+            licensorIpId: ipId1,
+            licenseTemplate: address(pilTemplate),
+            licenseTermsId: termsId2,
+            amount: 1,
+            receiver: ipOwner2,
+            royaltyContext: "",
+            maxMintingFee: 0,
+            maxRevenueShare: 0
+        });
+
+    }
 
     function test_LicensingModule_registerDerivativeWithLicenseTokens_revert_pause() public {
         uint256 termsId = pilTemplate.registerLicenseTerms(PILFlavors.nonCommercialSocialRemixing());


### PR DESCRIPTION
## Description

This PR ensures that the license template of a private license token always matches the license template of the attached license terms. This change enforces consistency and prevents discrepancies between the license templates.

## Key Changes

- **License Template Validation**: Added validation to ensure the license template of a private license token matches the license template of the attached license terms.
