### PR TITLE
Disallow Setting Permissions for Nested IP Accounts in AccessController

### DIFF
--- a/contracts/access/AccessController.sol
+++ b/contracts/access/AccessController.sol
@@ -313,8 +313,13 @@ contract AccessController is IAccessController, ProtocolPausableUpgradeable, UUP
         if (permission > 2) {
             revert Errors.AccessController__PermissionIsNotValid();
         }
-        if (ipAccount != msg.sender && IIPAccount(payable(ipAccount)).owner() != msg.sender) {
+        address owner = IIPAccount(payable(ipAccount)).owner();
+        if (ipAccount != msg.sender && owner != msg.sender) {
             revert Errors.AccessController__CallerIsNotIPAccountOrOwner();
+        }
+        // Do not support nested IPAccount setting permissions
+        if (IP_ASSET_REGISTRY.isIpAccount(owner)) {
+            revert Errors.AccessController__OwnerIsIPAccount(ipAccount, owner);
         }
         if (isTransient) {
             TRANSIENT_FLAG_SLOT.asBoolean().tstore(true);

--- a/contracts/lib/Errors.sol
+++ b/contracts/lib/Errors.sol
@@ -984,6 +984,9 @@ library Errors {
     /// @notice Both recipient (to) and function selectors are zero address means delegate all permissions to signer.
     error AccessController__ToAndFuncAreZeroAddressShouldCallSetAllPermissions();
 
+    /// @notice The IP Account's owner is another IP Account.
+    error AccessController__OwnerIsIPAccount(address ipAccount, address owner);
+
     ////////////////////////////////////////////////////////////////////////////
     //                            Access Controlled                           //
     ////////////////////////////////////////////////////////////////////////////

--- a/test/foundry/access/AccessController.t.sol
+++ b/test/foundry/access/AccessController.t.sol
@@ -102,6 +102,71 @@ contract AccessControllerTest is BaseTest {
         );
     }
 
+    function test_AccessController_revert_NestedIpAccountCannotSetPermission() public {
+        mockNFT.mintId(address(ipAccount), tokenId + 1);
+        IIPAccount nestedIpAccount = IIPAccount(
+            payable(ipAssetRegistry.register(block.chainid, address(mockNFT), tokenId + 1))
+        );
+
+        address signer = vm.addr(2);
+        address nonOwner = vm.addr(3);
+        vm.prank(owner);
+        vm.expectRevert(
+            abi.encodeWithSelector(
+                Errors.AccessController__OwnerIsIPAccount.selector,
+                address(nestedIpAccount),
+                address(ipAccount)
+            )
+        );
+        ipAccount.execute(
+            address(nestedIpAccount),
+            0,
+            abi.encodeWithSignature(
+                "execute(address,uint256,bytes)",
+                address(accessController),
+                0,
+                abi.encodeWithSignature(
+                    "setPermission(address,address,address,bytes4,uint8)",
+                    address(nestedIpAccount),
+                    signer,
+                    address(mockModule),
+                    mockModule.executeSuccessfully.selector,
+                    AccessPermission.ALLOW
+                )
+            )
+        );
+    }
+
+    function test_AccessController_revert_IPAccountCannotSetPermissionForNestedIpAccount() public {
+        mockNFT.mintId(address(ipAccount), tokenId + 1);
+        IIPAccount nestedIpAccount = IIPAccount(
+            payable(ipAssetRegistry.register(block.chainid, address(mockNFT), tokenId + 1))
+        );
+
+        address signer = vm.addr(2);
+        address nonOwner = vm.addr(3);
+        vm.prank(owner);
+        vm.expectRevert(
+            abi.encodeWithSelector(
+                Errors.AccessController__OwnerIsIPAccount.selector,
+                address(nestedIpAccount),
+                address(ipAccount)
+            )
+        );
+        ipAccount.execute(
+            address(accessController),
+            0,
+            abi.encodeWithSignature(
+                "setPermission(address,address,address,bytes4,uint8)",
+                address(nestedIpAccount),
+                signer,
+                address(mockModule),
+                mockModule.executeSuccessfully.selector,
+                AccessPermission.ALLOW
+            )
+        );
+    }
+
     function test_AccessController_revert_directSetPermission() public {
         address signer = vm.addr(2);
 


### PR DESCRIPTION
## Description

This PR introduces a restriction in the `AccessController` to disallow setting permissions for nested IP Accounts which owned by another IP Account. 

## Key Changes

- **Permission Restriction**: Added logic to prevent setting permissions for nested IP Accounts in the `AccessController`.

