### PR TITLE
Restrict Group IPs to Only Mint Tokens for Attached License Terms

### DIFF
--- a/contracts/registries/LicenseRegistry.sol
+++ b/contracts/registries/LicenseRegistry.sol
@@ -339,7 +339,7 @@ contract LicenseRegistry is ILicenseRegistry, AccessManagedUpgradeable, UUPSUpgr
         if (_isExpiredNow(licensorIpId)) {
             revert Errors.LicenseRegistry__ParentIpExpired(licensorIpId);
         }
-        if (isMintedByIpOwner) {
+        if (isMintedByIpOwner && !GROUP_IP_ASSET_REGISTRY.isRegisteredGroup(licensorIpId)) {
             if (!_exists(licenseTemplate, licenseTermsId)) {
                 revert Errors.LicenseRegistry__LicenseTermsNotExists(licenseTemplate, licenseTermsId);
             }


### PR DESCRIPTION
## Description
This PR fixes a security vulnerability that allowed Group IPs to bypass licensing restrictions by minting license tokens using terms that weren't officially attached to the group (i.e. private license tokens).
To fix this issue, this PR modified `verifyMintLicenseToken()` in the in the `LicenseRegistry` to ensure group IPs can only mint license tokens for terms that are attached to the group.

## Testing
Added a test case `test_GroupingModule_mintLicenseToken_revert_groupIpHasNoLicenseTerms()` that verifies:
- A group IP cannot mint license tokens for terms that aren't attached to it
- The system properly reverts with the expected error message when this is attempted