### PR TITLE
Prevent License Terms with Derivative Approval from Attaching to Group IPs

### DIFF
--- a/contracts/modules/licensing/PILicenseTemplate.sol
+++ b/contracts/modules/licensing/PILicenseTemplate.sol
@@ -338,6 +338,9 @@ contract PILicenseTemplate is
     /// @return True if the license terms support associate with group IP assets, false otherwise.
     function canAttachToGroupIp(uint256 licenseTermsId) external view returns (bool) {
         PILTerms memory terms = _getPILicenseTemplateStorage().licenseTerms[licenseTermsId];
+        if (terms.derivativesApproval) {
+            return false;
+        }
         address royaltyPolicy = terms.royaltyPolicy;
         if (royaltyPolicy == address(0)) {
             return true;

--- a/test/foundry/modules/grouping/GroupingModule.t.sol
+++ b/test/foundry/modules/grouping/GroupingModule.t.sol
@@ -823,6 +823,41 @@ contract GroupingModuleTest is BaseTest, ERC721Holder {
         vm.stopPrank();
     }
 
+    function test_GroupingModule_addIp_revert_derivativeApprovalRequired() public {
+        uint256 termsId = pilTemplate.registerLicenseTerms(
+            PILTerms({
+                transferable: true,
+                royaltyPolicy: address(0),
+                defaultMintingFee: 0,
+                expiration: 0,
+                commercialUse: false,
+                commercialAttribution: false,
+                commercializerChecker: address(0),
+                commercializerCheckerData: "",
+                commercialRevShare: 0,
+                commercialRevCeiling: 0,
+                derivativesAllowed: true,
+                derivativesAttribution: true,
+                derivativesApproval: true, // derivative approval required
+                derivativesReciprocal: true,
+                derivativeRevCeiling: 0,
+                currency: address(0),
+                uri: ""
+            })
+        );
+        vm.startPrank(alice);
+        address groupId1 = groupingModule.registerGroup(address(rewardPool));
+        vm.expectRevert(
+            abi.encodeWithSelector(
+                Errors.LicenseRegistry__LicenseTermsCannotAttachToGroupIp.selector,
+                address(pilTemplate),
+                termsId
+            )
+        );
+        licensingModule.attachLicenseTerms(groupId1, address(pilTemplate), termsId);
+        vm.stopPrank();
+    }
+
     function test_GroupingModule_addIp_revert_DisputedIp() public {
         bytes32 disputeEvidenceHashExample = 0xb7b94ecbd1f9f8cb209909e5785fb2858c9a8c4b220c017995a75346ad1b5db5;
         uint256 termsId = pilTemplate.registerLicenseTerms(


### PR DESCRIPTION
## Description
This PR adds a security fix that prevents license terms with `derivativesApproval = true` from being attached to group IP assets. This change addresses a vulnerability where the derivative approval requirement could be bypassed through group IPs.

## Problem
When a license has `derivativesApproval = true`, it requires the IP owner's explicit approval for derivatives. However, when such IPs are added to a group, this restriction could be bypassed:
- Create a group IP containing the restricted IP
- Approve deriving from the group IP (the group could be owned by a malicious user)
- Create a derivative of the group IP

This effectively circumvents the IP owner's intention to approve derivatives.

## Solution
Added a check in `PILicenseTemplate.canAttachToGroupIp()` that returns `false` when license terms have `derivativesApproval = true`. This prevents licenses requiring derivative approval from being attached to group IPs in the first place.

## Testing
Added a test case (`test_GroupingModule_addIp_revert_derivativeApprovalRequired`) to verify that attempting to attach a license with `derivativesApproval = true` to a group IP results in the appropriate error
