### PR TITLE
 Revert Royalty Transfer to Self's Vault

### DIFF
--- a/contracts/lib/Errors.sol
+++ b/contracts/lib/Errors.sol
@@ -814,6 +814,9 @@ library Errors {
     /// @notice Call failed.
     error RoyaltyPolicyLAP__CallFailed();
 
+    /// @notice Cannot transfer to the Same IP.
+    error RoyaltyPolicyLAP__SameIpTransfer();
+
     ////////////////////////////////////////////////////////////////////////////
     //                            Royalty Policy LRP                          //
     ////////////////////////////////////////////////////////////////////////////
@@ -841,6 +844,9 @@ library Errors {
 
     /// @notice Call failed.
     error RoyaltyPolicyLRP__CallFailed();
+
+    /// @notice Cannot transfer to the Same IP.
+    error RoyaltyPolicyLRP__SameIpTransfer();
 
     ////////////////////////////////////////////////////////////////////////////
     //                         IP Royalty Vault                               //

--- a/contracts/modules/royalty/policies/LAP/RoyaltyPolicyLAP.sol
+++ b/contracts/modules/royalty/policies/LAP/RoyaltyPolicyLAP.sol
@@ -130,6 +130,7 @@ contract RoyaltyPolicyLAP is
         address token
     ) external whenNotPaused returns (uint256) {
         RoyaltyPolicyLAPStorage storage $ = _getRoyaltyPolicyLAPStorage();
+        if (ipId == ancestorIpId) revert Errors.RoyaltyPolicyLAP__SameIpTransfer();
 
         uint32 ancestorPercent = $.ancestorPercentLAP[ipId][ancestorIpId];
         if (ancestorPercent == 0) {

--- a/contracts/modules/royalty/policies/LRP/RoyaltyPolicyLRP.sol
+++ b/contracts/modules/royalty/policies/LRP/RoyaltyPolicyLRP.sol
@@ -157,6 +157,7 @@ contract RoyaltyPolicyLRP is
         address token
     ) external whenNotPaused returns (uint256) {
         RoyaltyPolicyLRPStorage storage $ = _getRoyaltyPolicyLRPStorage();
+        if (ipId == ancestorIpId) revert Errors.RoyaltyPolicyLRP__SameIpTransfer();
 
         uint32 ancestorPercent = $.ancestorPercentLRP[ipId][ancestorIpId];
         if (ancestorPercent == 0) {

--- a/test/foundry/modules/royalty/LAP/RoyaltyPolicyLAP.t.sol
+++ b/test/foundry/modules/royalty/LAP/RoyaltyPolicyLAP.t.sol
@@ -212,6 +212,39 @@ contract TestRoyaltyPolicyLAP is BaseTest {
         royaltyPolicyLAP.transferToVault(ipAccount1, address(2000), address(USDC));
     }
 
+    function test_RoyaltyPolicyLAP_transferToVault_revert_SameIpTransfer() public {
+        address[] memory parents = new address[](3);
+        address[] memory licenseRoyaltyPolicies = new address[](3);
+        uint32[] memory parentRoyalties = new uint32[](3);
+        parents[0] = address(10);
+        parents[1] = address(20);
+        parents[2] = address(30);
+        licenseRoyaltyPolicies[0] = address(royaltyPolicyLAP);
+        licenseRoyaltyPolicies[1] = address(royaltyPolicyLAP);
+        licenseRoyaltyPolicies[2] = address(royaltyPolicyLAP);
+        parentRoyalties[0] = uint32(10 * 10 ** 6);
+        parentRoyalties[1] = uint32(15 * 10 ** 6);
+        parentRoyalties[2] = uint32(20 * 10 ** 6);
+        ipGraph.addParentIp(ipAccount1, parents);
+
+        vm.startPrank(address(licensingModule));
+        royaltyModule.onLinkToParents(ipAccount1, parents, licenseRoyaltyPolicies, parentRoyalties, "", 100e6);
+
+        // make payment to ip 80
+        uint256 royaltyAmount = 100 * 10 ** 6;
+        address receiverIpId = ipAccount1;
+        address payerIpId = address(3);
+        vm.startPrank(payerIpId);
+        USDC.mint(payerIpId, royaltyAmount);
+        USDC.approve(address(royaltyModule), royaltyAmount);
+        royaltyModule.payRoyaltyOnBehalf(receiverIpId, payerIpId, address(USDC), royaltyAmount);
+        vm.stopPrank();
+
+        // first transfer to vault
+        vm.expectRevert(Errors.RoyaltyPolicyLAP__SameIpTransfer.selector);
+        royaltyPolicyLAP.transferToVault(ipAccount1, ipAccount1, address(USDC));
+    }
+
     function test_RoyaltyPolicyLAP_transferToVault() public {
         address[] memory parents = new address[](3);
         address[] memory licenseRoyaltyPolicies = new address[](3);

--- a/test/foundry/modules/royalty/LRP/RoyaltyPolicyLRP.t.sol
+++ b/test/foundry/modules/royalty/LRP/RoyaltyPolicyLRP.t.sol
@@ -189,7 +189,7 @@ contract TestRoyaltyPolicyLRP is BaseTest {
         assertEq(royaltyPolicyLRP.getPolicyRoyalty(address(80), address(30)), 20 * 10 ** 6);
     }
 
-    function test_RoyaltyPolicyLRP_transferToVault_revert_ZeroClaimableRoyalty() public {
+    function test_RoyaltyPolicyLRP_transferToVault_revert_SameIpTransfer() public {
         address[] memory parents = new address[](3);
         address[] memory licenseRoyaltyPolicies = new address[](3);
         uint32[] memory parentRoyalties = new uint32[](3);
@@ -218,8 +218,8 @@ contract TestRoyaltyPolicyLRP is BaseTest {
         vm.stopPrank();
 
         // first transfer to vault
-        vm.expectRevert(); // throws out-of-gas instead of ZeroClaimableRoyalty due to using the mock ip graph
-        royaltyPolicyLRP.transferToVault(ipAccount1, address(2000), address(USDC));
+        vm.expectRevert(Errors.RoyaltyPolicyLRP__SameIpTransfer.selector);
+        royaltyPolicyLRP.transferToVault(ipAccount1, ipAccount1, address(USDC));
     }
 
     function test_RoyaltyPolicyLRP_transferToVault() public {

--- a/test/foundry/modules/royalty/LRP/RoyaltyPolicyLRP.t.sol
+++ b/test/foundry/modules/royalty/LRP/RoyaltyPolicyLRP.t.sol
@@ -189,6 +189,39 @@ contract TestRoyaltyPolicyLRP is BaseTest {
         assertEq(royaltyPolicyLRP.getPolicyRoyalty(address(80), address(30)), 20 * 10 ** 6);
     }
 
+    function test_RoyaltyPolicyLRP_transferToVault_revert_ZeroClaimableRoyalty() public {
+        address[] memory parents = new address[](3);
+        address[] memory licenseRoyaltyPolicies = new address[](3);
+        uint32[] memory parentRoyalties = new uint32[](3);
+        parents[0] = address(10);
+        parents[1] = address(20);
+        parents[2] = address(30);
+        licenseRoyaltyPolicies[0] = address(royaltyPolicyLRP);
+        licenseRoyaltyPolicies[1] = address(royaltyPolicyLRP);
+        licenseRoyaltyPolicies[2] = address(royaltyPolicyLRP);
+        parentRoyalties[0] = uint32(10 * 10 ** 6);
+        parentRoyalties[1] = uint32(15 * 10 ** 6);
+        parentRoyalties[2] = uint32(20 * 10 ** 6);
+        ipGraph.addParentIp(ipAccount1, parents);
+
+        vm.startPrank(address(licensingModule));
+        royaltyModule.onLinkToParents(ipAccount1, parents, licenseRoyaltyPolicies, parentRoyalties, "", 100e6);
+
+        // make payment to ip 80
+        uint256 royaltyAmount = 100 * 10 ** 6;
+        address receiverIpId = ipAccount1;
+        address payerIpId = address(3);
+        vm.startPrank(payerIpId);
+        USDC.mint(payerIpId, royaltyAmount);
+        USDC.approve(address(royaltyModule), royaltyAmount);
+        royaltyModule.payRoyaltyOnBehalf(receiverIpId, payerIpId, address(USDC), royaltyAmount);
+        vm.stopPrank();
+
+        // first transfer to vault
+        vm.expectRevert(); // throws out-of-gas instead of ZeroClaimableRoyalty due to using the mock ip graph
+        royaltyPolicyLRP.transferToVault(ipAccount1, address(2000), address(USDC));
+    }
+
     function test_RoyaltyPolicyLRP_transferToVault_revert_SameIpTransfer() public {
         address[] memory parents = new address[](3);
         address[] memory licenseRoyaltyPolicies = new address[](3);


### PR DESCRIPTION
## Description

This PR introduces a check to prevent the transfer of royalties to the same IP account's vault. If such a transfer is attempted, the transaction will be reverted. 

## Key Changes

- **Self-Transfer Check**: Added logic to revert the transaction if an attempt is made to transfer royalties to the same IP account's vault.

