### PR TITLE
Add dispute initiator to raise dispute function

### DIFF
--- a/contracts/interfaces/modules/dispute/IDisputeModule.sol
+++ b/contracts/interfaces/modules/dispute/IDisputeModule.sol
@@ -55,6 +55,7 @@ interface IDisputeModule {
     /// @notice Event emitted when a dispute is raised
     /// @param disputeId The dispute id
     /// @param targetIpId The ipId that is the target of the dispute
+    /// @param caller The address of the caller
     /// @param disputeInitiator The address of the dispute initiator
     /// @param disputeTimestamp The timestamp of the dispute
     /// @param arbitrationPolicy The address of the arbitration policy
@@ -64,6 +65,7 @@ interface IDisputeModule {
     event DisputeRaised(
         uint256 disputeId,
         address targetIpId,
+        address caller,
         address disputeInitiator,
         uint256 disputeTimestamp,
         address arbitrationPolicy,
@@ -185,12 +187,14 @@ interface IDisputeModule {
 
     /// @notice Raises a dispute on a given ipId
     /// @param targetIpId The ipId that is the target of the dispute
+    /// @param disputeInitiator The address of the dispute initiator
     /// @param disputeEvidenceHash The hash pointing to the dispute evidence
     /// @param targetTag The target tag of the dispute
     /// @param data The data to raise a dispute
     /// @return disputeId The id of the newly raised dispute
     function raiseDispute(
         address targetIpId,
+        address disputeInitiator,
         bytes32 disputeEvidenceHash,
         bytes32 targetTag,
         bytes calldata data

--- a/contracts/interfaces/modules/dispute/policies/IArbitrationPolicy.sol
+++ b/contracts/interfaces/modules/dispute/policies/IArbitrationPolicy.sol
@@ -6,6 +6,7 @@ interface IArbitrationPolicy {
     /// @notice Executes custom logic on raising dispute
     /// @dev Enforced to be only callable by the DisputeModule
     /// @param caller Address of the caller
+    /// @param disputeInitiator Address of the dispute initiator
     /// @param targetIpId The ipId that is the target of the dispute
     /// @param disputeEvidenceHash The hash pointing to the dispute evidence
     /// @param targetTag The target tag of the dispute
@@ -13,6 +14,7 @@ interface IArbitrationPolicy {
     /// @param data The arbitrary data used to raise the dispute
     function onRaiseDispute(
         address caller,
+        address disputeInitiator,
         address targetIpId,
         bytes32 disputeEvidenceHash,
         bytes32 targetTag,

--- a/contracts/lib/Errors.sol
+++ b/contracts/lib/Errors.sol
@@ -627,6 +627,9 @@ library Errors {
     /// @notice Evidence hash already used.
     error DisputeModule__EvidenceHashAlreadyUsed();
 
+    /// @notice Invalid dispute initiator.
+    error DisputeModule__InvalidDisputeInitiator();
+
     ////////////////////////////////////////////////////////////////////////////
     //                             Arbitration Policy UMA                     //
     ////////////////////////////////////////////////////////////////////////////

--- a/contracts/modules/dispute/DisputeModule.sol
+++ b/contracts/modules/dispute/DisputeModule.sol
@@ -219,7 +219,8 @@ contract DisputeModule is
         if (!$.isWhitelistedDisputeTag[targetTag]) revert Errors.DisputeModule__NotWhitelistedDisputeTag();
         if (disputeEvidenceHash == bytes32(0)) revert Errors.DisputeModule__ZeroDisputeEvidenceHash();
         if ($.isUsedEvidenceHash[disputeEvidenceHash]) revert Errors.DisputeModule__EvidenceHashAlreadyUsed();
-        if (disputeInitiator == address(0) || disputeInitiator == targetIpId) revert Errors.DisputeModule__InvalidDisputeInitiator();
+        if (disputeInitiator == address(0) || disputeInitiator == targetIpId)
+            revert Errors.DisputeModule__InvalidDisputeInitiator();
 
         address arbitrationPolicy = _updateActiveArbitrationPolicy(targetIpId);
         uint256 disputeId = ++$.disputeCounter;

--- a/contracts/modules/dispute/policies/UMA/ArbitrationPolicyUMA.sol
+++ b/contracts/modules/dispute/policies/UMA/ArbitrationPolicyUMA.sol
@@ -134,7 +134,8 @@ contract ArbitrationPolicyUMA is
 
     /// @notice Executes custom logic on raising dispute
     /// @dev Enforced to be only callable by the DisputeModule
-    /// @param caller Address of the caller
+    /// @param caller Address of the caller which will cover the dispute bond amount
+    /// @param disputeInitiator Address of the dispute initiator which will receive the bond upon winning the dispute
     /// @param targetIpId The ipId that is the target of the dispute
     /// @param disputeEvidenceHash The hash pointing to the dispute evidence
     /// @param targetTag The target tag of the dispute
@@ -142,6 +143,7 @@ contract ArbitrationPolicyUMA is
     /// @param data The arbitrary data used to raise the dispute
     function onRaiseDispute(
         address caller,
+        address disputeInitiator,
         address targetIpId,
         bytes32 disputeEvidenceHash,
         bytes32 targetTag,
@@ -163,7 +165,7 @@ contract ArbitrationPolicyUMA is
 
         bytes32 assertionId = oov3.assertTruth(
             _constructClaim(targetIpId, targetTag, disputeEvidenceHash, disputeId),
-            caller, // asserter
+            disputeInitiator, // asserter
             address(this), // callbackRecipient
             address(0), // escalationManager
             liveness,

--- a/test/foundry/invariants/DisputeModule.t.sol
+++ b/test/foundry/invariants/DisputeModule.t.sol
@@ -51,6 +51,7 @@ contract DisputeHarness is Test {
     /// It increments the counter if the dispute is raised successfully
     function raiseDispute(
         uint256 targetIpIdIdx,
+        address disputeInitiator,
         bytes32 disputeEvidenceHash,
         uint256 targetTagIdx,
         bytes calldata data
@@ -58,6 +59,7 @@ contract DisputeHarness is Test {
         try
             disputeModule.raiseDispute(
                 ipAccounts[targetIpIdIdx % ipAccounts.length],
+                disputeInitiator,
                 disputeEvidenceHash,
                 tags[targetTagIdx % tags.length],
                 data

--- a/test/foundry/mocks/dispute/MockArbitrationPolicy.sol
+++ b/test/foundry/mocks/dispute/MockArbitrationPolicy.sol
@@ -36,6 +36,7 @@ contract MockArbitrationPolicy is IArbitrationPolicy {
 
     function onRaiseDispute(
         address caller,
+        address disputeInitiator,
         address targetIpId,
         bytes32 disputeEvidenceHash,
         bytes32 targetTag,

--- a/test/foundry/modules/grouping/GroupingModule.t.sol
+++ b/test/foundry/modules/grouping/GroupingModule.t.sol
@@ -1951,7 +1951,7 @@ contract GroupingModuleTest is BaseTest, ERC721Holder {
         vm.startPrank(initiator);
         USDC.mint(initiator, 1000 * 10 ** 6);
         IERC20(USDC).approve(address(mockArbitrationPolicy), ARBITRATION_PRICE);
-        disputeModule.raiseDispute(targetIp, disputeEvidenceHash, "IMPROPER_REGISTRATION", "");
+        disputeModule.raiseDispute(targetIp, initiator, disputeEvidenceHash, "IMPROPER_REGISTRATION", "");
         vm.stopPrank();
 
         vm.prank(u.relayer);

--- a/test/foundry/modules/royalty/RoyaltyModule.t.sol
+++ b/test/foundry/modules/royalty/RoyaltyModule.t.sol
@@ -794,7 +794,7 @@ contract TestRoyaltyModule is BaseTest, ERC721Holder {
         // raise dispute
         vm.startPrank(ipAccount1);
         USDC.approve(address(mockArbitrationPolicy), ARBITRATION_PRICE);
-        disputeModule.raiseDispute(ipAddr, disputeEvidenceHashExample, "IMPROPER_REGISTRATION", "");
+        disputeModule.raiseDispute(ipAddr, ipAccount1, disputeEvidenceHashExample, "IMPROPER_REGISTRATION", "");
         vm.stopPrank();
 
         // set dispute judgement
@@ -1168,7 +1168,7 @@ contract TestRoyaltyModule is BaseTest, ERC721Holder {
         // raise dispute
         vm.startPrank(ipAccount1);
         USDC.approve(address(mockArbitrationPolicy), ARBITRATION_PRICE);
-        disputeModule.raiseDispute(ipAddr, disputeEvidenceHashExample, "IMPROPER_REGISTRATION", "");
+        disputeModule.raiseDispute(ipAddr, ipAccount1, disputeEvidenceHashExample, "IMPROPER_REGISTRATION", "");
         vm.stopPrank();
 
         // set dispute judgement

--- a/test/foundry/utils/BaseTest.t.sol
+++ b/test/foundry/utils/BaseTest.t.sol
@@ -131,6 +131,7 @@ contract BaseTest is Test, DeployHelper, LicensingHelper {
         bytes32 disputeEvidenceHashExample = 0xb7b94ecbd1f9f8cb209909e5785fb2858c9a8c4b220c017995a75346ad1b5db5;
         disputeId = disputeModule.raiseDispute(
             ipAddrToDispute,
+            disputeInitiator,
             disputeEvidenceHashExample,
             "IMPROPER_REGISTRATION",
             ""


### PR DESCRIPTION
## Description
This PR allows the caller of the `raiseDispute` function to define a dispute initiator different from the msg.sender. This enables wrapper contracts - ie. SPG - to raise a dispute of behalf of a user.