### PR TITLE
add tests for 1.3.2 change

### DIFF
--- a/test/hardhat/e2e/ipaccount/ipaccount.test.ts
+++ b/test/hardhat/e2e/ipaccount/ipaccount.test.ts
@@ -1,0 +1,58 @@
+// Test: IPAccount - state update on asset changes
+
+import "../setup";
+import { expect } from "chai";
+import hre from "hardhat";
+import { mintNFTAndRegisterIPA } from "../utils/mintNFTAndRegisterIPA";
+import { MockERC721, PILicenseTemplate } from "../constants";
+
+describe("IPAccount", function () {
+  it("Update nonce state of IPAsset on asset changes", async function () {
+    console.log("============ Register IP1 ============");
+    const { tokenId: tokenId1, ipId: ipId1 } = await mintNFTAndRegisterIPA();
+    console.log("IP1: ", ipId1);
+
+    console.log("============ Get state of IP1 ============");
+    const ipAccount1 = await this.ipAssetRegistry.ipAccount(this.chainId, MockERC721, tokenId1);
+    console.log("IPAccount1: ", ipAccount1);
+    const ipAccount1Contract = await hre.ethers.getContractAt("IPAccountImpl", ipAccount1);
+    const state1 = await ipAccount1Contract.state();
+    console.log("State of IP1: ", state1);
+
+    console.log("============ Attach license to IP1 ============");
+    await expect(
+      this.licensingModule.attachLicenseTerms(ipId1, PILicenseTemplate, this.commericialRemixLicenseId)
+    ).not.be.rejectedWith(Error).then((tx: any) => tx.wait());
+
+    console.log("============ Get state of IP1 after attaching license ============");
+    const stateAfterLicense = await ipAccount1Contract.state();
+    console.log("State of IP1 after attaching license: ", stateAfterLicense);
+    expect(stateAfterLicense).to.not.equal(state1);
+
+    console.log("============Register IP2 as IP1's derivative ============");
+    const { tokenId: tokenId2, ipId: ipId2 } = await mintNFTAndRegisterIPA();
+    console.log("IP2: ", ipId2);
+    const ipAccount2 = await this.ipAssetRegistry.ipAccount(this.chainId, MockERC721, tokenId2);
+    const ipAccount2Contract = await hre.ethers.getContractAt("IPAccountImpl", ipAccount2);
+    const state2 = await ipAccount2Contract.state();
+    console.log("State of IP2: ", state2);
+    await expect(
+      this.licensingModule.registerDerivative(ipId2, [ipId1], [this.commericialRemixLicenseId], PILicenseTemplate, "0x", 0, 100e6, 0)
+    ).not.to.be.rejectedWith(Error).then((tx: any) => tx.wait());
+
+    console.log("============ Get state of IP2 after registering as derivative ============");
+    const state2After = await ipAccount2Contract.state();
+    console.log("State of IP2 after registering as derivative: ", state2After);
+    expect(state2After).to.not.equal(state2);
+
+    console.log("============ Mint License Token for IP1 ============");
+    await expect(
+      this.licensingModule.mintLicenseTokens(ipId1, PILicenseTemplate, this.commericialRemixLicenseId, 1, this.owner.address, "0x", 0, 0)
+    ).not.to.be.rejectedWith(Error).then((tx) => tx.wait());
+
+    console.log("============ Get state of IP1 after minting license token ============");
+    const stateAfterMint = await ipAccount1Contract.state();
+    console.log("State of IP1 after minting license token: ", stateAfterMint);
+    expect(stateAfterMint).to.not.equal(stateAfterLicense);
+  });
+});

--- a/test/hardhat/e2e/royalty/royalty.test.ts
+++ b/test/hardhat/e2e/royalty/royalty.test.ts
@@ -333,4 +333,40 @@ describe("RoyaltyModule", function () {
     console.log("IP1's claimableRevenue: ", ip1ClaimableRevenue);
     expect(ip1ClaimableRevenue).to.be.a("BigInt").and.equal(BigInt(mintingFee + payAmount));
   });
+
+  it("LAP Transfer of royalties to the same IP account's vault", async function () {
+    console.log("============ Register IP1 ============");
+    ({ ipId: ipId1 } = await mintNFTAndRegisterIPAWithLicenseTerms(licenseTermsLAPId));
+    console.log("IP1: ", ipId1);
+
+    console.log("============ Register IP2 as IP1's derivative ============");
+    ({ ipId: ipId2 } = await mintNFTAndRegisterIPA());
+    await expect(
+      this.licensingModule.registerDerivative(ipId2, [ipId1], [licenseTermsLAPId], PILicenseTemplate, "0x", 0, 100e6, 0)
+    ).not.to.be.rejectedWith(Error).then((tx: any) => tx.wait());
+    console.log("IP2: ", ipId2);
+    
+    console.log("============ IP1 Transfer to same IP account's vault ============");
+    await expect(
+      this.royaltyPolicyLAP.transferToVault(ipId1, ipId1, MockERC20)
+    ).to.be.revertedWithCustomError(this.errors, "RoyaltyPolicyLAP__SameIpTransfer");
+  });
+
+  it("LRP Transfer of royalties to the same IP account's vault", async function () {
+    console.log("============ Register IP1 ============");
+    ({ ipId: ipId1 } = await mintNFTAndRegisterIPAWithLicenseTerms(licenseTermsLRPId));
+    console.log("IP1: ", ipId1);
+
+    console.log("============ Register IP2 as IP1's derivative ============");
+    ({ ipId: ipId2 } = await mintNFTAndRegisterIPA());
+    await expect(
+      this.licensingModule.registerDerivative(ipId2, [ipId1], [licenseTermsLRPId], PILicenseTemplate, "0x", 0, 100e6, 0)
+    ).not.to.be.rejectedWith(Error).then((tx: any) => tx.wait());
+    console.log("IP2: ", ipId2);
+    
+    console.log("============ IP1 Transfer to  same IP account's vault ============");
+    await expect(
+      this.royaltyPolicyLRP.transferToVault(ipId1, ipId1, MockERC20)
+    ).to.be.revertedWithCustomError(this.errors, "RoyaltyPolicyLRP__SameIpTransfer");
+  });
 });


### PR DESCRIPTION
## Description
<!-- Add a description of the changes that this PR introduces -->
This pr adds e2e tests for poc changes, includes:

- Test the transfer of royalties to the same IP account's vault
- Test the state update of IPAccount on Asset Changes