### PR TITLE
Add new grouping tests

### DIFF
--- a/test/hardhat/e2e/utils/licenseHelper.ts
+++ b/test/hardhat/e2e/utils/licenseHelper.ts
@@ -24,6 +24,7 @@ export async function registerPILTerms
   expiration: number = 0,
   currencyToken: string = MockERC20,
   derivativesReciprocal: boolean = true,
+  derivativesApproval: boolean = false,
 ): Promise<number> {
   
   const licenseTemplate = await hre.ethers.getContractAt("PILicenseTemplate", PILicenseTemplate);
@@ -36,7 +37,7 @@ export async function registerPILTerms
   testTerms.currency = currencyToken;
   testTerms.expiration = expiration;
   testTerms.derivativesReciprocal = derivativesReciprocal;
-
+  testTerms.derivativesApproval = derivativesApproval;
   await licenseTemplate.registerLicenseTerms(testTerms).then((tx) => tx.wait());
   const licenseTermsId = await licenseTemplate.getLicenseTermsId(testTerms);
   console.log("licenseTermsId", licenseTermsId);


### PR DESCRIPTION
## Description
<!-- Add a description of the changes that this PR introduces -->
New tests:
- 1. Should revert when mint license tokens for terms that aren't attached to a group IP 
- 2. Should revert when attach a license with derivativesApproval = true to a group IP and should succeed when attach a license with derivativesApproval = false to a group IP

## Related PRs
<!-- The related Issue section can indicate which issue or task the Pull Request is related with -->
https://github.com/storyprotocol/protocol-core-v1/pull/413
https://github.com/storyprotocol/protocol-core-v1/pull/412
