### PR TITLE
Add permission verification to `attachDefaultLicenseTerms` function

### DIFF
--- a/contracts/modules/licensing/LicensingModule.sol
+++ b/contracts/modules/licensing/LicensingModule.sol
@@ -132,7 +132,7 @@ contract LicensingModule is
         __ProtocolPausable_init(accessManager);
     }
 
-    function attachDefaultLicenseTerms(address ipId) external {
+    function attachDefaultLicenseTerms(address ipId) external verifyPermission(ipId) {
         _verifyIpNotDisputed(ipId);
         (address defaultLicenseTemplate, uint256 defaultLicenseTermsId) = LICENSE_REGISTRY.getDefaultLicenseTerms();
         LICENSE_REGISTRY.attachLicenseTermsToIp(ipId, defaultLicenseTemplate, defaultLicenseTermsId);

--- a/test/foundry/modules/licensing/LicensingModule.t.sol
+++ b/test/foundry/modules/licensing/LicensingModule.t.sol
@@ -3836,6 +3836,53 @@ contract LicensingModuleTest is BaseTest {
         );
     }
 
+    function test_LicensingModule_attachDefaultLicenseTerms_revert_NoPermission() public {
+        vm.expectRevert(
+            abi.encodeWithSelector(
+                Errors.AccessController__PermissionDenied.selector,
+                address(ipId1),
+                ipOwner2,
+                address(licensingModule),
+                ILicensingModule.attachDefaultLicenseTerms.selector
+            )
+        );
+        vm.prank(ipOwner2);
+        licensingModule.attachDefaultLicenseTerms(ipId1);
+
+        // Verify that the IP owner can attach default license terms
+        vm.prank(ipOwner1);
+        licensingModule.attachDefaultLicenseTerms(ipId1);
+    }
+
+    function test_LicensingModule_attachDefaultLicenseTerms_withPermission() public {
+        // Test that an unauthorized user cannot attach default license terms to ipId3
+        vm.expectRevert(
+            abi.encodeWithSelector(
+                Errors.AccessController__PermissionDenied.selector,
+                address(ipId3),
+                ipOwner1,
+                address(licensingModule),
+                ILicensingModule.attachDefaultLicenseTerms.selector
+            )
+        );
+        vm.prank(ipOwner1);
+        licensingModule.attachDefaultLicenseTerms(ipId3);
+
+        // Grant permission to ipOwner1 to attach default license terms to ipId3
+        vm.prank(ipOwner3);
+        accessController.setPermission(
+            ipId3,
+            ipOwner1,
+            address(licensingModule),
+            ILicensingModule.attachDefaultLicenseTerms.selector,
+            AccessPermission.ALLOW
+        );
+
+        // Verify that an authorized operator can attach default license terms to ipId3
+        vm.prank(ipOwner1);
+        licensingModule.attachDefaultLicenseTerms(ipId3);
+    }
+
     function onERC721Received(address, address, uint256, bytes memory) public pure returns (bytes4) {
         return this.onERC721Received.selector;
     }


### PR DESCRIPTION
## Description
This PR adds the `verifyPermission(ipId)` modifier to the `attachDefaultLicenseTerms` function in the LicensingModule contract.

## Changes
- Add `verifyPermission(ipId)` modifier to the `attachDefaultLicenseTerms` function
- Add test cases to verify proper permission enforcement

## Why this change is needed
All other functions that modify IP asset properties in the LicensingModule (such as `attachLicenseTerms`, `registerDerivative`, etc.) already use the `verifyPermission` modifier to ensure that only the IP owner or authorized users can make changes. This function was missing this check.

## Testing
Added two test cases:
1. `test_LicensingModule_attachDefaultLicenseTerms_revert_NoPermission` - Verifies that unauthorized users cannot attach default license terms
2. `test_LicensingModule_attachDefaultLicenseTerms_withPermission` - Verifies that the IP owner and users with explicit permission can attach default license terms

## Impact
This change improves the protocol by enforcing consistent permission checks across all IP-modifying functions. The change is minimal and follows the established pattern used throughout the module.
