### PR TITLE
Add new function raiseDisputeOnBehalf

### DIFF
--- a/contracts/interfaces/modules/dispute/IDisputeModule.sol
+++ b/contracts/interfaces/modules/dispute/IDisputeModule.sol
@@ -55,6 +55,7 @@ interface IDisputeModule {
     /// @notice Event emitted when a dispute is raised
     /// @param disputeId The dispute id
     /// @param targetIpId The ipId that is the target of the dispute
+    /// @param caller The address of the caller
     /// @param disputeInitiator The address of the dispute initiator
     /// @param disputeTimestamp The timestamp of the dispute
     /// @param arbitrationPolicy The address of the arbitration policy
@@ -64,6 +65,7 @@ interface IDisputeModule {
     event DisputeRaised(
         uint256 disputeId,
         address targetIpId,
+        address caller,
         address disputeInitiator,
         uint256 disputeTimestamp,
         address arbitrationPolicy,

--- a/contracts/interfaces/modules/dispute/policies/IArbitrationPolicy.sol
+++ b/contracts/interfaces/modules/dispute/policies/IArbitrationPolicy.sol
@@ -6,6 +6,7 @@ interface IArbitrationPolicy {
     /// @notice Executes custom logic on raising dispute
     /// @dev Enforced to be only callable by the DisputeModule
     /// @param caller Address of the caller
+    /// @param disputeInitiator Address of the dispute initiator
     /// @param targetIpId The ipId that is the target of the dispute
     /// @param disputeEvidenceHash The hash pointing to the dispute evidence
     /// @param targetTag The target tag of the dispute
@@ -13,6 +14,7 @@ interface IArbitrationPolicy {
     /// @param data The arbitrary data used to raise the dispute
     function onRaiseDispute(
         address caller,
+        address disputeInitiator,
         address targetIpId,
         bytes32 disputeEvidenceHash,
         bytes32 targetTag,

--- a/contracts/interfaces/modules/dispute/policies/UMA/IArbitrationPolicyUMA.sol
+++ b/contracts/interfaces/modules/dispute/policies/UMA/IArbitrationPolicyUMA.sol
@@ -24,14 +24,14 @@ interface IArbitrationPolicyUMA is IArbitrationPolicy, IOOV3Callbacks {
     /// @notice Emitted when a dispute is raised
     /// @param disputeId The dispute id
     /// @param assertionId The assertion id
-    /// @param caller The caller address that raised the dispute
+    /// @param disputeInitiator The address that initiated the dispute
     /// @param liveness The liveness time
     /// @param currency The bond currency
     /// @param bond The bond size
     event DisputeRaisedUMA(
         uint256 disputeId,
         bytes32 assertionId,
-        address caller,
+        address disputeInitiator,
         uint64 liveness,
         address currency,
         uint256 bond

--- a/contracts/lib/Errors.sol
+++ b/contracts/lib/Errors.sol
@@ -627,6 +627,9 @@ library Errors {
     /// @notice Evidence hash already used.
     error DisputeModule__EvidenceHashAlreadyUsed();
 
+    /// @notice Invalid dispute initiator.
+    error DisputeModule__InvalidDisputeInitiator();
+
     ////////////////////////////////////////////////////////////////////////////
     //                             Arbitration Policy UMA                     //
     ////////////////////////////////////////////////////////////////////////////

--- a/contracts/modules/dispute/policies/UMA/ArbitrationPolicyUMA.sol
+++ b/contracts/modules/dispute/policies/UMA/ArbitrationPolicyUMA.sol
@@ -134,7 +134,8 @@ contract ArbitrationPolicyUMA is
 
     /// @notice Executes custom logic on raising dispute
     /// @dev Enforced to be only callable by the DisputeModule
-    /// @param caller Address of the caller
+    /// @param caller Address of the caller which will cover the dispute bond amount
+    /// @param disputeInitiator Address of the dispute initiator which will receive the bond upon winning the dispute
     /// @param targetIpId The ipId that is the target of the dispute
     /// @param disputeEvidenceHash The hash pointing to the dispute evidence
     /// @param targetTag The target tag of the dispute
@@ -142,6 +143,7 @@ contract ArbitrationPolicyUMA is
     /// @param data The arbitrary data used to raise the dispute
     function onRaiseDispute(
         address caller,
+        address disputeInitiator,
         address targetIpId,
         bytes32 disputeEvidenceHash,
         bytes32 targetTag,
@@ -163,7 +165,7 @@ contract ArbitrationPolicyUMA is
 
         bytes32 assertionId = oov3.assertTruth(
             _constructClaim(targetIpId, targetTag, disputeEvidenceHash, disputeId),
-            caller, // asserter
+            disputeInitiator, // asserter
             address(this), // callbackRecipient
             address(0), // escalationManager
             liveness,
@@ -177,7 +179,7 @@ contract ArbitrationPolicyUMA is
         $.assertionIdToDisputeId[assertionId] = disputeId;
         $.disputeIdToAssertionId[disputeId] = assertionId;
 
-        emit DisputeRaisedUMA(disputeId, assertionId, caller, liveness, address(currencyToken), bond);
+        emit DisputeRaisedUMA(disputeId, assertionId, disputeInitiator, liveness, address(currencyToken), bond);
     }
 
     /// @notice Executes custom logic on disputing judgement

--- a/test/foundry/mocks/dispute/MockArbitrationPolicy.sol
+++ b/test/foundry/mocks/dispute/MockArbitrationPolicy.sol
@@ -37,6 +37,7 @@ contract MockArbitrationPolicy is IArbitrationPolicy {
     function onRaiseDispute(
         address caller,
         address targetIpId,
+        address disputeInitiator,
         bytes32 disputeEvidenceHash,
         bytes32 targetTag,
         uint256 disputeId,


### PR DESCRIPTION
## Description
To improve UX for wrapper contracts integrating with the dispute module a new function `raiseDisputeOnBehalf` is created which allows passing an arbitrary dispute initiator.