### PR TITLE
feat(grouping): automatic royalty vault deployment during reward claim

### DIFF
--- a/contracts/modules/grouping/GroupingModule.sol
+++ b/contracts/modules/grouping/GroupingModule.sol
@@ -282,6 +282,10 @@ contract GroupingModule is
         if (!ROYALTY_MODULE.isWhitelistedRoyaltyToken(token)) {
             revert Errors.GroupingModule__RoyaltyTokenNotWhitelisted(groupId, token);
         }
+        // deploy vault for each group member if not already deployed
+        for (uint256 i = 0; i < ipIds.length; i++) {
+            if (ROYALTY_MODULE.ipRoyaltyVaults(ipIds[i]) == address(0)) ROYALTY_MODULE.deployVault(ipIds[i]);
+        }
         // trigger group pool to distribute rewards to group members vault
         uint256[] memory rewards = pool.distributeRewards(groupId, token, ipIds);
         emit ClaimedReward(groupId, token, ipIds, rewards);


### PR DESCRIPTION
## Description

This PR enhances the `GroupingModule` by automatically deploying royalty vaults for group members during the `claimReward` process if they do not already exist.

Previously, vaults for all member IPs in a group needed to be manually deployed before rewards could be claimed. This change simplifies the workflow by handling the vault deployment on-the-fly within the `claimReward` function.

## Changes

- **`contracts/modules/grouping/GroupingModule.sol`**:
    - The `claimReward` function now iterates through the provided `ipIds`.
    - For each `ipId`, it checks if a royalty vault exists.
    - If a vault is not found (`ROYALTY_MODULE.ipRoyaltyVaults(ipIds[i]) == address(0)`), it automatically calls `ROYALTY_MODULE.deployVault(ipIds[i])` to create it before distributing rewards.

- **`test/foundry/modules/grouping/GroupingModule.t.sol`**:
    - Added a new test case: `test_GroupingModule_claimReward_memberVaultsNotDeployed`.
    - This test ensures that rewards are correctly claimed and distributed to member IP vaults even when those vaults are not pre-deployed.

## Motivation

This improvement aims to streamline the user experience for group reward claims. By automating the deployment of necessary royalty vaults, it removes a manual prerequisite. This feature is made possible by the changes introduced in #435, which enabled the `deployVault` functionality within the `RoyaltyModule`.