### PR TITLE
fix(test): ensure accurate tracking of registered IP accounts in test harness

### DIFF
--- a/test/foundry/invariants/IPAssetRegistry.t.sol
+++ b/test/foundry/invariants/IPAssetRegistry.t.sol
@@ -44,8 +44,10 @@ contract IPAssetRegistryHarness is Test {
     function register(uint8 index) public {
         vm.warp(10000);
         IPAccount memory ipAccount = ipAccounts[index];
+        address ipId = ipAssetRegistry.ipId(ipAccount.chainId, ipAccount.tokenAddress, ipAccount.tokenId);
+        bool wasRegistered = ipAssetRegistry.isRegistered(ipId);
         ipAssetRegistry.register(ipAccount.chainId, ipAccount.tokenAddress, ipAccount.tokenId);
-        registered++;
+        if (!wasRegistered) registered++;
     }
 }
 


### PR DESCRIPTION
## Description

This PR addresses a issue in the `IPAssetRegistryHarness` where the `registered` counter was incorrectly incremented for already registered IP accounts. This led to inaccurate accounting and failures in invariant tests.

The fix makes sure that the `registered` counter is only incremented if an IP account transitions from an unregistered to a registered state within the `harness.register()` function. This is achieved by checking the registration status before and after the `ipAssetRegistry.register()` call.

Test results are attached: [test_result.txt](https://github.com/user-attachments/files/20513238/test_result.txt)
