### PR TITLE
Add test cases to dispute module RaiseDispute and RaiseDisputeOnBehalf

### DIFF
--- a/test/foundry/modules/dispute/DisputeModule.t.sol
+++ b/test/foundry/modules/dispute/DisputeModule.t.sol
@@ -319,6 +319,16 @@ contract DisputeModuleTest is BaseTest {
         vm.stopPrank();
     }
 
+    function test_DisputeModule_raiseDispute_revert_InvalidDisputeInitiator() public {
+        vm.startPrank(ipAddr);
+        vm.expectRevert(Errors.DisputeModule__InvalidDisputeInitiator.selector);
+        disputeModule.raiseDispute(ipAddr, disputeEvidenceHashExample, "IMPROPER_REGISTRATION", "");
+
+        vm.startPrank(address(0));
+        vm.expectRevert(Errors.DisputeModule__InvalidDisputeInitiator.selector);
+        disputeModule.raiseDispute(ipAddr, disputeEvidenceHashExample, "IMPROPER_REGISTRATION", "");
+    }
+
     function test_DisputeModule_raiseDispute_BlacklistedPolicy() public {
         vm.startPrank(u.admin);
         disputeModule.setBaseArbitrationPolicy(address(mockArbitrationPolicy2));
@@ -467,6 +477,14 @@ contract DisputeModuleTest is BaseTest {
         vm.expectRevert(abi.encodeWithSelector(PausableUpgradeable.EnforcedPause.selector));
         disputeModule.raiseDisputeOnBehalf(ipAddr, address(2), disputeEvidenceHashExample, "IMPROPER_REGISTRATION", "");
         vm.stopPrank();
+    }
+
+    function test_DisputeModule_raiseDisputeOnBehalf_revert_InvalidDisputeInitiator() public {
+        vm.expectRevert(Errors.DisputeModule__InvalidDisputeInitiator.selector);
+        disputeModule.raiseDisputeOnBehalf(ipAddr, ipAddr, disputeEvidenceHashExample, "IMPROPER_REGISTRATION", "");
+
+        vm.expectRevert(Errors.DisputeModule__InvalidDisputeInitiator.selector);
+        disputeModule.raiseDisputeOnBehalf(ipAddr, address(0), disputeEvidenceHashExample, "IMPROPER_REGISTRATION", "");
     }
 
     function test_DisputeModule_raiseDisputeOnBehalf_BlacklistedPolicy() public {


### PR DESCRIPTION
## Description
This PR adds new test cases to the DisputeModule.t.sol test suite, targeting the raiseDispute and raiseDisputeOnBehalf functions. The new tests ensure that the contract correctly reverts when an invalid dispute initiator attempts to raise a dispute.

## Details
Added `test_DisputeModule_raiseDispute_revert_InvalidDisputeInitiator` to verify that only valid initiators can call raiseDispute.
Added `test_DisputeModule_raiseDisputeOnBehalf_revert_InvalidDisputeInitiator` to verify that only valid initiators can call raiseDisputeOnBehalf.
Both tests check for the correct revert reason (DisputeModule__InvalidDisputeInitiator).