### PR TITLE
fix(PILicenseTemplate): filter out id 0 in exists() function

### DIFF
--- a/contracts/modules/licensing/PILicenseTemplate.sol
+++ b/contracts/modules/licensing/PILicenseTemplate.sol
@@ -490,7 +490,7 @@ contract PILicenseTemplate is
 
     /// @dev Checks if a license terms exists.
     function _exists(uint256 licenseTermsId) internal view returns (bool) {
-        return licenseTermsId <= _getPILicenseTemplateStorage().licenseTermsCounter;
+        return licenseTermsId > 0 && licenseTermsId <= _getPILicenseTemplateStorage().licenseTermsCounter;
     }
 
     ////////////////////////////////////////////////////////////////////////////

--- a/test/foundry/modules/licensing/PILicenseTemplate.t.sol
+++ b/test/foundry/modules/licensing/PILicenseTemplate.t.sol
@@ -380,6 +380,10 @@ contract PILicenseTemplateTest is BaseTest {
         assertFalse(pilTemplate.exists(999));
     }
 
+    function test_PILicenseTemplate_exists_zeroIdDoesNotExist() public {
+        assertFalse(pilTemplate.exists(0));
+    }
+
     // test verifyMintLicenseToken
     function test_PILicenseTemplate_verifyMintLicenseToken() public {
         uint256 commUseTermsId = pilTemplate.registerLicenseTerms(


### PR DESCRIPTION
## Description
This PR adds a check for licenseTermsId > 0 in the `_exists() `function of the PILicenseTemplate.sol contract, ensuring the` exists()` function returns false for the licenseTermsId 0. 

## Test Plan 
Added the following unit test in PILicenseTemplate.t.sol: `test_PILicenseTemplate_exists_zeroIdDoesNotExist`

## Related Issue
https://github.com/storyprotocol/protocol-core-v1/issues/472