### PR TITLE
fix: escape license terms URI before id retrieval

### DIFF
--- a/contracts/modules/licensing/PILicenseTemplate.sol
+++ b/contracts/modules/licensing/PILicenseTemplate.sol
@@ -291,7 +291,9 @@ contract PILicenseTemplate is
     /// @param terms The PILTerms to get the ID for.
     /// @return selectedLicenseTermsId The ID of the given license terms.
     function getLicenseTermsId(PILTerms calldata terms) external view returns (uint256 selectedLicenseTermsId) {
-        return _getPILicenseTemplateStorage().hashedLicenseTerms[keccak256(abi.encode(terms))];
+        PILTerms memory termsEscaped = terms;
+        termsEscaped.uri = LibString.escapeJSON(terms.uri);
+        return _getPILicenseTemplateStorage().hashedLicenseTerms[keccak256(abi.encode(termsEscaped))];
     }
 
     /// @notice Gets license terms of the given ID.

--- a/test/foundry/modules/licensing/PILicenseTemplate.t.sol
+++ b/test/foundry/modules/licensing/PILicenseTemplate.t.sol
@@ -352,6 +352,22 @@ contract PILicenseTemplateTest is BaseTest {
         );
     }
 
+    function test_PILicenseTemplate_getLicenseTermsId_escapeURI() public {
+        PILTerms memory terms = PILFlavors.commercialUse({
+            mintingFee: 100,
+            currencyToken: address(erc20),
+            royaltyPolicy: address(royaltyPolicyLAP)
+        });
+
+        terms.uri = 'https://github.com/piplabs/pil-document/off-chain-terms/CommercialRemix.json?name="my product"';
+
+        // URI is escaped when registering license terms
+        uint256 licenseTermsId = pilTemplate.registerLicenseTerms(terms);
+
+        // Terms ID will be retrieved only if the terms URI is escaped before retrieval
+        assertEq(licenseTermsId, pilTemplate.getLicenseTermsId(terms));
+    }
+
     // get license terms struct by ID
     function test_PILicenseTemplate_getLicenseTerms() public {
         uint256 commUseTermsId = pilTemplate.registerLicenseTerms(


### PR DESCRIPTION
## Description
This PR fixes an issue in the `PILicenseTemplate.getLicenseTermsId()` function.

When license terms are registered using `registerLicenseTerms()`, the terms URI is escaped before registration.

Problem: the URI was not escaped when retrieving the license terms ID with `getLicenseTermsId()`, which could cause incorrect lookups if the URI had unusual formatting.

Fix: escape the license terms URI before retrieving the ID.

Testing: `test_PILicenseTemplate_getLicenseTermsId_escapeURI` registers license terms using a URI that changes when escaped, then verifies that the correct terms ID is retrieved.