### PR TITLE
Add tests for 1.3.3

### DIFF
--- a/script/hardhat/prepare-test.ts
+++ b/script/hardhat/prepare-test.ts
@@ -2,18 +2,19 @@ import fs from 'fs';
 import path from 'path';
 
 async function main() {
-    // copy mock contracts to contracts directory
+    // copy mock contracts to contracts/mocks directory
     // this is a workaround to avoid the issue that the mock contracts are not found by hardhat
     // because the mock contracts are in the foundry test directory
     const mockFilesPath = [
         'test/foundry/mocks/module/MockLicenseTemplate.sol',
         'test/foundry/mocks/token/MockERC20.sol',
+        'test/foundry/mocks/module/MockLicensingHook.sol',
     ];
 
     for (const filePath of mockFilesPath) {
         const fileName = filePath.split('/').pop() || '';
         const sourceFile = path.join(__dirname, '..', '..', filePath);
-        const targetDir = path.join(__dirname, '..', '..', 'contracts');
+        const targetDir = path.join(__dirname, '..', '..', 'contracts', 'mocks');
         const targetFile = path.join(targetDir, fileName);
 
         // ensure target directory exists
@@ -26,8 +27,15 @@ async function main() {
             throw new Error(`Source file not found: ${sourceFile}`);
         }
 
-        // copy file
-        fs.copyFileSync(sourceFile, targetFile);
+        // read file content
+        let fileContent = fs.readFileSync(sourceFile, 'utf8');
+        
+        // fix import paths for files copied from test/foundry/mocks
+        // change ../../../../contracts/ to ../
+        fileContent = fileContent.replace(/..\/..\/..\/..\/contracts\//g, '../');
+        
+        // write file with updated imports
+        fs.writeFileSync(targetFile, fileContent);
         console.log(`Mock contract has been copied from ${sourceFile} to ${targetFile}`);
     }
 

--- a/test/hardhat/e2e/license/licenseTemplate.test.ts
+++ b/test/hardhat/e2e/license/licenseTemplate.test.ts
@@ -3,9 +3,10 @@
 import "../setup";
 import { expect } from "chai";
 import { mintNFTAndRegisterIPA } from "../utils/mintNFTAndRegisterIPA";
-import { RoyaltyPolicyLRP, RoyaltyPolicyLAP, PILicenseTemplate } from "../constants";
+import { RoyaltyPolicyLRP, RoyaltyPolicyLAP, PILicenseTemplate, MockERC20 } from "../constants";
 import { SignerWithAddress } from "@nomicfoundation/hardhat-ethers/signers";
 import { registerPILTerms } from "../utils/licenseHelper";
+import { terms } from "../licenseTermsTemplate";
 import hre from "hardhat";
 
 describe("LicensingModule - License Template Tests", function () {
@@ -29,7 +30,7 @@ describe("LicensingModule - License Template Tests", function () {
     await this.licensingModule.attachLicenseTerms(ipId1, PILicenseTemplate, termsId1);
 
     // Deploy and register second template
-    const MockLicenseTemplateFactory = await hre.ethers.getContractFactory("contracts/MockLicenseTemplate.sol:MockLicenseTemplate");
+    const MockLicenseTemplateFactory = await hre.ethers.getContractFactory("MockLicenseTemplate");
     const pilTemplate2 = await MockLicenseTemplateFactory.deploy();
     await pilTemplate2.waitForDeployment();
     const pilTemplate2Address = await pilTemplate2.getAddress();
@@ -64,7 +65,7 @@ describe("LicensingModule - License Template Tests", function () {
     await this.licensingModule.mintLicenseTokens(ipId1, PILicenseTemplate, termsId1, 1, signers[1].address, hre.ethers.ZeroAddress, 0, 0);
 
     // Deploy and register second template
-    const MockLicenseTemplateFactory = await hre.ethers.getContractFactory("contracts/MockLicenseTemplate.sol:MockLicenseTemplate");
+    const MockLicenseTemplateFactory = await hre.ethers.getContractFactory("MockLicenseTemplate");
     const pilTemplate2 = await MockLicenseTemplateFactory.deploy();
     await pilTemplate2.waitForDeployment();
     const pilTemplate2Address = await pilTemplate2.getAddress();
@@ -145,7 +146,7 @@ describe("LicensingModule - License Template Tests", function () {
 
   it("Should revert when minting license token and attach license terms with unregistered license template", async function () {
     // Deploy license template
-    const MockLicenseTemplateFactory = await hre.ethers.getContractFactory("contracts/MockLicenseTemplate.sol:MockLicenseTemplate");
+    const MockLicenseTemplateFactory = await hre.ethers.getContractFactory("MockLicenseTemplate");
     const pilTemplate2 = await MockLicenseTemplateFactory.deploy();
     await pilTemplate2.waitForDeployment();
     const pilTemplate2Address = await pilTemplate2.getAddress();
@@ -167,5 +168,59 @@ describe("LicensingModule - License Template Tests", function () {
     await expect(
         this.licensingModule.attachLicenseTerms(ipId1, pilTemplate2Address, termsId2)
     ).to.be.revertedWithCustomError(this.errors, "LicensingModule__LicenseTermsNotFound");
+  });
+
+  it("Should return false when checking if license terms with id 0 exists", async function () {
+    // Check that license terms with id 0 does not exist
+    const exists = await this.licenseTemplate.exists(0);
+    expect(exists).to.be.false;
+  });
+
+  it("Should retrieve license terms id with escaped URI", async function () {
+    // Create terms with URI containing special characters that need escaping
+    const testTerms = {
+      ...terms,
+      royaltyPolicy: RoyaltyPolicyLAP,
+      defaultMintingFee: 1,
+      commercialUse: true,
+      currency: MockERC20,
+      uri: 'http://example.com/?name="escaped URI"',
+    };
+
+    // Register license terms - the contract will escape the URI internally
+    const tx = await this.licenseTemplate.registerLicenseTerms(testTerms);
+    await tx.wait();
+
+    // Get the license terms id - the contract will apply the same escaping to match the hash
+    const licenseTermsId = await this.licenseTemplate.getLicenseTermsId(testTerms);
+    console.log("licenseTermsId with escaped URI:", licenseTermsId);
+
+    // Verify we can retrieve the same ID by calling getLicenseTermsId
+    const retrievedId = await this.licenseTemplate.getLicenseTermsId(testTerms);
+    expect(licenseTermsId).to.equal(retrievedId);
+  });
+
+  it("Should retrieve license terms id when URI is not set", async function () {
+    // Create terms with empty URI
+    const testTerms = {
+      ...terms,
+      royaltyPolicy: RoyaltyPolicyLAP,
+      defaultMintingFee: 100,
+      commercialUse: true,
+      currency: MockERC20,
+      uri: "",
+    };
+
+    // Register license terms with empty URI
+    const tx = await this.licenseTemplate.registerLicenseTerms(testTerms);
+    await tx.wait();
+
+    // Get the license terms id
+    const licenseTermsId = await this.licenseTemplate.getLicenseTermsId(testTerms);
+    console.log("licenseTermsId with empty URI:", licenseTermsId);
+
+    // Terms ID should be retrieved correctly even with empty URI
+    const retrievedId = await this.licenseTemplate.getLicenseTermsId(testTerms);
+    expect(licenseTermsId).to.equal(retrievedId);
   });
 }); 

--- a/test/hardhat/e2e/license/registerDerivative.test.ts
+++ b/test/hardhat/e2e/license/registerDerivative.test.ts
@@ -440,4 +440,284 @@ describe("LicensingModule - registerDerivative", function () {
     
     console.log("Correctly prevented IP with derivatives from linking to new parents");
   });
+
+  it("Should revert registerDerivative with currency token mismatch", async function () {
+    console.log("============ Currency Token Mismatch Test ============");
+
+    // Deploy a second MockERC20 token for testing currency mismatch
+    const MockERC20Factory = await hre.ethers.getContractFactory("MockERC20");
+    const erc20b = await MockERC20Factory.deploy();
+    await erc20b.waitForDeployment();
+    const erc20bAddress = await erc20b.getAddress();
+    console.log("Second MockERC20 (erc20b) deployed at:", erc20bAddress);
+
+    console.log(`================= Whitelist Royalty Token =================`);
+    try {
+      await this.royaltyModule.whitelistRoyaltyToken(erc20bAddress, true).then((tx : any) => tx.wait());
+      console.log(`✅ whitelistRoyaltyToken successfully! `)
+    } catch (error: any) {
+      console.log(error);
+      console.error("❌ Transaction Reverted!");
+      console.error("🔴 Error Message:", error.message || "No error message");
+      console.error("📜 Error Data:", error.data || "No error data");
+    }
+
+    // Register license terms with first currency (MockERC20)
+    const termsErc20 = {
+      ...terms,
+      commercialUse: true,
+      commercialRevShare: 10 * 10 ** 6,
+      royaltyPolicy: RoyaltyPolicyLAP,
+      currency: MockERC20,
+      defaultMintingFee: 0,
+      derivativesReciprocal: false,
+    };
+
+    console.log("============ Register license terms with first currency ============");
+    await expect(
+      this.licenseTemplate.registerLicenseTerms(termsErc20)
+    ).not.to.be.rejectedWith(Error).then((tx: any) => tx.wait());
+    const termsIdErc20 = await this.licenseTemplate.getLicenseTermsId(termsErc20);
+    console.log("License terms ID with erc20:", termsIdErc20);
+
+    // Register license terms with second currency (erc20b)
+    const termsErc20b = {
+      ...terms,
+      commercialUse: true,
+      commercialRevShare: 10 * 10 ** 6,
+      royaltyPolicy: RoyaltyPolicyLAP,
+      currency: erc20bAddress,
+      defaultMintingFee: 0,
+      derivativesReciprocal: false,
+    };
+
+    console.log("============ Register license terms with second currency ============");
+    await expect(
+      this.licenseTemplate.registerLicenseTerms(termsErc20b)
+    ).not.to.be.rejectedWith(Error).then((tx: any) => tx.wait());
+    const termsIdErc20b = await this.licenseTemplate.getLicenseTermsId(termsErc20b);
+    console.log("License terms ID with erc20b:", termsIdErc20b);
+
+    console.log("============ Register parent IPs ============");
+    const { ipId: parentIpId1 } = await mintNFTAndRegisterIPA(this.user1, this.user1);
+    const { ipId: parentIpId2 } = await mintNFTAndRegisterIPA(this.user1, this.user11);
+    const { ipId: childIpId } = await mintNFTAndRegisterIPA(this.user2, this.user2);
+
+    console.log("Parent IP 1:", parentIpId1);
+    console.log("Parent IP 2:", parentIpId2);
+    console.log("Child IP:", childIpId);
+
+    // Attach first license terms to parent 1
+    await expect(
+      this.licensingModule.connect(this.user1).attachLicenseTerms(parentIpId1, PILicenseTemplate, termsIdErc20)
+    ).not.to.be.rejectedWith(Error).then((tx: any) => tx.wait());
+    console.log("Attached erc20 terms to parent 1");
+
+    // Attach second license terms to parent 2
+    await expect(
+      this.licensingModule.connect(this.user1).attachLicenseTerms(parentIpId2, PILicenseTemplate, termsIdErc20b)
+    ).not.to.be.rejectedWith(Error).then((tx: any) => tx.wait());
+    console.log("Attached erc20b terms to parent 2");
+
+    await new Promise(resolve => setTimeout(resolve, 10000));
+
+    // Try to register derivative with mismatched currency tokens
+    console.log("============ Attempting to register derivative with mismatched currencies ============");
+    try {
+      await this.licensingModule.connect(this.user2).registerDerivative(
+        childIpId,
+        [parentIpId1, parentIpId2],
+        [termsIdErc20, termsIdErc20b],
+        PILicenseTemplate,
+        hre.ethers.ZeroAddress,
+        0,
+        0,
+        0
+      );
+      // If we reach here, the transaction didn't revert
+      expect.fail("Expected transaction to revert with currency token mismatch");
+    } catch (error: any) {
+      console.log("❌ Transaction reverted as expected");
+      console.log("Error message:", error.message);
+      
+      // Extract the error data from the error
+      let errorData = error.data;
+      if (!errorData && error.error && error.error.data) {
+        errorData = error.error.data;
+      }
+      
+      console.log("Error data:", errorData);
+      
+      // Verify that the error data starts with 0xb57c1977
+      // LicensingModule__CurrencyTokenMismatch is a new error code, which is not included in this repo's Errors.sol
+      // TODO: will update the code to revertedWithCustomError(this.errors, "LicensingModule__CurrencyTokenMismatch")
+      expect(errorData).to.be.a("string");
+      expect(errorData.toLowerCase().startsWith("0xb57c1977")).to.be.true;
+      console.log("✅ Error data starts with 0xb57c1977 (LicensingModule__CurrencyTokenMismatch)");
+    }
+  });
+
+  it("Should revert registerDerivativeWithLicenseTokens with currency token mismatch", async function () {
+    console.log("============ Currency Token Mismatch Test (With License Tokens) ============");
+
+    // Deploy a second MockERC20 token for testing currency mismatch
+    const MockERC20Factory = await hre.ethers.getContractFactory("MockERC20");
+    const erc20b = await MockERC20Factory.deploy();
+    await erc20b.waitForDeployment();
+    const erc20bAddress = await erc20b.getAddress();
+    console.log("Second MockERC20 (erc20b) deployed at:", erc20bAddress);
+
+    console.log(`================= Whitelist Royalty Token =================`);
+    try {
+      await this.royaltyModule.whitelistRoyaltyToken(erc20bAddress, true).then((tx : any) => tx.wait());
+      console.log(`✅ whitelistRoyaltyToken successfully! `)
+    } catch (error: any) {
+      console.log(error);
+      console.error("❌ Transaction Reverted!");
+      console.error("🔴 Error Message:", error.message || "No error message");
+      console.error("📜 Error Data:", error.data || "No error data");
+    }
+
+    // Register license terms with first currency (MockERC20)
+    const termsErc20 = {
+      ...terms,
+      commercialUse: true,
+      commercialRevShare: 10 * 10 ** 6,
+      royaltyPolicy: RoyaltyPolicyLAP,
+      currency: MockERC20,
+      defaultMintingFee: 0,
+      derivativesReciprocal: false,
+    };
+
+    console.log("============ Register license terms with first currency ============");
+    await expect(
+      this.licenseTemplate.registerLicenseTerms(termsErc20)
+    ).not.to.be.rejectedWith(Error).then((tx: any) => tx.wait());
+    const termsIdErc20 = await this.licenseTemplate.getLicenseTermsId(termsErc20);
+    console.log("License terms ID with erc20:", termsIdErc20);
+
+    // Register license terms with second currency (erc20b)
+    const termsErc20b = {
+      ...terms,
+      commercialUse: true,
+      commercialRevShare: 10 * 10 ** 6,
+      royaltyPolicy: RoyaltyPolicyLAP,
+      currency: erc20bAddress,
+      defaultMintingFee: 0,
+      derivativesReciprocal: false,
+    };
+
+    console.log("============ Register license terms with second currency ============");
+    await expect(
+      this.licenseTemplate.registerLicenseTerms(termsErc20b)
+    ).not.to.be.rejectedWith(Error).then((tx: any) => tx.wait());
+    const termsIdErc20b = await this.licenseTemplate.getLicenseTermsId(termsErc20b);
+    console.log("License terms ID with erc20b:", termsIdErc20b);
+
+    console.log("============ Register parent IPs ============");
+    const { ipId: parentIpId1 } = await mintNFTAndRegisterIPA(this.user1, this.user1);
+    const { ipId: parentIpId2 } = await mintNFTAndRegisterIPA(this.user2, this.user2);
+    const { ipId: childIpId } = await mintNFTAndRegisterIPA(this.owner, this.owner);
+
+    console.log("Parent IP 1:", parentIpId1);
+    console.log("Parent IP 2:", parentIpId2);
+    console.log("Child IP:", childIpId);
+
+    // Attach first license terms to parent 1
+    await expect(
+      this.licensingModule.connect(this.user1).attachLicenseTerms(parentIpId1, PILicenseTemplate, termsIdErc20)
+    ).not.to.be.rejectedWith(Error).then((tx: any) => tx.wait());
+    console.log("Attached erc20 terms to parent 1");
+
+    // Attach second license terms to parent 2
+    await expect(
+      this.licensingModule.connect(this.user2).attachLicenseTerms(parentIpId2, PILicenseTemplate, termsIdErc20b)
+    ).not.to.be.rejectedWith(Error).then((tx: any) => tx.wait());
+    console.log("Attached erc20b terms to parent 2");
+
+    await new Promise(resolve => setTimeout(resolve, 10000));
+
+    // Mint license token from parent 1
+    console.log("============ Minting license token from parent 1 ============");
+    const mintTx1 = await this.licensingModule.connect(this.user1).mintLicenseTokens(
+      parentIpId1,
+      PILicenseTemplate,
+      termsIdErc20,
+      1,
+      this.owner.address,
+      "0x",
+      0,
+      0
+    );
+    const receipt1 = await mintTx1.wait();
+    // Get license token ID from event
+    const event1 = receipt1.logs.find((log: any) => {
+      try {
+        const parsed = this.licensingModule.interface.parseLog(log);
+        return parsed?.name === "LicenseTokensMinted";
+      } catch {
+        return false;
+      }
+    });
+    const lcTokenId1 = this.licensingModule.interface.parseLog(event1).args.startLicenseTokenId;
+    console.log("License token 1 ID:", lcTokenId1);
+
+    // Mint license token from parent 2
+    console.log("============ Minting license token from parent 2 ============");
+    const mintTx2 = await this.licensingModule.connect(this.user2).mintLicenseTokens(
+      parentIpId2,
+      PILicenseTemplate,
+      termsIdErc20b,
+      1,
+      this.owner.address,
+      "0x",
+      0,
+      0
+    );
+    const receipt2 = await mintTx2.wait();
+    // Get license token ID from event
+    const event2 = receipt2.logs.find((log: any) => {
+      try {
+        const parsed = this.licensingModule.interface.parseLog(log);
+        return parsed?.name === "LicenseTokensMinted";
+      } catch {
+        return false;
+      }
+    });
+    const lcTokenId2 = this.licensingModule.interface.parseLog(event2).args.startLicenseTokenId;
+    console.log("License token 2 ID:", lcTokenId2);
+
+    await new Promise(resolve => setTimeout(resolve, 10000));
+
+    // Try to register derivative with license tokens that have mismatched currencies
+    console.log("============ Attempting to register derivative with mismatched currency tokens ============");
+    try {
+      await this.licensingModule.connect(this.owner).registerDerivativeWithLicenseTokens(
+        childIpId,
+        [lcTokenId1, lcTokenId2],
+        "0x",
+        100 * 10 ** 6
+      );
+      // If we reach here, the transaction didn't revert
+      expect.fail("Expected transaction to revert with currency token mismatch");
+    } catch (error: any) {
+      console.log("❌ Transaction reverted as expected");
+      console.log("Error message:", error.message);
+      
+      // Extract the error data from the error
+      let errorData = error.data;
+      if (!errorData && error.error && error.error.data) {
+        errorData = error.error.data;
+      }
+      
+      console.log("Error data:", errorData);
+      
+      // Verify that the error data starts with 0xb57c1977
+      // LicensingModule__CurrencyTokenMismatch is a new error code, which is not included in this repo's Errors.sol
+      // TODO: will update the code to revertedWithCustomError(this.errors, "LicensingModule__CurrencyTokenMismatch")
+      expect(errorData).to.be.a("string");
+      expect(errorData.toLowerCase().startsWith("0xb57c1977")).to.be.true;
+      console.log("✅ Error data starts with 0xb57c1977 (LicensingModule__CurrencyTokenMismatch)");
+    }
+  });
 });

--- a/test/hardhat/e2e/license/registerLicenseTerms.test.ts
+++ b/test/hardhat/e2e/license/registerLicenseTerms.test.ts
@@ -3,8 +3,9 @@
 import "../setup";
 import { expect } from "chai";
 import hre from "hardhat";
-import { MockERC20, RoyaltyPolicyLAP, RoyaltyPolicyLRP } from "../constants";
+import { MockERC20, RoyaltyPolicyLAP, RoyaltyPolicyLRP, PILicenseTemplate, ModuleRegistry } from "../constants";
 import { terms } from "../licenseTermsTemplate";
+import { mintNFTAndRegisterIPA } from "../utils/mintNFTAndRegisterIPA";
 
 describe("PILicenseTemplate - registerLicenseTerms", function () {
   let signers:any;
@@ -110,5 +111,143 @@ describe("PILicenseTemplate - registerLicenseTerms", function () {
     await expect(
       this.licenseTemplate.registerLicenseTerms(testTerms)
     ).to.be.rejectedWith("missing value for component expiration");
+  });
+
+  it("Should revert predictMintingLicenseFee with invalid inputs", async function () {
+    // Register license terms with default values
+    const testTerms = {
+      ...terms,
+      royaltyPolicy: RoyaltyPolicyLAP,
+      defaultMintingFee: 100,
+      commercialUse: true,
+      currency: MockERC20,
+    };
+    const termsId = await this.licenseTemplate.registerLicenseTerms(testTerms);
+    await termsId.wait();
+    const licenseTermsId = await this.licenseTemplate.getLicenseTermsId(testTerms);
+    console.log("Registered licenseTermsId:", licenseTermsId);
+
+    // Create and register an IP
+    const result = await mintNFTAndRegisterIPA(signers[0], signers[0]);
+    const ipId = result.ipId;
+    console.log("ipId:", ipId);
+
+    // Attach license terms to the IP
+    await this.licensingModule.connect(signers[0]).attachLicenseTerms(ipId, PILicenseTemplate, licenseTermsId);
+
+    const receiver = signers[1].address;
+
+    // Should revert when amount is 0
+    await expect(
+      this.licensingModule.predictMintingLicenseFee(
+        ipId,
+        PILicenseTemplate,
+        licenseTermsId,
+        0,
+        receiver,
+        "0x"
+      )
+    ).to.be.revertedWithCustomError(this.errors, "LicensingModule__MintAmountZero");
+
+    // Should revert when receiver is zero address
+    await expect(
+      this.licensingModule.predictMintingLicenseFee(
+        ipId,
+        PILicenseTemplate,
+        licenseTermsId,
+        1,
+        hre.ethers.ZeroAddress,
+        "0x"
+      )
+    ).to.be.revertedWithCustomError(this.errors, "LicensingModule__ReceiverZeroAddress");
+  });
+
+  it("Should revert predictMintingLicenseFee when licensing hook minting fee is below license terms", async function () {
+    // Register commercial remix license terms with mintingFee = 300
+    const commRemixTerms = {
+      ...terms,
+      royaltyPolicy: RoyaltyPolicyLAP,
+      defaultMintingFee: 300,
+      commercialRevShare: 10,
+      commercialUse: true,
+      currency: MockERC20,
+    };
+    
+    const tx = await this.licenseTemplate.registerLicenseTerms(commRemixTerms);
+    await tx.wait();
+    const commRemixTermsId = await this.licenseTemplate.getLicenseTermsId(commRemixTerms);
+    console.log("Registered commRemixTermsId:", commRemixTermsId);
+
+    // Create and register an IP
+    const result = await mintNFTAndRegisterIPA(signers[1], signers[1]);
+    const ipId = result.ipId;
+    console.log("ipId:", ipId);
+
+    // Attach license terms to the IP
+    await this.licensingModule.connect(signers[1]).attachLicenseTerms(ipId, PILicenseTemplate, commRemixTermsId);
+
+    // Get ModuleRegistry
+    const moduleRegistry = await hre.ethers.getContractAt("ModuleRegistry", ModuleRegistry);
+    
+    // Try to get existing MockLicensingHook from registry first
+    let licensingHookAddress = await moduleRegistry.getModule("MockLicensingHook");
+    console.log("Existing MockLicensingHook address:", licensingHookAddress);
+    
+    // If not registered yet (address is zero), deploy and register a new one
+    if (licensingHookAddress === hre.ethers.ZeroAddress) {
+      console.log("MockLicensingHook not found, deploying new one...");
+      const MockLicensingHookFactory = await hre.ethers.getContractFactory("MockLicensingHook");
+      const licensingHook = await MockLicensingHookFactory.deploy();
+      await licensingHook.waitForDeployment();
+      licensingHookAddress = await licensingHook.getAddress();
+      console.log("MockLicensingHook deployed at:", licensingHookAddress);
+      
+      try {
+        console.log("Attempting to register MockLicensingHook...");
+        const registerTx = await moduleRegistry.connect(signers[0]).registerModule("MockLicensingHook", licensingHookAddress);
+        await registerTx.wait();
+        console.log("✅ MockLicensingHook registered in ModuleRegistry");
+      } catch (error: any) {
+        console.error("❌ Failed to register MockLicensingHook");
+        console.error("Error:", error.message);
+        console.error("⚠️  You may need admin privileges to register modules.");
+        throw error;
+      }
+    } else {
+      console.log("✅ Using existing MockLicensingHook at:", licensingHookAddress);
+    }
+
+    // Set licensing config with hook that returns mintingFee = 100 (amount * 100 = 1 * 100)
+    // This is below the license terms defaultMintingFee of 300
+    const licensingConfig = {
+      isSet: true,
+      mintingFee: 400,
+      licensingHook: licensingHookAddress,
+      hookData: hre.ethers.AbiCoder.defaultAbiCoder().encode(["address"], [hre.ethers.ZeroAddress]),
+      disabled: false,
+      commercialRevShare: 0,
+      expectMinimumGroupRewardShare: 0,
+      expectGroupRewardPool: hre.ethers.ZeroAddress,
+    };
+
+    await this.licensingModule.connect(signers[1]).setLicensingConfig(
+      ipId,
+      PILicenseTemplate,
+      commRemixTermsId,
+      licensingConfig
+    );
+    console.log("✅ Licensing config set with hook");
+    await new Promise(resolve => setTimeout(resolve, 10000));
+
+    await expect(
+      this.licensingModule.predictMintingLicenseFee(
+        ipId,
+        PILicenseTemplate,
+        commRemixTermsId,
+        1,
+        signers[2].address,
+        "0x"
+      )
+    ).to.be.revertedWithCustomError(this.errors, "LicensingModule__LicensingHookMintingFeeBelowLicenseTerms");
   });
 });


### PR DESCRIPTION
## Description
Added hardhat tests for v1.3.3 changes

- Should return false when checking if license terms with id 0 exists 
- Should retrieve license terms id with escaped URI 
- Should retrieve license terms id when URI is not set 
- Should revert registerDerivative with currency token mismatch
- Should revert registerDerivativeWithLicenseTokens with currency token mismatch
- Should revert predictMintingLicenseFee with invalid inputs
- Should revert predictMintingLicenseFee when licensing hook minting fee is below license terms


## Test Plan 
<!-- The test plan section indicates detailed steps on how to verify and test code changes. 
You can list the test cases or test steps that need to be performed.-->
https://github.com/storyprotocol/protocol-core-v1/actions/runs/20264244169