### PR TITLE
fix(ci): prevent shell injection in Slack PR-merge notify

### DIFF
--- a/.github/workflows/notify-slack-on-pr-merge.yml
+++ b/.github/workflows/notify-slack-on-pr-merge.yml
@@ -11,11 +11,33 @@ jobs:
 
     steps:
       - name: Send Slack Notification
+        env:
+          # Pass untrusted/context values via env so they are not interpolated into the script text.
+          # (Direct ${{ github.event.pull_request.title }} inside run: enables shell injection.)
+          REPO: ${{ github.repository }}
+          PR_TITLE: ${{ github.event.pull_request.title }}
+          PR_URL: ${{ github.event.pull_request.html_url }}
+          SLACK_YAO_MEMBER_ID: ${{ secrets.SLACK_YAO_MEMBER_ID }}
+          SLACK_BO_MEMBER_ID: ${{ secrets.SLACK_BO_MEMBER_ID }}
+          SLACK_QA_MESSENGER_WEBHOOK_URL: ${{ secrets.SLACK_QA_MESSENGER_WEBHOOK_URL }}
         run: |
+          payload="$(jq -n \
+            --arg channel "qa-messenger" \
+            --arg repo "$REPO" \
+            --arg title "$PR_TITLE" \
+            --arg yao "$SLACK_YAO_MEMBER_ID" \
+            --arg bo "$SLACK_BO_MEMBER_ID" \
+            --arg url "$PR_URL" \
+            '{
+              channel: $channel,
+              text: (
+                "---\n**PR Merged** \n*Repo:* " + $repo +
+                "\n*Title:* " + $title +
+                "\n*Tag:* <" + $yao + "> <" + $bo +
+                ">\n*Link:* <" + $url + "|View PR>"
+              )
+            }')"
           curl -X POST \
             -H 'Content-type: application/json' \
-            --data '{
-              "channel": "qa-messenger",
-              "text": "---\n**PR Merged** \n*Repo:* '"${{ github.repository }}"'\n*Title:* '"${{ github.event.pull_request.title }}"'\n*Tag:* <'"${{ secrets.SLACK_YAO_MEMBER_ID }}"'> <'"${{ secrets.SLACK_BO_MEMBER_ID }}"'>\n*Link:* <'"${{ github.event.pull_request.html_url }}"'|View PR>"
-            }' \
-            ${{ secrets.SLACK_QA_MESSENGER_WEBHOOK_URL }}
+            --data "$payload" \
+            "$SLACK_QA_MESSENGER_WEBHOOK_URL"


### PR DESCRIPTION
## Description

`notify-slack-on-pr-merge.yml` previously expanded `${{ github.event.pull_request.title }}` (and other context/secrets) directly into a `run:` shell script. GitHub Actions expression expansion happens before the shell parses the script, so a malicious PR title containing `` ` `` or `$(...)` can execute on the runner when the PR is merged to the default branch. The same script also embeds Slack webhook / member-id secrets, so injection can exfiltrate them.

This change:

- Moves repository, PR title, PR URL, and secrets into `env:`
- Builds the Slack JSON payload with `jq` so untrusted title text cannot break out of the data

## AI disclosure

Drafted with AI assistance; reviewed against GitHub’s guidance for not interpolating untrusted `${{ }}` into `run:` scripts.

## Test plan

- [ ] Merge a test PR with a boring title → Slack message still posts
- [ ] Confirm workflow YAML has no `${{ github.event.pull_request.title }}` inside the script body
- [ ] Optional: rotate `SLACK_QA_MESSENGER_WEBHOOK_URL` as hygiene after landing


Made with [Cursor](https://cursor.com)