### PR TITLE
fix(access): key transient-permission flag by IP account

### DIFF
--- a/contracts/access/AccessController.sol
+++ b/contracts/access/AccessController.sol
@@ -38,9 +38,12 @@ contract AccessController is IAccessController, ProtocolPausableUpgradeable, UUP
     bytes32 private constant TRANSIENT_PERMISSION_SLOT =
         0x55aa2c4cf058a8e32191027e4897f2eec4c890df0e178393ed5558115d936a00;
 
-    // the slot to store the transient permission flag, to indicate whether the transient permission is used
-    // when the flag is set to true, the transient permission will be used
-    // permanent permission will be ignored
+    // the base slot to derive the per-IP-account transient permission flag, to indicate whether the transient
+    // permission is used for that IP account
+    // when the flag is set to true, the transient permission will be used for that IP account
+    // permanent permission of that IP account will be ignored
+    // the flag is keyed by IP account so that one account using transient permissions does not
+    // switch every other account's permission reads to transient storage for the rest of the transaction
     bytes32 private constant TRANSIENT_FLAG_SLOT =
         keccak256(abi.encodePacked(TRANSIENT_PERMISSION_SLOT, "TransientPermissionFlag"));
 
@@ -214,7 +217,7 @@ contract AccessController is IAccessController, ProtocolPausableUpgradeable, UUP
         if (to != address(this) && !MODULE_REGISTRY.isRegistered(to) && !MODULE_REGISTRY.isRegistered(signer)) {
             revert Errors.AccessController__BothCallerAndRecipientAreNotRegisteredModule(signer, to);
         }
-        bool isTransient = _usingTransientPermission();
+        bool isTransient = _usingTransientPermission(ipAccount);
         uint functionPermission = _getPermission(ipAccount, signer, to, func, isTransient);
         // Specific function permission overrides wildcard/general permission
         if (functionPermission == AccessPermission.ALLOW) {
@@ -251,7 +254,7 @@ contract AccessController is IAccessController, ProtocolPausableUpgradeable, UUP
     /// @param func The function selector of `to` that can be called by the `signer` on behalf of the `ipAccount`
     /// @return permission The current permission level for the function call on `to` by the `signer` for `ipAccount`
     function getPermission(address ipAccount, address signer, address to, bytes4 func) public view returns (uint8) {
-        if (_usingTransientPermission()) {
+        if (_usingTransientPermission(ipAccount)) {
             return _getPermission(ipAccount, signer, to, func, true);
         }
         return _getPermission(ipAccount, signer, to, func, false);
@@ -322,7 +325,7 @@ contract AccessController is IAccessController, ProtocolPausableUpgradeable, UUP
             revert Errors.AccessController__OwnerIsIPAccount(ipAccount, owner);
         }
         if (isTransient) {
-            TRANSIENT_FLAG_SLOT.asBoolean().tstore(true);
+            _transientFlagSlot(ipAccount).asBoolean().tstore(true);
             bytes32 transientPermissionSlot = keccak256(
                 abi.encodePacked(TRANSIENT_PERMISSION_SLOT, _encodePermission(ipAccount, signer, to, func))
             );
@@ -351,9 +354,14 @@ contract AccessController is IAccessController, ProtocolPausableUpgradeable, UUP
         return keccak256(abi.encode(IIPAccount(payable(ipAccount)).owner(), ipAccount, signer, to, func));
     }
 
-    /// @dev Returns true if the transient permission is used
-    function _usingTransientPermission() internal view returns (bool) {
-        return TRANSIENT_FLAG_SLOT.asBoolean().tload();
+    /// @dev Returns the transient flag slot for a specific IP account
+    function _transientFlagSlot(address ipAccount) internal pure returns (bytes32) {
+        return keccak256(abi.encodePacked(TRANSIENT_FLAG_SLOT, ipAccount));
+    }
+
+    /// @dev Returns true if the transient permission is used for a specific IP account
+    function _usingTransientPermission(address ipAccount) internal view returns (bool) {
+        return _transientFlagSlot(ipAccount).asBoolean().tload();
     }
 
     /// @dev Returns the permission level for a specific function call.

--- a/test/foundry/access/AccessController.t.sol
+++ b/test/foundry/access/AccessController.t.sol
@@ -1826,6 +1826,71 @@ contract AccessControllerTest is BaseTest {
         );
     }
 
+    // transient permission used by one IP account must not switch other accounts' permission reads
+    // to transient storage for the rest of the transaction
+    function test_AccessController_transientPermissionDoesNotAffectOtherAccounts() public {
+        address signer = vm.addr(2);
+        address owner2 = vm.addr(3);
+        address signer2 = vm.addr(4);
+
+        // second IP account with a permanent ALLOW permission
+        mockNFT.mintId(owner2, tokenId + 1);
+        IIPAccount ipAccount2 = IIPAccount(
+            payable(ipAssetRegistry.register(block.chainid, address(mockNFT), tokenId + 1))
+        );
+        vm.prank(owner2);
+        ipAccount2.execute(
+            address(accessController),
+            0,
+            abi.encodeWithSignature(
+                "setPermission(address,address,address,bytes4,uint8)",
+                address(ipAccount2),
+                signer2,
+                address(mockModule),
+                mockModule.executeSuccessfully.selector,
+                AccessPermission.ALLOW
+            )
+        );
+
+        // first IP account uses a transient permission in the same transaction
+        vm.prank(owner);
+        ipAccount.execute(
+            address(accessController),
+            0,
+            abi.encodeWithSignature(
+                "setTransientPermission(address,address,address,bytes4,uint8)",
+                address(ipAccount),
+                signer,
+                address(mockModule),
+                bytes4(0),
+                AccessPermission.ALLOW
+            )
+        );
+
+        // the second account's permanent permission must still be honored
+        assertEq(
+            accessController.getPermission(
+                address(ipAccount2),
+                signer2,
+                address(mockModule),
+                mockModule.executeSuccessfully.selector
+            ),
+            AccessPermission.ALLOW
+        );
+        accessController.checkPermission(
+            address(ipAccount2),
+            signer2,
+            address(mockModule),
+            mockModule.executeSuccessfully.selector
+        );
+
+        // and the first account's own transient permission still applies
+        assertEq(
+            accessController.getPermission(address(ipAccount), signer, address(mockModule), bytes4(0)),
+            AccessPermission.ALLOW
+        );
+    }
+
     // transient permission can override persistent permission
     function test_AccessController_transientPermissionOverridePersistentPermission() public {
         address signer = vm.addr(2);


### PR DESCRIPTION
## Summary

`TRANSIENT_FLAG_SLOT` was a single transaction-wide boolean in EIP-1153 storage. Once **any** IP account set a transient permission, `checkPermission` / `getPermission` for **every other IP account** in the same transaction switched to reading transient storage — where untouched slots default to `ABSTAIN` — so their permanent permissions were silently ignored for the rest of the transaction.

Concretely: account A calls `setTransientPermission`, then a batched / group flow touches account B whose owner previously granted a permanent `ALLOW` — B's `checkPermission` now resolves the transient (empty) slots and reverts with `AccessController__PermissionDenied`. One account's transient-permission use poisons the transaction for every other account.

## Fix

Derive the flag slot per IP account — `keccak256(abi.encodePacked(TRANSIENT_FLAG_SLOT, ipAccount))` — and thread `ipAccount` through `_usingTransientPermission(...)`. Transient mode now only affects the account that opted into it; per-account override semantics are unchanged.

## Test plan

- [x] New regression test `test_AccessController_transientPermissionDoesNotAffectOtherAccounts`: second account's permanent `ALLOW` survives a first account's transient-permission use in the same transaction
- [x] Negative control: the test **fails with `PermissionDenied` on the unpatched contract**, passes with this change
- [x] `forge test --match-contract AccessControllerTest` — 50/50 pass, including all pre-existing transient-permission tests

Made with [Cursor](https://cursor.com)